### PR TITLE
Remove pull_request trigger from deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,9 +3,6 @@ name: Deploy Vite App
 on:
   push:
     branches:
-      - master  # Change to your default branch if different
-  pull_request:
-    branches:
       - master
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
Updated the GitHub Actions deploy workflow to remove the `pull_request` trigger, ensuring deployments only occur on direct pushes to the master branch.

## Key Changes
- Removed the `pull_request` trigger configuration from the deploy workflow
- Kept the `push` trigger for the master branch as the primary deployment trigger
- Retained `workflow_dispatch` for manual trigger capability

## Details
This change prevents automatic deployments from being triggered on pull requests to the master branch. Deployments will now only occur when code is directly pushed to master or when manually triggered via `workflow_dispatch`. This is a safer approach that avoids unintended deployments during the pull request review process.

https://claude.ai/code/session_015j5CzhB3bBQGSxyLjA9sQb