### PR TITLE
Fix memory leaks in MenuScene by properly cleaning up listeners

### DIFF
--- a/src/scenes/MenuScene.js
+++ b/src/scenes/MenuScene.js
@@ -20,14 +20,14 @@ export default class MenuScene extends Phaser.Scene {
         this.buildFooter();
 
         this.scale.on("resize", this.handleResize, this);
-        this.events.once("shutdown", () => this.scale.off("resize", this.handleResize, this));
 
         this.showAuthState("loading");
 
+        let unsubscribeAuth = null;
         if (window.electronAPI?.isElectron) {
             this.updateUIForLoggedInUser();
         } else {
-            auth.onAuthStateChanged((user) => {
+            unsubscribeAuth = auth.onAuthStateChanged((user) => {
                 if (user) {
                     this.updateUIForLoggedInUser(user);
                 } else {
@@ -35,6 +35,11 @@ export default class MenuScene extends Phaser.Scene {
                 }
             });
         }
+
+        this.events.once("shutdown", () => {
+            this.scale.off("resize", this.handleResize, this);
+            if (unsubscribeAuth) unsubscribeAuth();
+        });
     }
 
     computeLayout() {
@@ -44,7 +49,6 @@ export default class MenuScene extends Phaser.Scene {
             w,
             h,
             cx: w / 2,
-            cy: h / 2,
             titleY: Math.max(120, h * 0.22),
             panelY: h * 0.62,
             panelW: Math.min(460, w * 0.85),


### PR DESCRIPTION
## Summary
This PR fixes memory leaks in MenuScene by ensuring that event listeners and Firebase auth subscriptions are properly cleaned up when the scene shuts down.

## Key Changes
- **Moved shutdown listener setup**: Relocated the `shutdown` event listener to after the auth state setup, allowing it to properly reference and clean up the auth subscription
- **Captured auth unsubscribe function**: Store the return value from `auth.onAuthStateChanged()` so it can be properly unsubscribed during scene shutdown
- **Added cleanup logic**: The shutdown handler now unsubscribes from Firebase auth changes in addition to removing the resize listener, preventing memory leaks when the scene is destroyed
- **Removed unused layout property**: Deleted the unused `cy` (center Y) property from the `computeLayout()` method

## Implementation Details
The key improvement is that the Firebase auth listener is now properly unsubscribed when the scene shuts down. Previously, the auth listener would persist even after the scene was destroyed, causing memory leaks. The `unsubscribeAuth` variable is scoped to the `create()` method and captured in the shutdown event closure, ensuring it's available for cleanup.

https://claude.ai/code/session_015j5CzhB3bBQGSxyLjA9sQb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small lifecycle cleanup that only affects `MenuScene` teardown behavior, with minimal impact on gameplay logic. Main risk is inadvertently unsubscribing too early or missing Electron paths, potentially leaving the menu in the wrong auth state.
> 
> **Overview**
> Fixes a `MenuScene` lifecycle leak by capturing the Firebase `auth.onAuthStateChanged()` unsubscribe function and calling it during scene `shutdown`, alongside removing the resize listener.
> 
> Also removes the unused `cy` field from `computeLayout()` and reorders shutdown hookup so it can close over the auth unsubscribe handler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 349a3cc0b0050d1d10e692e6a570db6589f675bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->