### PR TITLE
Add procedural tile texture atlas and visual polish

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,71 @@
+name: Deploy Preview
+
+# Builds the current branch and deploys it to GitHub Pages under
+# /deeper/preview/<branch>/ without touching the production deploy at /deeper/.
+#
+# Trigger manually from the Actions tab for any branch, or automatically on
+# push to claude/** branches. Edit the `push` filter below to widen/narrow.
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'claude/**'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: preview-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy-preview:
+    runs-on: ubuntu-latest
+    environment: github-pages
+    env:
+      VITE_FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
+      VITE_FIREBASE_AUTH_DOMAIN: ${{ vars.FIREBASE_AUTH_DOMAIN }}
+      VITE_FIREBASE_DATABASE_URL: ${{ vars.FIREBASE_DATABASE_URL }}
+      VITE_FIREBASE_PROJECT_ID: ${{ vars.FIREBASE_PROJECT_ID }}
+      VITE_FIREBASE_STORAGE_BUCKET: ${{ vars.FIREBASE_STORAGE_BUCKET }}
+      VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ vars.FIREBASE_MESSAGING_SENDER_ID }}
+      VITE_FIREBASE_APP_ID: ${{ vars.FIREBASE_APP_ID }}
+      VITE_FIREBASE_MEASUREMENT_ID: ${{ vars.FIREBASE_MEASUREMENT_ID }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Sanitize branch name
+        id: branch
+        run: |
+          slug="${GITHUB_REF_NAME//\//-}"
+          echo "slug=$slug" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build project
+        run: npx vite build --base=/deeper/preview/${{ steps.branch.outputs.slug }}/
+
+      - name: Deploy preview to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: dist
+          target-folder: preview/${{ steps.branch.outputs.slug }}
+          clean: false
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Print preview URL
+        run: |
+          url="https://acjeff.github.io/deeper/preview/${{ steps.branch.outputs.slug }}/"
+          echo "::notice title=Preview deployed::$url"
+          echo "## Preview ready" >> "$GITHUB_STEP_SUMMARY"
+          echo "$url" >> "$GITHUB_STEP_SUMMARY"

--- a/src/classes/breakable.js
+++ b/src/classes/breakable.js
@@ -1,5 +1,5 @@
 import {Tile} from "./tile";
-import {darkenColor} from "../services/colourManager";
+import {darkenColor, lightenColor} from "../services/colourManager";
 
 const hexStringToInt = (str) => parseInt(str.replace(/^0x/, ''), 16);
 
@@ -74,86 +74,101 @@ export class Breakable extends Tile {
         g.clear();
 
         const ts = this.game.tileSize;
-        const half = ts / 2;
-        const x = this.worldX - half;
-        const y = this.worldY - half;
+        const x = this.worldX - ts / 2;
+        const y = this.worldY - ts / 2;
 
-        // Sharp pixel-art body. Edges get small deterministic 1px bumps
-        // and erosions on sides that face air — adjacent tiles' bumps
-        // don't have to align, which breaks the grid alignment naturally.
+        // Sharp Terraria-style body. The "uneven" feel comes from internal
+        // texture, not silhouette.
         g.fillStyle(this.tileBaseColor, 1);
         g.fillRect(x, y, ts, ts);
 
         if (this.tileDetails.type) return; // coal — overlay covers the rest
 
-        const erodeColor = hexStringToInt(darkenColor(this.tileBaseColor, 35));
+        const lightHex = hexStringToInt(lightenColor(this.tileBaseColor, 22));
+        const dark1 = hexStringToInt(darkenColor(this.tileBaseColor, 22));
+        const dark2 = hexStringToInt(darkenColor(this.tileBaseColor, 40));
 
-        // Helper: place a 1px nub just outside the tile in tile-base colour,
-        // and a 1px darker erosion just inside, at hash-positioned spots.
-        const decorateEdge = (axis, edgeOpen, salt) => {
-            if (!edgeOpen) return;
-            // 0-2 nubs sticking out
-            const nubCount = Math.floor(this.posHash(salt) * 2.6);
-            for (let i = 0; i < nubCount; i++) {
-                const t = Math.floor(this.posHash(salt + 10 + i) * (ts - 2)) + 1;
-                let px, py;
-                if (axis === 'top')    { px = x + t;       py = y - 1; }
-                if (axis === 'bottom') { px = x + t;       py = y + ts; }
-                if (axis === 'left')   { px = x - 1;       py = y + t; }
-                if (axis === 'right')  { px = x + ts;      py = y + t; }
-                g.fillStyle(this.tileBaseColor, 1);
-                g.fillRect(px, py, 1, 1);
+        // Top edge: a brighter row when light hits from above.
+        if (top) {
+            g.fillStyle(lightHex, 0.95);
+            g.fillRect(x, y, ts, 1);
+            // Weather it with a few scattered dark pixels
+            const wear = 2 + Math.floor(this.posHash(70) * 3);
+            for (let i = 0; i < wear; i++) {
+                const px = x + Math.floor(this.posHash(71 + i) * ts);
+                g.fillStyle(dark1, 1);
+                g.fillRect(px, y, 1, 1);
             }
-            // 1-3 erosions just inside the body
-            const eroCount = 1 + Math.floor(this.posHash(salt + 20) * 2);
-            for (let i = 0; i < eroCount; i++) {
-                const t = Math.floor(this.posHash(salt + 30 + i) * (ts - 2)) + 1;
-                let px, py;
-                if (axis === 'top')    { px = x + t;       py = y; }
-                if (axis === 'bottom') { px = x + t;       py = y + ts - 1; }
-                if (axis === 'left')   { px = x;           py = y + t; }
-                if (axis === 'right')  { px = x + ts - 1;  py = y + t; }
-                g.fillStyle(erodeColor, 0.9);
-                g.fillRect(px, py, 1, 1);
-            }
-        };
-        decorateEdge('top', top, 200);
-        decorateEdge('right', right, 220);
-        decorateEdge('bottom', bottom, 240);
-        decorateEdge('left', left, 260);
-
-        // Speckles for organic texture inside the body.
-        const speckleHex = hexStringToInt(darkenColor(this.tileBaseColor, 22));
-        const speckleCount = 1 + Math.floor(this.posHash(2) * 3);
-        for (let i = 0; i < speckleCount; i++) {
-            const sx = (this.posHash(10 + i) - 0.5) * (ts - 3);
-            const sy = (this.posHash(20 + i) - 0.5) * (ts - 3);
-            g.fillStyle(speckleHex, 0.75);
-            g.fillRect(Math.round(this.worldX + sx), Math.round(this.worldY + sy), 1, 1);
+        }
+        // Bottom edge: a darker row to suggest shadow falloff.
+        if (bottom) {
+            g.fillStyle(dark2, 0.85);
+            g.fillRect(x, y + ts - 1, ts, 1);
+        }
+        // Side edges: subtle vertical shading.
+        if (left) {
+            g.fillStyle(dark1, 0.55);
+            g.fillRect(x, y, 1, ts);
+        }
+        if (right) {
+            g.fillStyle(dark1, 0.55);
+            g.fillRect(x + ts - 1, y, 1, ts);
         }
 
-        // Grass tufts on the topmost soil rows where the sky meets the surface.
+        // Chipped corners — where two adjacent sides face air, the corner
+        // pixel reads as crumbled. Stops corners feeling perfectly square
+        // without rounding the silhouette.
+        const chip = (cx, cy) => { g.fillStyle(dark2, 1); g.fillRect(cx, cy, 1, 1); };
+        if (top && left)     chip(x, y);
+        if (top && right)    chip(x + ts - 1, y);
+        if (bottom && left)  chip(x, y + ts - 1);
+        if (bottom && right) chip(x + ts - 1, y + ts - 1);
+
+        // Body texture: scatter darker and lighter pixels for soil grain.
+        const speckleCount = 4 + Math.floor(this.posHash(2) * 3);
+        for (let i = 0; i < speckleCount; i++) {
+            const sx = x + 1 + Math.floor(this.posHash(10 + i) * (ts - 2));
+            const sy = y + 1 + Math.floor(this.posHash(20 + i) * (ts - 2));
+            const useLight = this.posHash(30 + i) > 0.78;
+            g.fillStyle(useLight ? lightHex : dark1, useLight ? 0.7 : 0.85);
+            g.fillRect(sx, sy, 1, 1);
+        }
+
+        // Grass on the topmost soil rows where the sky meets the surface.
         const aboveGroundY = this.game.aboveGround * ts;
-        const isNearSurface = this.worldY >= aboveGroundY && this.worldY <= aboveGroundY + ts * 4;
+        const isNearSurface = this.worldY >= aboveGroundY && this.worldY <= aboveGroundY + ts * 3;
         if (top && isNearSurface) {
-            const tuftCount = 2 + Math.floor(this.posHash(50) * 3);
-            for (let i = 0; i < tuftCount; i++) {
-                const tx = x + 1 + this.posHash(60 + i) * (ts - 2);
-                const tHeight = 1 + this.posHash(70 + i) * 1.5;
-                const grassShade = this.posHash(80 + i) < 0.5 ? 0x6e9c47 : 0x7faa53;
-                g.fillStyle(grassShade, 1);
-                g.fillTriangle(
-                    tx - 0.5, y + 0.5,
-                    tx + 0.5, y + 0.5,
-                    tx, y - tHeight
-                );
+            const grassA = 0x6e9c47;
+            const grassB = 0x88b85c;
+            const grassDark = 0x4f7330;
+            // Solid green band along the top
+            g.fillStyle(grassA, 1);
+            g.fillRect(x, y, ts, 1);
+            // Mottle with darker greens
+            const mottle = 2 + Math.floor(this.posHash(60) * 3);
+            for (let i = 0; i < mottle; i++) {
+                const px = x + Math.floor(this.posHash(61 + i) * ts);
+                g.fillStyle(grassDark, 1);
+                g.fillRect(px, y, 1, 1);
+            }
+            // A second softer row of green underneath (Terraria-ish)
+            g.fillStyle(grassA, 0.45);
+            g.fillRect(x, y + 1, ts, 1);
+            // Hanging/standing grass blades on top
+            const blades = 2 + Math.floor(this.posHash(80) * 3);
+            for (let i = 0; i < blades; i++) {
+                const px = x + 1 + Math.floor(this.posHash(81 + i) * (ts - 2));
+                const blen = 1 + Math.floor(this.posHash(91 + i) * 3);
+                const useLight = this.posHash(101 + i) > 0.5;
+                g.fillStyle(useLight ? grassB : grassA, 1);
+                g.fillRect(px, y - blen, 1, blen);
             }
         }
 
         // Embedded curiosities — rare and small.
-        const detailRoll = this.posHash(100);
+        const detailRoll = this.posHash(200);
         if (detailRoll < 0.04) {
-            const detailType = this.posHash(101);
+            const detailType = this.posHash(201);
             if (detailType < 0.5) this.drawWorm(g);
             else this.drawFossil(g);
         } else if (detailRoll < 0.07) {

--- a/src/classes/breakable.js
+++ b/src/classes/breakable.js
@@ -78,86 +78,112 @@ export class Breakable extends Tile {
         const x = this.worldX - half;
         const y = this.worldY - half;
 
-        // Round corners only where two adjacent sides are both exposed —
-        // these are real cave corners. Internal corners stay sharp so
-        // stacks of soil don't develop visible seams.
-        const r = 2;
-        const tl = (top && left) ? r : 0;
-        const tr = (top && right) ? r : 0;
-        const br = (bottom && right) ? r : 0;
-        const bl = (bottom && left) ? r : 0;
-
+        // Sharp pixel-art body. Edges get small deterministic 1px bumps
+        // and erosions on sides that face air — adjacent tiles' bumps
+        // don't have to align, which breaks the grid alignment naturally.
         g.fillStyle(this.tileBaseColor, 1);
-        g.fillRoundedRect(x, y, ts, ts, {tl, tr, br, bl});
+        g.fillRect(x, y, ts, ts);
 
-        // Skip extra decoration on coal — its overlay sprite covers most
-        // of the surface area anyway.
-        if (!this.tileDetails.type) {
-            // Speckles: small darker dots scattered across the body.
-            const speckleHex = hexStringToInt(darkenColor(this.tileBaseColor, 25));
-            const speckleCount = 1 + Math.floor(this.posHash(2) * 3);
-            for (let i = 0; i < speckleCount; i++) {
-                const sx = (this.posHash(10 + i) - 0.5) * (ts - 3);
-                const sy = (this.posHash(20 + i) - 0.5) * (ts - 3);
-                const size = 0.4 + this.posHash(30 + i) * 0.7;
-                g.fillStyle(speckleHex, 0.8);
-                g.fillCircle(this.worldX + sx, this.worldY + sy, size);
-            }
+        if (this.tileDetails.type) return; // coal — overlay covers the rest
 
-            // Grass tufts on the topmost soil rows where the sky meets the surface.
-            const aboveGroundY = this.game.aboveGround * ts;
-            const isNearSurface = this.worldY >= aboveGroundY && this.worldY <= aboveGroundY + ts * 4;
-            if (top && isNearSurface) {
-                const tuftCount = 3 + Math.floor(this.posHash(50) * 3);
-                for (let i = 0; i < tuftCount; i++) {
-                    const tx = x + 1 + this.posHash(60 + i) * (ts - 2);
-                    const tHeight = 1.2 + this.posHash(70 + i) * 1.8;
-                    const grassShade = this.posHash(80 + i) < 0.5 ? 0x6e9c47 : 0x7faa53;
-                    g.fillStyle(grassShade, 1);
-                    g.fillTriangle(
-                        tx - 0.55, y + 0.5,
-                        tx + 0.55, y + 0.5,
-                        tx, y - tHeight
-                    );
-                }
-            }
+        const erodeColor = hexStringToInt(darkenColor(this.tileBaseColor, 35));
 
-            // Embedded curiosities: rare worms and fossils. Stable per tile
-            // via the position hash.
-            const detailRoll = this.posHash(100);
-            if (detailRoll < 0.04) {
-                const detailType = this.posHash(101);
-                if (detailType < 0.5) this.drawWorm(g);
-                else this.drawFossil(g);
-            } else if (detailRoll < 0.07) {
-                this.drawPebbleCluster(g);
+        // Helper: place a 1px nub just outside the tile in tile-base colour,
+        // and a 1px darker erosion just inside, at hash-positioned spots.
+        const decorateEdge = (axis, edgeOpen, salt) => {
+            if (!edgeOpen) return;
+            // 0-2 nubs sticking out
+            const nubCount = Math.floor(this.posHash(salt) * 2.6);
+            for (let i = 0; i < nubCount; i++) {
+                const t = Math.floor(this.posHash(salt + 10 + i) * (ts - 2)) + 1;
+                let px, py;
+                if (axis === 'top')    { px = x + t;       py = y - 1; }
+                if (axis === 'bottom') { px = x + t;       py = y + ts; }
+                if (axis === 'left')   { px = x - 1;       py = y + t; }
+                if (axis === 'right')  { px = x + ts;      py = y + t; }
+                g.fillStyle(this.tileBaseColor, 1);
+                g.fillRect(px, py, 1, 1);
             }
+            // 1-3 erosions just inside the body
+            const eroCount = 1 + Math.floor(this.posHash(salt + 20) * 2);
+            for (let i = 0; i < eroCount; i++) {
+                const t = Math.floor(this.posHash(salt + 30 + i) * (ts - 2)) + 1;
+                let px, py;
+                if (axis === 'top')    { px = x + t;       py = y; }
+                if (axis === 'bottom') { px = x + t;       py = y + ts - 1; }
+                if (axis === 'left')   { px = x;           py = y + t; }
+                if (axis === 'right')  { px = x + ts - 1;  py = y + t; }
+                g.fillStyle(erodeColor, 0.9);
+                g.fillRect(px, py, 1, 1);
+            }
+        };
+        decorateEdge('top', top, 200);
+        decorateEdge('right', right, 220);
+        decorateEdge('bottom', bottom, 240);
+        decorateEdge('left', left, 260);
+
+        // Speckles for organic texture inside the body.
+        const speckleHex = hexStringToInt(darkenColor(this.tileBaseColor, 22));
+        const speckleCount = 1 + Math.floor(this.posHash(2) * 3);
+        for (let i = 0; i < speckleCount; i++) {
+            const sx = (this.posHash(10 + i) - 0.5) * (ts - 3);
+            const sy = (this.posHash(20 + i) - 0.5) * (ts - 3);
+            g.fillStyle(speckleHex, 0.75);
+            g.fillRect(Math.round(this.worldX + sx), Math.round(this.worldY + sy), 1, 1);
+        }
+
+        // Grass tufts on the topmost soil rows where the sky meets the surface.
+        const aboveGroundY = this.game.aboveGround * ts;
+        const isNearSurface = this.worldY >= aboveGroundY && this.worldY <= aboveGroundY + ts * 4;
+        if (top && isNearSurface) {
+            const tuftCount = 2 + Math.floor(this.posHash(50) * 3);
+            for (let i = 0; i < tuftCount; i++) {
+                const tx = x + 1 + this.posHash(60 + i) * (ts - 2);
+                const tHeight = 1 + this.posHash(70 + i) * 1.5;
+                const grassShade = this.posHash(80 + i) < 0.5 ? 0x6e9c47 : 0x7faa53;
+                g.fillStyle(grassShade, 1);
+                g.fillTriangle(
+                    tx - 0.5, y + 0.5,
+                    tx + 0.5, y + 0.5,
+                    tx, y - tHeight
+                );
+            }
+        }
+
+        // Embedded curiosities — rare and small.
+        const detailRoll = this.posHash(100);
+        if (detailRoll < 0.04) {
+            const detailType = this.posHash(101);
+            if (detailType < 0.5) this.drawWorm(g);
+            else this.drawFossil(g);
+        } else if (detailRoll < 0.07) {
+            this.drawPebbleCluster(g);
         }
     }
 
     drawWorm(g) {
         const cx = this.worldX;
-        const cy = this.worldY + (this.posHash(112) - 0.5) * 2;
+        const cy = this.worldY + (this.posHash(112) - 0.5) * 1.4;
         const wormColor = 0xc9846f;
-        const startX = cx - 3 + this.posHash(110) * 0.6;
-        const endX = cx + 2.4 + this.posHash(113) * 0.6;
+        const startX = cx - 1.8 + this.posHash(110) * 0.4;
+        const endX = cx + 1.6 + this.posHash(113) * 0.4;
         const phase = this.posHash(114) * Math.PI * 2;
-        const amp = 1.2 + this.posHash(115) * 0.6;
-        const segments = 14;
-        g.lineStyle(0.9, wormColor, 0.95);
+        const amp = 0.6 + this.posHash(115) * 0.4;
+        const segments = 8;
+        g.lineStyle(0.6, wormColor, 0.95);
         g.beginPath();
         g.moveTo(startX, cy);
         for (let i = 1; i <= segments; i++) {
             const t = i / segments;
-            const x = startX + (endX - startX) * t;
+            const wx = startX + (endX - startX) * t;
             const wave = Math.sin(t * Math.PI * 2.2 + phase) * amp;
-            g.lineTo(x, cy + wave);
+            g.lineTo(wx, cy + wave);
         }
         g.strokePath();
-        // Tiny head dot at the end
-        g.fillStyle(wormColor, 1);
+        // Tiny head pixel
         const headWave = Math.sin(Math.PI * 2.2 + phase) * amp;
-        g.fillCircle(endX, cy + headWave, 0.55);
+        g.fillStyle(wormColor, 1);
+        g.fillRect(Math.round(endX - 0.5), Math.round(cy + headWave - 0.5), 1, 1);
     }
 
     drawFossil(g) {
@@ -166,25 +192,25 @@ export class Breakable extends Tile {
         const baseAngle = (this.posHash(120) - 0.5) * 0.9;
         const cos = Math.cos(baseAngle);
         const sin = Math.sin(baseAngle);
-        g.fillStyle(0xd9c4a0, 0.95);
-        // Vertebrae spaced along a slightly curved spine.
-        for (let i = 0; i < 5; i++) {
-            const t = (i - 2) * 1.2;
-            const wobble = Math.sin(i * 0.9 + this.posHash(121) * 6) * 0.4;
-            const px = cx + cos * t - sin * wobble;
-            const py = cy + sin * t + cos * wobble;
-            g.fillCircle(px, py, 0.65);
+        const boneColor = 0xd9c4a0;
+        // Three vertebrae as 1px squares along a slightly curved spine.
+        g.fillStyle(boneColor, 0.95);
+        for (let i = 0; i < 3; i++) {
+            const t = (i - 1) * 1.1;
+            const px = cx + cos * t;
+            const py = cy + sin * t;
+            g.fillRect(Math.round(px - 0.5), Math.round(py - 0.5), 1, 1);
         }
-        // Two ribbon-rib hints either side of the spine.
-        g.lineStyle(0.45, 0xd9c4a0, 0.7);
+        // Two short rib hints
+        g.lineStyle(0.4, boneColor, 0.7);
         for (let side = -1; side <= 1; side += 2) {
             g.beginPath();
-            for (let i = -2; i <= 2; i++) {
-                const t = i * 1.2;
-                const px = cx + cos * t - sin * 1.2 * side;
-                const py = cy + sin * t + cos * 1.2 * side;
-                if (i === -2) g.moveTo(px, py); else g.lineTo(px, py);
-            }
+            const startX = cx - sin * 0.7 * side;
+            const startY = cy + cos * 0.7 * side;
+            const endX = cx + cos * 1.0 - sin * 1.4 * side;
+            const endY = cy + sin * 1.0 + cos * 1.4 * side;
+            g.moveTo(startX, startY);
+            g.lineTo(endX, endY);
             g.strokePath();
         }
     }
@@ -192,14 +218,13 @@ export class Breakable extends Tile {
     drawPebbleCluster(g) {
         const cx = this.worldX;
         const cy = this.worldY;
-        const pebbleHex = hexStringToInt(darkenColor(this.tileBaseColor, 38));
-        const count = 3 + Math.floor(this.posHash(130) * 2);
+        const pebbleHex = hexStringToInt(darkenColor(this.tileBaseColor, 40));
+        const count = 2 + Math.floor(this.posHash(130) * 2);
         g.fillStyle(pebbleHex, 0.95);
         for (let i = 0; i < count; i++) {
-            const px = cx + (this.posHash(131 + i) - 0.5) * 5;
-            const py = cy + (this.posHash(141 + i) - 0.5) * 5;
-            const r = 0.5 + this.posHash(151 + i) * 0.6;
-            g.fillCircle(px, py, r);
+            const px = cx + (this.posHash(131 + i) - 0.5) * 4;
+            const py = cy + (this.posHash(141 + i) - 0.5) * 4;
+            g.fillRect(Math.round(px - 0.5), Math.round(py - 0.5), 1, 1);
         }
     }
 

--- a/src/classes/breakable.js
+++ b/src/classes/breakable.js
@@ -217,6 +217,18 @@ export class Breakable extends Tile {
         this.tileImage.setOrigin(0.5, 0.5);
         this.tileImage.setDepth(0);
 
+        // Per-tile tint jitter so neighbouring tiles of the same mask+variant
+        // still look subtly different. Tint multiplies the texture so we
+        // can only darken; range is a gentle ~88-100% brightness with a
+        // small warm/cool shift.
+        const baseT = 0.88 + this.posHash(500) * 0.12;
+        const warmShift = (this.posHash(501) - 0.5) * 0.05;
+        const tr = Math.max(0, Math.min(1, baseT + warmShift));
+        const tg = Math.max(0, Math.min(1, baseT));
+        const tb = Math.max(0, Math.min(1, baseT - warmShift));
+        const tintInt = (Math.round(tr * 255) << 16) | (Math.round(tg * 255) << 8) | Math.round(tb * 255);
+        this.tileImage.setTint(tintInt);
+
         if (this.tileDetails.type) {
             this.image = this.game.soilTypes[this.tileDetails.type].image;
             this.overlaySprite = this.game.add.image(this.worldX, this.worldY, this.image);

--- a/src/classes/breakable.js
+++ b/src/classes/breakable.js
@@ -23,14 +23,29 @@ export class Breakable extends Tile {
     }
 
     checkState() {
-        // Self-healing edge refresh. Cheap because redrawTile early-outs if
-        // the mask hasn't changed.
+        // Self-healing refresh. Cheap because redrawTile and
+        // refreshCurveOverlay early-out when state hasn't changed.
         //
         // We deliberately skip checkStateWrapper here — that wrapper is
         // designed for tiles that loose soil falls INTO (empty/light/rail).
         // It transforms its target into a falling block, which is the wrong
         // behaviour for actual soil that already occupies its cell.
         this.redrawTile();
+        this.refreshCurveOverlay();
+    }
+
+    refreshCurveOverlay() {
+        if (!this.curveOverlay) return;
+        const mask = this.game.tileAtlas.cornerCurveMaskFor(this.worldX, this.worldY);
+        if (mask === this.lastCurveMask) return;
+        this.lastCurveMask = mask;
+        if (mask === 0) {
+            this.curveOverlay.setVisible(false);
+            return;
+        }
+        const key = this.game.tileAtlas.ensureCornerCurveTexture(mask);
+        if (this.curveOverlay.texture.key !== key) this.curveOverlay.setTexture(key);
+        this.curveOverlay.setVisible(true);
     }
 
     addToGroup() {
@@ -241,15 +256,28 @@ export class Breakable extends Tile {
         this.crackSprite.setAlpha(1 - this.tileDetails.health + 0.1);
         this.crackSprite.setDepth(4);
 
+        // Inside-corner curve overlay — small Image rendered above the body
+        // depth, with curve pixels in its corner overhang regions that
+        // extend INTO adjacent open diagonal cells. Uses the dark outline
+        // colour so it blends with the surrounding tile borders.
+        this.curveOverlay = this.game.add.image(this.worldX, this.worldY, atlas.cornerCurveKey(0));
+        this.curveOverlay.setOrigin(0.5, 0.5);
+        this.curveOverlay.setDepth(0.5);
+        this.curveOverlay.setVisible(false);
+        this.lastCurveMask = -1;
+
         this.fadeElements = [this.tileImage];
         this.lastEdgeMask = -1;
 
         // Initial draw — neighbours may not exist yet, so do an initial
         // pass and a delayed follow-up.
         this.redrawTile();
+        this.refreshCurveOverlay();
         this.edgeRefreshDelay = this.game.time.delayedCall(80, () => {
             this.lastEdgeMask = -1;
+            this.lastCurveMask = -1;
             this.redrawTile();
+            this.refreshCurveOverlay();
         });
 
         // Rare embedded detail: drawn once as a tiny Graphics overlay since
@@ -266,6 +294,7 @@ export class Breakable extends Tile {
         this.sprite.destroy();
         if (this.overlaySprite) this.overlaySprite.destroy();
         if (this.tileImage) this.tileImage.destroy();
+        if (this.curveOverlay) this.curveOverlay.destroy();
         if (this.detailGraphics) this.detailGraphics.destroy();
         if (this.edgeRefreshDelay) this.edgeRefreshDelay.remove();
     }

--- a/src/classes/breakable.js
+++ b/src/classes/breakable.js
@@ -24,6 +24,10 @@ export class Breakable extends Tile {
 
     checkState() {
         this.checkStateWrapper();
+        // Cheap self-healing: re-evaluate edges so any tile whose neighbour
+        // changed without a direct refresh (e.g. cross-chunk boundary loads)
+        // still picks up the new state. Early-outs if the mask is unchanged.
+        this.redrawTile();
     }
 
     addToGroup() {
@@ -39,22 +43,32 @@ export class Breakable extends Tile {
         return s - Math.floor(s);
     }
 
-    isOpenNeighbor(block) {
-        if (!block) return true;
-        if (block.tileRef?.disabled) return true;
-        if (block.tileRef && !block.tileRef.active) return true;
-        const id = block.tileRef?.tileDetails?.id;
-        return id === 0 || id === 2;
+    // Direct grid lookup is O(1) and works regardless of which Phaser group
+    // a neighbour lives in. Avoids the expensive getAdjacentBlocks scan.
+    isOpenAt(worldX, worldY) {
+        const ts = this.game.tileSize;
+        const cs = this.game.chunkSize;
+        const gcx = Math.floor(worldX / ts);
+        const gcy = Math.floor(worldY / ts);
+        const chunkX = Math.floor(gcx / cs) * cs;
+        const chunkY = Math.floor(gcy / cs) * cs;
+        const chunk = this.game.grid[`${chunkX}_${chunkY}`];
+        if (!chunk) return true; // unloaded chunk -> treat as open
+        const lx = ((gcx % cs) + cs) % cs;
+        const ly = ((gcy % cs) + cs) % cs;
+        const tile = chunk[ly]?.[lx];
+        if (!tile) return true;
+        return tile.id === 0 || tile.id === 2;
     }
 
     getEdgeMask() {
-        const adj = this.game.mapService.getAdjacentBlocks(this.worldX, this.worldY);
-        const aboveGroundY = this.game.aboveGround * this.game.tileSize;
-        const isSurfaceTop = this.worldY <= aboveGroundY + this.game.tileSize;
-        const top = this.isOpenNeighbor(adj.above) || isSurfaceTop;
-        const right = this.isOpenNeighbor(adj.right);
-        const bottom = this.isOpenNeighbor(adj.below);
-        const left = this.isOpenNeighbor(adj.left);
+        const ts = this.game.tileSize;
+        const aboveGroundY = this.game.aboveGround * ts;
+        const isSurfaceTop = this.worldY <= aboveGroundY + ts;
+        const top = this.isOpenAt(this.worldX, this.worldY - ts) || isSurfaceTop;
+        const right = this.isOpenAt(this.worldX + ts, this.worldY);
+        const bottom = this.isOpenAt(this.worldX, this.worldY + ts);
+        const left = this.isOpenAt(this.worldX - ts, this.worldY);
         return (top ? 1 : 0) | (right ? 2 : 0) | (bottom ? 4 : 0) | (left ? 8 : 0);
     }
 

--- a/src/classes/breakable.js
+++ b/src/classes/breakable.js
@@ -33,7 +33,7 @@ export class Breakable extends Tile {
     }
 
     createSprite() {
-        let baseSprite = this.game.add.rectangle(this.worldX, this.worldY, this.game.tileSize, this.game.tileSize, darkenColor(0x724c25, parseInt(this.tileDetails.strength) / 10));
+        let baseSprite = this.game.add.rectangle(this.worldX, this.worldY, this.game.tileSize, this.game.tileSize, darkenColor(0x6e4525, parseInt(this.tileDetails.strength) / 10));
         if (this.tileDetails.type) {
             this.image = this.game.soilTypes[this.tileDetails.type].image;
             this.overlaySprite = this.game.add.image(this.worldX, this.worldY, this.image);

--- a/src/classes/breakable.js
+++ b/src/classes/breakable.js
@@ -217,15 +217,21 @@ export class Breakable extends Tile {
         this.tileImage.setOrigin(0.5, 0.5);
         this.tileImage.setDepth(0);
 
-        // Per-tile tint jitter so neighbouring tiles of the same mask+variant
-        // still look subtly different. Tint multiplies the texture so we
-        // can only darken; range is a gentle ~88-100% brightness with a
-        // small warm/cool shift.
+        // Per-tile tint jitter (so neighbouring tiles still differ slightly)
+        // combined with a hardness-driven shift: softer tiles read brighter
+        // and warmer, harder tiles darker and cooler. Tint can only darken
+        // so per-tile brightness is multiplicative on top of jitter.
+        const strength = parseInt(this.tileDetails.strength) || 200;
+        const hardness = Math.max(-2, Math.min(2, Math.log2(Math.max(1, strength) / 200)));
+        const strengthScale = 1 - hardness * 0.06;
+        const strengthWarm = -hardness * 0.025;
+
         const baseT = 0.88 + this.posHash(500) * 0.12;
-        const warmShift = (this.posHash(501) - 0.5) * 0.05;
-        const tr = Math.max(0, Math.min(1, baseT + warmShift));
-        const tg = Math.max(0, Math.min(1, baseT));
-        const tb = Math.max(0, Math.min(1, baseT - warmShift));
+        const wobble = (this.posHash(501) - 0.5) * 0.05;
+        const fB = Math.max(0.4, Math.min(1, baseT * strengthScale));
+        const tr = Math.max(0, Math.min(1, fB + wobble + strengthWarm));
+        const tg = Math.max(0, Math.min(1, fB));
+        const tb = Math.max(0, Math.min(1, fB - wobble - strengthWarm));
         const tintInt = (Math.round(tr * 255) << 16) | (Math.round(tg * 255) << 8) | Math.round(tb * 255);
         this.tileImage.setTint(tintInt);
 

--- a/src/classes/breakable.js
+++ b/src/classes/breakable.js
@@ -1,5 +1,5 @@
 import {Tile} from "./tile";
-import {darkenColor} from "../services/colourManager";
+import {darkenColor, lightenColor} from "../services/colourManager";
 
 export class Breakable extends Tile {
     constructor({game, worldX, worldY, tileDetails, cellDetails}) {
@@ -33,7 +33,27 @@ export class Breakable extends Tile {
     }
 
     createSprite() {
-        let baseSprite = this.game.add.rectangle(this.worldX, this.worldY, this.game.tileSize, this.game.tileSize, darkenColor(0x6e4525, parseInt(this.tileDetails.strength) / 10));
+        const baseHex = darkenColor(0x6e4525, parseInt(this.tileDetails.strength) / 10);
+        let baseSprite = this.game.add.rectangle(this.worldX, this.worldY, this.game.tileSize, this.game.tileSize, baseHex);
+
+        // Soft bevel: top highlight + bottom shadow read as crumbly soil
+        // instead of flat squares. Skipped on coal (overlay covers them).
+        if (!this.tileDetails.type) {
+            const highlightHex = lightenColor(parseInt(baseHex, 16), 18);
+            const shadowHex = darkenColor(parseInt(baseHex, 16), 30);
+            const halfTile = this.game.tileSize / 2;
+            this.highlightSprite = this.game.add.rectangle(
+                this.worldX, this.worldY - halfTile + 0.5,
+                this.game.tileSize, 1, highlightHex
+            );
+            this.highlightSprite.setDepth(2);
+            this.shadowSprite = this.game.add.rectangle(
+                this.worldX, this.worldY + halfTile - 0.5,
+                this.game.tileSize, 1, shadowHex
+            );
+            this.shadowSprite.setDepth(2);
+        }
+
         if (this.tileDetails.type) {
             this.image = this.game.soilTypes[this.tileDetails.type].image;
             this.overlaySprite = this.game.add.image(this.worldX, this.worldY, this.image);
@@ -46,6 +66,8 @@ export class Breakable extends Tile {
         this.crackSprite.setAlpha(1 - this.tileDetails.health + 0.1);
         this.crackSprite.setDepth(4);
         this.fadeElements = [baseSprite];
+        if (this.highlightSprite) this.fadeElements.push(this.highlightSprite);
+        if (this.shadowSprite) this.fadeElements.push(this.shadowSprite);
 
         return baseSprite;
     }
@@ -56,6 +78,8 @@ export class Breakable extends Tile {
         this.crackSprite.destroy();
         this.sprite.destroy();
         if (this.overlaySprite) this.overlaySprite.destroy();
+        if (this.highlightSprite) this.highlightSprite.destroy();
+        if (this.shadowSprite) this.shadowSprite.destroy();
     }
 
     destroy(prefs) {
@@ -96,6 +120,7 @@ export class Breakable extends Tile {
                     this.crackSprite.setAlpha(0);
                     this.sprite.setStrokeStyle(0, 0);
                     this.game.dustEmitter.explode(50);
+                    this.game.cameras.main.shake(80, 0.0018);
                     baseCell = this.tileDetails.trapped || {...this.game.tileTypes.empty};
                     this.clicking = false;
                     this.game.mapService.setTile(this.worldX, this.worldY, baseCell, this.sprite);

--- a/src/classes/breakable.js
+++ b/src/classes/breakable.js
@@ -23,10 +23,13 @@ export class Breakable extends Tile {
     }
 
     checkState() {
-        this.checkStateWrapper();
-        // Cheap self-healing: re-evaluate edges so any tile whose neighbour
-        // changed without a direct refresh (e.g. cross-chunk boundary loads)
-        // still picks up the new state. Early-outs if the mask is unchanged.
+        // Self-healing edge refresh. Cheap because redrawTile early-outs if
+        // the mask hasn't changed.
+        //
+        // We deliberately skip checkStateWrapper here — that wrapper is
+        // designed for tiles that loose soil falls INTO (empty/light/rail).
+        // It transforms its target into a falling block, which is the wrong
+        // behaviour for actual soil that already occupies its cell.
         this.redrawTile();
     }
 

--- a/src/classes/breakable.js
+++ b/src/classes/breakable.js
@@ -72,7 +72,20 @@ export class Breakable extends Tile {
         const right = this.isOpenAt(this.worldX + ts, this.worldY);
         const bottom = this.isOpenAt(this.worldX, this.worldY + ts);
         const left = this.isOpenAt(this.worldX - ts, this.worldY);
-        return (top ? 1 : 0) | (right ? 2 : 0) | (bottom ? 4 : 0) | (left ? 8 : 0);
+
+        let mask = (top ? 1 : 0) | (right ? 2 : 0) | (bottom ? 4 : 0) | (left ? 8 : 0);
+
+        // Diagonal-only bits: track inner corners. A bit is set when both
+        // adjacent orthogonals are solid neighbours (so this corner is inside
+        // the cave silhouette) AND the diagonal cell is open. That's the
+        // configuration where this tile's corner pixel pokes into a concave
+        // cave corner and should be chipped to round the cave's inside.
+        if (!top && !left && this.isOpenAt(this.worldX - ts, this.worldY - ts)) mask |= 16;
+        if (!top && !right && this.isOpenAt(this.worldX + ts, this.worldY - ts)) mask |= 32;
+        if (!bottom && !left && this.isOpenAt(this.worldX - ts, this.worldY + ts)) mask |= 64;
+        if (!bottom && !right && this.isOpenAt(this.worldX + ts, this.worldY + ts)) mask |= 128;
+
+        return mask;
     }
 
     isNearSurface() {
@@ -95,7 +108,8 @@ export class Breakable extends Tile {
         const top = !!(mask & 1);
         const variant = Math.floor(this.posHash(0) * atlas.variantCount);
         const useGrass = top && this.isNearSurface();
-        const key = atlas.keyFor(useGrass ? 'grass' : 'dirt', mask, variant);
+        const kind = useGrass ? 'grass' : 'dirt';
+        const key = atlas.ensureTexture(kind, mask, variant);
         if (this.tileImage.texture.key !== key) {
             this.tileImage.setTexture(key);
         }

--- a/src/classes/breakable.js
+++ b/src/classes/breakable.js
@@ -139,19 +139,25 @@ export class Breakable extends Tile {
         const cx = this.worldX;
         const cy = this.worldY + (this.posHash(112) - 0.5) * 2;
         const wormColor = 0xc9846f;
-        g.lineStyle(0.9, wormColor, 0.95);
-        g.beginPath();
         const startX = cx - 3 + this.posHash(110) * 0.6;
         const endX = cx + 2.4 + this.posHash(113) * 0.6;
-        const cp1Y = cy - 1.6 - this.posHash(114) * 0.6;
-        const cp2Y = cy + 1.6 + this.posHash(115) * 0.6;
+        const phase = this.posHash(114) * Math.PI * 2;
+        const amp = 1.2 + this.posHash(115) * 0.6;
+        const segments = 14;
+        g.lineStyle(0.9, wormColor, 0.95);
+        g.beginPath();
         g.moveTo(startX, cy);
-        g.quadraticCurveTo(cx - 1.2, cp1Y, cx, cy);
-        g.quadraticCurveTo(cx + 1.2, cp2Y, endX, cy);
+        for (let i = 1; i <= segments; i++) {
+            const t = i / segments;
+            const x = startX + (endX - startX) * t;
+            const wave = Math.sin(t * Math.PI * 2.2 + phase) * amp;
+            g.lineTo(x, cy + wave);
+        }
         g.strokePath();
-        // Tiny head
+        // Tiny head dot at the end
         g.fillStyle(wormColor, 1);
-        g.fillCircle(endX, cy, 0.55);
+        const headWave = Math.sin(Math.PI * 2.2 + phase) * amp;
+        g.fillCircle(endX, cy + headWave, 0.55);
     }
 
     drawFossil(g) {

--- a/src/classes/breakable.js
+++ b/src/classes/breakable.js
@@ -1,5 +1,5 @@
 import {Tile} from "./tile";
-import {darkenColor, lightenColor} from "../services/colourManager";
+import {darkenColor} from "../services/colourManager";
 
 const hexStringToInt = (str) => parseInt(str.replace(/^0x/, ''), 16);
 
@@ -34,7 +34,6 @@ export class Breakable extends Tile {
         return this.game.soilGroup.remove(this.sprite);
     }
 
-    // Deterministic position-based pseudo-random in [0, 1).
     posHash(salt = 0) {
         const s = Math.sin(this.worldX * 12.9898 + this.worldY * 78.233 + salt * 37.719) * 43758.5453;
         return s - Math.floor(s);
@@ -59,121 +58,48 @@ export class Breakable extends Tile {
         return (top ? 1 : 0) | (right ? 2 : 0) | (bottom ? 4 : 0) | (left ? 8 : 0);
     }
 
+    isNearSurface() {
+        const ts = this.game.tileSize;
+        const aboveGroundY = this.game.aboveGround * ts;
+        return this.worldY >= aboveGroundY && this.worldY <= aboveGroundY + ts * 3;
+    }
+
     redrawTile() {
-        if (!this.tileGraphics || !this.active) return;
+        if (!this.tileImage || !this.active) return;
         const mask = this.getEdgeMask();
         if (mask === this.lastEdgeMask) return;
         this.lastEdgeMask = mask;
 
+        // Coal tiles use the existing dark base + overlay sprite — skip
+        // texture swap so the overlay still shows.
+        if (this.tileDetails.type) return;
+
+        const atlas = this.game.tileAtlas;
         const top = !!(mask & 1);
-        const right = !!(mask & 2);
-        const bottom = !!(mask & 4);
-        const left = !!(mask & 8);
-
-        const g = this.tileGraphics;
-        g.clear();
-
-        const ts = this.game.tileSize;
-        const x = this.worldX - ts / 2;
-        const y = this.worldY - ts / 2;
-
-        // Sharp Terraria-style body. The "uneven" feel comes from internal
-        // texture, not silhouette.
-        g.fillStyle(this.tileBaseColor, 1);
-        g.fillRect(x, y, ts, ts);
-
-        if (this.tileDetails.type) return; // coal — overlay covers the rest
-
-        const lightHex = hexStringToInt(lightenColor(this.tileBaseColor, 22));
-        const dark1 = hexStringToInt(darkenColor(this.tileBaseColor, 22));
-        const dark2 = hexStringToInt(darkenColor(this.tileBaseColor, 40));
-
-        // Top edge: a brighter row when light hits from above.
-        if (top) {
-            g.fillStyle(lightHex, 0.95);
-            g.fillRect(x, y, ts, 1);
-            // Weather it with a few scattered dark pixels
-            const wear = 2 + Math.floor(this.posHash(70) * 3);
-            for (let i = 0; i < wear; i++) {
-                const px = x + Math.floor(this.posHash(71 + i) * ts);
-                g.fillStyle(dark1, 1);
-                g.fillRect(px, y, 1, 1);
-            }
+        const variant = Math.floor(this.posHash(0) * atlas.variantCount);
+        const useGrass = top && this.isNearSurface();
+        const key = atlas.keyFor(useGrass ? 'grass' : 'dirt', mask, variant);
+        if (this.tileImage.texture.key !== key) {
+            this.tileImage.setTexture(key);
         }
-        // Bottom edge: a darker row to suggest shadow falloff.
-        if (bottom) {
-            g.fillStyle(dark2, 0.85);
-            g.fillRect(x, y + ts - 1, ts, 1);
-        }
-        // Side edges: subtle vertical shading.
-        if (left) {
-            g.fillStyle(dark1, 0.55);
-            g.fillRect(x, y, 1, ts);
-        }
-        if (right) {
-            g.fillStyle(dark1, 0.55);
-            g.fillRect(x + ts - 1, y, 1, ts);
-        }
+    }
 
-        // Chipped corners — where two adjacent sides face air, the corner
-        // pixel reads as crumbled. Stops corners feeling perfectly square
-        // without rounding the silhouette.
-        const chip = (cx, cy) => { g.fillStyle(dark2, 1); g.fillRect(cx, cy, 1, 1); };
-        if (top && left)     chip(x, y);
-        if (top && right)    chip(x + ts - 1, y);
-        if (bottom && left)  chip(x, y + ts - 1);
-        if (bottom && right) chip(x + ts - 1, y + ts - 1);
-
-        // Body texture: scatter darker and lighter pixels for soil grain.
-        const speckleCount = 4 + Math.floor(this.posHash(2) * 3);
-        for (let i = 0; i < speckleCount; i++) {
-            const sx = x + 1 + Math.floor(this.posHash(10 + i) * (ts - 2));
-            const sy = y + 1 + Math.floor(this.posHash(20 + i) * (ts - 2));
-            const useLight = this.posHash(30 + i) > 0.78;
-            g.fillStyle(useLight ? lightHex : dark1, useLight ? 0.7 : 0.85);
-            g.fillRect(sx, sy, 1, 1);
-        }
-
-        // Grass on the topmost soil rows where the sky meets the surface.
-        const aboveGroundY = this.game.aboveGround * ts;
-        const isNearSurface = this.worldY >= aboveGroundY && this.worldY <= aboveGroundY + ts * 3;
-        if (top && isNearSurface) {
-            const grassA = 0x6e9c47;
-            const grassB = 0x88b85c;
-            const grassDark = 0x4f7330;
-            // Solid green band along the top
-            g.fillStyle(grassA, 1);
-            g.fillRect(x, y, ts, 1);
-            // Mottle with darker greens
-            const mottle = 2 + Math.floor(this.posHash(60) * 3);
-            for (let i = 0; i < mottle; i++) {
-                const px = x + Math.floor(this.posHash(61 + i) * ts);
-                g.fillStyle(grassDark, 1);
-                g.fillRect(px, y, 1, 1);
-            }
-            // A second softer row of green underneath (Terraria-ish)
-            g.fillStyle(grassA, 0.45);
-            g.fillRect(x, y + 1, ts, 1);
-            // Hanging/standing grass blades on top
-            const blades = 2 + Math.floor(this.posHash(80) * 3);
-            for (let i = 0; i < blades; i++) {
-                const px = x + 1 + Math.floor(this.posHash(81 + i) * (ts - 2));
-                const blen = 1 + Math.floor(this.posHash(91 + i) * 3);
-                const useLight = this.posHash(101 + i) > 0.5;
-                g.fillStyle(useLight ? grassB : grassA, 1);
-                g.fillRect(px, y - blen, 1, blen);
-            }
-        }
-
-        // Embedded curiosities — rare and small.
+    drawDetailOverlay() {
+        if (this.tileDetails.type) return; // skip on coal
         const detailRoll = this.posHash(200);
+        if (detailRoll >= 0.07) return;
+
+        this.detailGraphics = this.game.add.graphics();
+        this.detailGraphics.setDepth(2);
+        const g = this.detailGraphics;
         if (detailRoll < 0.04) {
             const detailType = this.posHash(201);
             if (detailType < 0.5) this.drawWorm(g);
             else this.drawFossil(g);
-        } else if (detailRoll < 0.07) {
+        } else {
             this.drawPebbleCluster(g);
         }
+        if (this.fadeElements) this.fadeElements.push(this.detailGraphics);
     }
 
     drawWorm(g) {
@@ -195,7 +121,6 @@ export class Breakable extends Tile {
             g.lineTo(wx, cy + wave);
         }
         g.strokePath();
-        // Tiny head pixel
         const headWave = Math.sin(Math.PI * 2.2 + phase) * amp;
         g.fillStyle(wormColor, 1);
         g.fillRect(Math.round(endX - 0.5), Math.round(cy + headWave - 0.5), 1, 1);
@@ -208,7 +133,6 @@ export class Breakable extends Tile {
         const cos = Math.cos(baseAngle);
         const sin = Math.sin(baseAngle);
         const boneColor = 0xd9c4a0;
-        // Three vertebrae as 1px squares along a slightly curved spine.
         g.fillStyle(boneColor, 0.95);
         for (let i = 0; i < 3; i++) {
             const t = (i - 1) * 1.1;
@@ -216,7 +140,6 @@ export class Breakable extends Tile {
             const py = cy + sin * t;
             g.fillRect(Math.round(px - 0.5), Math.round(py - 0.5), 1, 1);
         }
-        // Two short rib hints
         g.lineStyle(0.4, boneColor, 0.7);
         for (let side = -1; side <= 1; side += 2) {
             g.beginPath();
@@ -233,7 +156,7 @@ export class Breakable extends Tile {
     drawPebbleCluster(g) {
         const cx = this.worldX;
         const cy = this.worldY;
-        const pebbleHex = hexStringToInt(darkenColor(this.tileBaseColor, 40));
+        const pebbleHex = hexStringToInt(darkenColor(0x6e4525, 40));
         const count = 2 + Math.floor(this.posHash(130) * 2);
         g.fillStyle(pebbleHex, 0.95);
         for (let i = 0; i < count; i++) {
@@ -244,44 +167,53 @@ export class Breakable extends Tile {
     }
 
     createSprite() {
-        // Per-tile lightness jitter breaks the uniform colour-field so the
-        // cave wall reads as organic dirt rather than a flat plane. Coal
-        // tiles get less jitter since their overlay dominates.
-        const jitterRange = this.tileDetails.type ? 4 : 9;
-        const jitter = Phaser.Math.Between(-jitterRange, jitterRange);
-        const baseFactor = parseInt(this.tileDetails.strength) / 10 + jitter;
-        this.tileBaseColor = hexStringToInt(darkenColor(0x6e4525, baseFactor));
+        const atlas = this.game.tileAtlas;
+        const ts = this.game.tileSize;
+        const overhang = atlas.grassOverhang;
 
-        // Invisible rectangle is the hit/collision body — visual is drawn
-        // on the Graphics layer below.
-        let baseSprite = this.game.add.rectangle(this.worldX, this.worldY, this.game.tileSize, this.game.tileSize, this.tileBaseColor);
+        // Invisible rectangle is the hit/collision body. Visual is the
+        // Image sprite below, which references a pre-rendered atlas texture.
+        const baseColor = hexStringToInt(darkenColor(0x6e4525, parseInt(this.tileDetails.strength) / 10));
+        let baseSprite = this.game.add.rectangle(this.worldX, this.worldY, ts, ts, baseColor);
         baseSprite.setAlpha(0);
 
-        this.tileGraphics = this.game.add.graphics();
-        this.tileGraphics.setDepth(0);
+        // Place the image so its body region (bottom tileSize rows of the
+        // textureHeight-tall texture) aligns with the world tile bounds.
+        // Center origin + Y offset = -overhang/2 means the texture's vertical
+        // center sits overhang/2 above worldY.
+        const initialKey = atlas.keyFor('dirt', 0, 0);
+        this.tileImage = this.game.add.image(this.worldX, this.worldY - overhang / 2, initialKey);
+        this.tileImage.setOrigin(0.5, 0.5);
+        this.tileImage.setDepth(0);
 
         if (this.tileDetails.type) {
             this.image = this.game.soilTypes[this.tileDetails.type].image;
             this.overlaySprite = this.game.add.image(this.worldX, this.worldY, this.image);
-            this.overlaySprite.setDisplaySize(this.game.tileSize, this.game.tileSize);
+            this.overlaySprite.setDisplaySize(ts, ts);
             this.overlaySprite.setDepth(3);
+            // Hide the dirt texture under coal — overlay covers it.
+            this.tileImage.setVisible(false);
         }
 
         this.crackSprite = this.game.add.image(this.worldX, this.worldY, 'crack');
-        this.crackSprite.setDisplaySize(this.game.tileSize - 1, this.game.tileSize - 1);
+        this.crackSprite.setDisplaySize(ts - 1, ts - 1);
         this.crackSprite.setAlpha(1 - this.tileDetails.health + 0.1);
         this.crackSprite.setDepth(4);
 
-        this.fadeElements = [this.tileGraphics];
+        this.fadeElements = [this.tileImage];
         this.lastEdgeMask = -1;
 
-        // Initial draw — neighbours may not all exist yet, so schedule a
-        // follow-up once they've been created.
+        // Initial draw — neighbours may not exist yet, so do an initial
+        // pass and a delayed follow-up.
         this.redrawTile();
         this.edgeRefreshDelay = this.game.time.delayedCall(80, () => {
             this.lastEdgeMask = -1;
             this.redrawTile();
         });
+
+        // Rare embedded detail: drawn once as a tiny Graphics overlay since
+        // it's truly per-tile (not cacheable) and only fires on ~7% of tiles.
+        this.drawDetailOverlay();
 
         return baseSprite;
     }
@@ -292,14 +224,15 @@ export class Breakable extends Tile {
         this.crackSprite.destroy();
         this.sprite.destroy();
         if (this.overlaySprite) this.overlaySprite.destroy();
-        if (this.tileGraphics) this.tileGraphics.destroy();
+        if (this.tileImage) this.tileImage.destroy();
+        if (this.detailGraphics) this.detailGraphics.destroy();
         if (this.edgeRefreshDelay) this.edgeRefreshDelay.remove();
     }
 
     destroy(prefs) {
-        if (!this.active) return;  // Guard against double-destroy
+        if (!this.active) return;
         if (this.clicking) {
-            this.removeElements()
+            this.removeElements();
         } else {
             this.destroyHandler(this.removeElements.bind(this), prefs);
         }
@@ -320,9 +253,8 @@ export class Breakable extends Tile {
                 let health = -(damageAmount / this.tileDetails.strength - 1);
                 this.game.dustEmitter.setPosition(this.sprite.x, this.sprite.y);
                 if (this.image) {
-                    // TODO Throw out collision object
                     let debris = this.game.physics.add.image(this.worldX, this.worldY, this.image);
-                    debris.setDisplaySize(3, 3)
+                    debris.setDisplaySize(3, 3);
                     debris.materialRef = this;
                     debris.setVelocity(Phaser.Math.Between(-10, 10), Phaser.Math.Between(-10, -10));
                     debris.setBounce(0.6);

--- a/src/classes/breakable.js
+++ b/src/classes/breakable.js
@@ -1,6 +1,8 @@
 import {Tile} from "./tile";
 import {darkenColor} from "../services/colourManager";
 
+const hexStringToInt = (str) => parseInt(str.replace(/^0x/, ''), 16);
+
 export class Breakable extends Tile {
     constructor({game, worldX, worldY, tileDetails, cellDetails}) {
         super({game, worldX, worldY, tileDetails, cellDetails});
@@ -32,6 +34,169 @@ export class Breakable extends Tile {
         return this.game.soilGroup.remove(this.sprite);
     }
 
+    // Deterministic position-based pseudo-random in [0, 1).
+    posHash(salt = 0) {
+        const s = Math.sin(this.worldX * 12.9898 + this.worldY * 78.233 + salt * 37.719) * 43758.5453;
+        return s - Math.floor(s);
+    }
+
+    isOpenNeighbor(block) {
+        if (!block) return true;
+        if (block.tileRef?.disabled) return true;
+        if (block.tileRef && !block.tileRef.active) return true;
+        const id = block.tileRef?.tileDetails?.id;
+        return id === 0 || id === 2;
+    }
+
+    getEdgeMask() {
+        const adj = this.game.mapService.getAdjacentBlocks(this.worldX, this.worldY);
+        const aboveGroundY = this.game.aboveGround * this.game.tileSize;
+        const isSurfaceTop = this.worldY <= aboveGroundY + this.game.tileSize;
+        const top = this.isOpenNeighbor(adj.above) || isSurfaceTop;
+        const right = this.isOpenNeighbor(adj.right);
+        const bottom = this.isOpenNeighbor(adj.below);
+        const left = this.isOpenNeighbor(adj.left);
+        return (top ? 1 : 0) | (right ? 2 : 0) | (bottom ? 4 : 0) | (left ? 8 : 0);
+    }
+
+    redrawTile() {
+        if (!this.tileGraphics || !this.active) return;
+        const mask = this.getEdgeMask();
+        if (mask === this.lastEdgeMask) return;
+        this.lastEdgeMask = mask;
+
+        const top = !!(mask & 1);
+        const right = !!(mask & 2);
+        const bottom = !!(mask & 4);
+        const left = !!(mask & 8);
+
+        const g = this.tileGraphics;
+        g.clear();
+
+        const ts = this.game.tileSize;
+        const half = ts / 2;
+        const x = this.worldX - half;
+        const y = this.worldY - half;
+
+        // Round corners only where two adjacent sides are both exposed —
+        // these are real cave corners. Internal corners stay sharp so
+        // stacks of soil don't develop visible seams.
+        const r = 2;
+        const tl = (top && left) ? r : 0;
+        const tr = (top && right) ? r : 0;
+        const br = (bottom && right) ? r : 0;
+        const bl = (bottom && left) ? r : 0;
+
+        g.fillStyle(this.tileBaseColor, 1);
+        g.fillRoundedRect(x, y, ts, ts, {tl, tr, br, bl});
+
+        // Skip extra decoration on coal — its overlay sprite covers most
+        // of the surface area anyway.
+        if (!this.tileDetails.type) {
+            // Speckles: small darker dots scattered across the body.
+            const speckleHex = hexStringToInt(darkenColor(this.tileBaseColor, 25));
+            const speckleCount = 1 + Math.floor(this.posHash(2) * 3);
+            for (let i = 0; i < speckleCount; i++) {
+                const sx = (this.posHash(10 + i) - 0.5) * (ts - 3);
+                const sy = (this.posHash(20 + i) - 0.5) * (ts - 3);
+                const size = 0.4 + this.posHash(30 + i) * 0.7;
+                g.fillStyle(speckleHex, 0.8);
+                g.fillCircle(this.worldX + sx, this.worldY + sy, size);
+            }
+
+            // Grass tufts on the topmost soil rows where the sky meets the surface.
+            const aboveGroundY = this.game.aboveGround * ts;
+            const isNearSurface = this.worldY >= aboveGroundY && this.worldY <= aboveGroundY + ts * 4;
+            if (top && isNearSurface) {
+                const tuftCount = 3 + Math.floor(this.posHash(50) * 3);
+                for (let i = 0; i < tuftCount; i++) {
+                    const tx = x + 1 + this.posHash(60 + i) * (ts - 2);
+                    const tHeight = 1.2 + this.posHash(70 + i) * 1.8;
+                    const grassShade = this.posHash(80 + i) < 0.5 ? 0x6e9c47 : 0x7faa53;
+                    g.fillStyle(grassShade, 1);
+                    g.fillTriangle(
+                        tx - 0.55, y + 0.5,
+                        tx + 0.55, y + 0.5,
+                        tx, y - tHeight
+                    );
+                }
+            }
+
+            // Embedded curiosities: rare worms and fossils. Stable per tile
+            // via the position hash.
+            const detailRoll = this.posHash(100);
+            if (detailRoll < 0.04) {
+                const detailType = this.posHash(101);
+                if (detailType < 0.5) this.drawWorm(g);
+                else this.drawFossil(g);
+            } else if (detailRoll < 0.07) {
+                this.drawPebbleCluster(g);
+            }
+        }
+    }
+
+    drawWorm(g) {
+        const cx = this.worldX;
+        const cy = this.worldY + (this.posHash(112) - 0.5) * 2;
+        const wormColor = 0xc9846f;
+        g.lineStyle(0.9, wormColor, 0.95);
+        g.beginPath();
+        const startX = cx - 3 + this.posHash(110) * 0.6;
+        const endX = cx + 2.4 + this.posHash(113) * 0.6;
+        const cp1Y = cy - 1.6 - this.posHash(114) * 0.6;
+        const cp2Y = cy + 1.6 + this.posHash(115) * 0.6;
+        g.moveTo(startX, cy);
+        g.quadraticCurveTo(cx - 1.2, cp1Y, cx, cy);
+        g.quadraticCurveTo(cx + 1.2, cp2Y, endX, cy);
+        g.strokePath();
+        // Tiny head
+        g.fillStyle(wormColor, 1);
+        g.fillCircle(endX, cy, 0.55);
+    }
+
+    drawFossil(g) {
+        const cx = this.worldX;
+        const cy = this.worldY;
+        const baseAngle = (this.posHash(120) - 0.5) * 0.9;
+        const cos = Math.cos(baseAngle);
+        const sin = Math.sin(baseAngle);
+        g.fillStyle(0xd9c4a0, 0.95);
+        // Vertebrae spaced along a slightly curved spine.
+        for (let i = 0; i < 5; i++) {
+            const t = (i - 2) * 1.2;
+            const wobble = Math.sin(i * 0.9 + this.posHash(121) * 6) * 0.4;
+            const px = cx + cos * t - sin * wobble;
+            const py = cy + sin * t + cos * wobble;
+            g.fillCircle(px, py, 0.65);
+        }
+        // Two ribbon-rib hints either side of the spine.
+        g.lineStyle(0.45, 0xd9c4a0, 0.7);
+        for (let side = -1; side <= 1; side += 2) {
+            g.beginPath();
+            for (let i = -2; i <= 2; i++) {
+                const t = i * 1.2;
+                const px = cx + cos * t - sin * 1.2 * side;
+                const py = cy + sin * t + cos * 1.2 * side;
+                if (i === -2) g.moveTo(px, py); else g.lineTo(px, py);
+            }
+            g.strokePath();
+        }
+    }
+
+    drawPebbleCluster(g) {
+        const cx = this.worldX;
+        const cy = this.worldY;
+        const pebbleHex = hexStringToInt(darkenColor(this.tileBaseColor, 38));
+        const count = 3 + Math.floor(this.posHash(130) * 2);
+        g.fillStyle(pebbleHex, 0.95);
+        for (let i = 0; i < count; i++) {
+            const px = cx + (this.posHash(131 + i) - 0.5) * 5;
+            const py = cy + (this.posHash(141 + i) - 0.5) * 5;
+            const r = 0.5 + this.posHash(151 + i) * 0.6;
+            g.fillCircle(px, py, r);
+        }
+    }
+
     createSprite() {
         // Per-tile lightness jitter breaks the uniform colour-field so the
         // cave wall reads as organic dirt rather than a flat plane. Coal
@@ -39,8 +204,15 @@ export class Breakable extends Tile {
         const jitterRange = this.tileDetails.type ? 4 : 9;
         const jitter = Phaser.Math.Between(-jitterRange, jitterRange);
         const baseFactor = parseInt(this.tileDetails.strength) / 10 + jitter;
-        const baseHex = darkenColor(0x6e4525, baseFactor);
-        let baseSprite = this.game.add.rectangle(this.worldX, this.worldY, this.game.tileSize, this.game.tileSize, baseHex);
+        this.tileBaseColor = hexStringToInt(darkenColor(0x6e4525, baseFactor));
+
+        // Invisible rectangle is the hit/collision body — visual is drawn
+        // on the Graphics layer below.
+        let baseSprite = this.game.add.rectangle(this.worldX, this.worldY, this.game.tileSize, this.game.tileSize, this.tileBaseColor);
+        baseSprite.setAlpha(0);
+
+        this.tileGraphics = this.game.add.graphics();
+        this.tileGraphics.setDepth(0);
 
         if (this.tileDetails.type) {
             this.image = this.game.soilTypes[this.tileDetails.type].image;
@@ -53,7 +225,17 @@ export class Breakable extends Tile {
         this.crackSprite.setDisplaySize(this.game.tileSize - 1, this.game.tileSize - 1);
         this.crackSprite.setAlpha(1 - this.tileDetails.health + 0.1);
         this.crackSprite.setDepth(4);
-        this.fadeElements = [baseSprite];
+
+        this.fadeElements = [this.tileGraphics];
+        this.lastEdgeMask = -1;
+
+        // Initial draw — neighbours may not all exist yet, so schedule a
+        // follow-up once they've been created.
+        this.redrawTile();
+        this.edgeRefreshDelay = this.game.time.delayedCall(80, () => {
+            this.lastEdgeMask = -1;
+            this.redrawTile();
+        });
 
         return baseSprite;
     }
@@ -64,6 +246,8 @@ export class Breakable extends Tile {
         this.crackSprite.destroy();
         this.sprite.destroy();
         if (this.overlaySprite) this.overlaySprite.destroy();
+        if (this.tileGraphics) this.tileGraphics.destroy();
+        if (this.edgeRefreshDelay) this.edgeRefreshDelay.remove();
     }
 
     destroy(prefs) {

--- a/src/classes/breakable.js
+++ b/src/classes/breakable.js
@@ -73,19 +73,11 @@ export class Breakable extends Tile {
         const bottom = this.isOpenAt(this.worldX, this.worldY + ts);
         const left = this.isOpenAt(this.worldX - ts, this.worldY);
 
-        let mask = (top ? 1 : 0) | (right ? 2 : 0) | (bottom ? 4 : 0) | (left ? 8 : 0);
-
-        // Diagonal-only bits: track inner corners. A bit is set when both
-        // adjacent orthogonals are solid neighbours (so this corner is inside
-        // the cave silhouette) AND the diagonal cell is open. That's the
-        // configuration where this tile's corner pixel pokes into a concave
-        // cave corner and should be chipped to round the cave's inside.
-        if (!top && !left && this.isOpenAt(this.worldX - ts, this.worldY - ts)) mask |= 16;
-        if (!top && !right && this.isOpenAt(this.worldX + ts, this.worldY - ts)) mask |= 32;
-        if (!bottom && !left && this.isOpenAt(this.worldX - ts, this.worldY + ts)) mask |= 64;
-        if (!bottom && !right && this.isOpenAt(this.worldX + ts, this.worldY + ts)) mask |= 128;
-
-        return mask;
+        // Inside corners are now rounded by the empty tile drawing a curve
+        // into its corner with dirt-coloured pixels (see Empty.redrawCurve).
+        // The solid tile keeps its corner intact so the two effects don't
+        // overlap into a chunky double-chip.
+        return (top ? 1 : 0) | (right ? 2 : 0) | (bottom ? 4 : 0) | (left ? 8 : 0);
     }
 
     isNearSurface() {

--- a/src/classes/breakable.js
+++ b/src/classes/breakable.js
@@ -1,5 +1,5 @@
 import {Tile} from "./tile";
-import {darkenColor, lightenColor} from "../services/colourManager";
+import {darkenColor} from "../services/colourManager";
 
 export class Breakable extends Tile {
     constructor({game, worldX, worldY, tileDetails, cellDetails}) {
@@ -33,26 +33,14 @@ export class Breakable extends Tile {
     }
 
     createSprite() {
-        const baseHex = darkenColor(0x6e4525, parseInt(this.tileDetails.strength) / 10);
+        // Per-tile lightness jitter breaks the uniform colour-field so the
+        // cave wall reads as organic dirt rather than a flat plane. Coal
+        // tiles get less jitter since their overlay dominates.
+        const jitterRange = this.tileDetails.type ? 4 : 9;
+        const jitter = Phaser.Math.Between(-jitterRange, jitterRange);
+        const baseFactor = parseInt(this.tileDetails.strength) / 10 + jitter;
+        const baseHex = darkenColor(0x6e4525, baseFactor);
         let baseSprite = this.game.add.rectangle(this.worldX, this.worldY, this.game.tileSize, this.game.tileSize, baseHex);
-
-        // Soft bevel: top highlight + bottom shadow read as crumbly soil
-        // instead of flat squares. Skipped on coal (overlay covers them).
-        if (!this.tileDetails.type) {
-            const highlightHex = lightenColor(parseInt(baseHex, 16), 18);
-            const shadowHex = darkenColor(parseInt(baseHex, 16), 30);
-            const halfTile = this.game.tileSize / 2;
-            this.highlightSprite = this.game.add.rectangle(
-                this.worldX, this.worldY - halfTile + 0.5,
-                this.game.tileSize, 1, highlightHex
-            );
-            this.highlightSprite.setDepth(2);
-            this.shadowSprite = this.game.add.rectangle(
-                this.worldX, this.worldY + halfTile - 0.5,
-                this.game.tileSize, 1, shadowHex
-            );
-            this.shadowSprite.setDepth(2);
-        }
 
         if (this.tileDetails.type) {
             this.image = this.game.soilTypes[this.tileDetails.type].image;
@@ -66,8 +54,6 @@ export class Breakable extends Tile {
         this.crackSprite.setAlpha(1 - this.tileDetails.health + 0.1);
         this.crackSprite.setDepth(4);
         this.fadeElements = [baseSprite];
-        if (this.highlightSprite) this.fadeElements.push(this.highlightSprite);
-        if (this.shadowSprite) this.fadeElements.push(this.shadowSprite);
 
         return baseSprite;
     }
@@ -78,8 +64,6 @@ export class Breakable extends Tile {
         this.crackSprite.destroy();
         this.sprite.destroy();
         if (this.overlaySprite) this.overlaySprite.destroy();
-        if (this.highlightSprite) this.highlightSprite.destroy();
-        if (this.shadowSprite) this.shadowSprite.destroy();
     }
 
     destroy(prefs) {
@@ -120,7 +104,6 @@ export class Breakable extends Tile {
                     this.crackSprite.setAlpha(0);
                     this.sprite.setStrokeStyle(0, 0);
                     this.game.dustEmitter.explode(50);
-                    this.game.cameras.main.shake(80, 0.0018);
                     baseCell = this.tileDetails.trapped || {...this.game.tileTypes.empty};
                     this.clicking = false;
                     this.game.mapService.setTile(this.worldX, this.worldY, baseCell, this.sprite);

--- a/src/classes/buttress.js
+++ b/src/classes/buttress.js
@@ -14,12 +14,46 @@ export class Buttress extends Tile {
         return this.game.buttressGroup.remove(this.sprite);
     }
 
+    checkState() {
+        super.checkState();
+        this.refreshCurveOverlay();
+    }
+
+    refreshCurveOverlay() {
+        if (!this.curveOverlay) return;
+        const mask = this.game.tileAtlas.cornerCurveMaskFor(this.worldX, this.worldY);
+        if (mask === this.lastCurveMask) return;
+        this.lastCurveMask = mask;
+        if (mask === 0) {
+            this.curveOverlay.setVisible(false);
+            return;
+        }
+        const key = this.game.tileAtlas.ensureCornerCurveTexture(mask);
+        if (this.curveOverlay.texture.key !== key) this.curveOverlay.setTexture(key);
+        this.curveOverlay.setVisible(true);
+    }
+
     createSprite() {
         let baseSprite = this.game.add.rectangle(this.worldX, this.worldY, this.game.tileSize, this.game.tileSize, '0xffffff');
         this.buttressSprite = this.game.add.image(this.worldX, this.worldY, 'buttress');
         this.buttressSprite.setDisplaySize(this.game.tileSize, this.game.tileSize);
         baseSprite.setAlpha(0);
+
+        // Inside-corner curve overlay (same machinery as Breakable).
+        this.curveOverlay = this.game.add.image(this.worldX, this.worldY, this.game.tileAtlas.cornerCurveKey(0));
+        this.curveOverlay.setOrigin(0.5, 0.5);
+        this.curveOverlay.setDepth(0.5);
+        this.curveOverlay.setVisible(false);
+        this.lastCurveMask = -1;
+
         this.fadeElements = [this.buttressSprite];
+
+        this.refreshCurveOverlay();
+        this.curveRefreshDelay = this.game.time.delayedCall(80, () => {
+            this.lastCurveMask = -1;
+            this.refreshCurveOverlay();
+        });
+
         return baseSprite;
     }
 
@@ -27,6 +61,8 @@ export class Buttress extends Tile {
         this.active = false;
         this.removeFromGroup();
         this.buttressSprite.destroy();
+        if (this.curveOverlay) this.curveOverlay.destroy();
+        if (this.curveRefreshDelay) this.curveRefreshDelay.remove();
         this.sprite.destroy();
     }
 

--- a/src/classes/empty.js
+++ b/src/classes/empty.js
@@ -15,9 +15,79 @@ export class Empty extends Tile {
         return this.game.emptyGroup.remove(this.sprite);
     }
 
+    isSolidAt(worldX, worldY) {
+        const ts = this.game.tileSize;
+        const cs = this.game.chunkSize;
+        const gcx = Math.floor(worldX / ts);
+        const gcy = Math.floor(worldY / ts);
+        const chunkX = Math.floor(gcx / cs) * cs;
+        const chunkY = Math.floor(gcy / cs) * cs;
+        const chunk = this.game.grid[`${chunkX}_${chunkY}`];
+        if (!chunk) return false;
+        const lx = ((gcx % cs) + cs) % cs;
+        const ly = ((gcy % cs) + cs) % cs;
+        const tile = chunk[ly]?.[lx];
+        if (!tile) return false;
+        // "Solid" for inside-corner curve purposes — anything dirt-like that
+        // forms part of a continuous wall mass.
+        return tile.id === 1 || tile.id === 5;
+    }
+
+    getCurveMask() {
+        const ts = this.game.tileSize;
+        const top = this.isSolidAt(this.worldX, this.worldY - ts);
+        const right = this.isSolidAt(this.worldX + ts, this.worldY);
+        const bottom = this.isSolidAt(this.worldX, this.worldY + ts);
+        const left = this.isSolidAt(this.worldX - ts, this.worldY);
+        let mask = 0;
+        if (top && left && this.isSolidAt(this.worldX - ts, this.worldY - ts)) mask |= 1;
+        if (top && right && this.isSolidAt(this.worldX + ts, this.worldY - ts)) mask |= 2;
+        if (bottom && left && this.isSolidAt(this.worldX - ts, this.worldY + ts)) mask |= 4;
+        if (bottom && right && this.isSolidAt(this.worldX + ts, this.worldY + ts)) mask |= 8;
+        return mask;
+    }
+
+    redrawCurve() {
+        if (!this.curveImage) return;
+        const mask = this.getCurveMask();
+        if (mask === this.lastCurveMask) return;
+        this.lastCurveMask = mask;
+        if (mask === 0) {
+            this.curveImage.setVisible(false);
+            return;
+        }
+        const key = this.game.tileAtlas.ensureEmptyCurveTexture(mask);
+        if (this.curveImage.texture.key !== key) this.curveImage.setTexture(key);
+        this.curveImage.setVisible(true);
+    }
+
+    checkState() {
+        super.checkState();
+        this.redrawCurve();
+    }
+
     createSprite() {
         let baseSprite = this.game.add.rectangle(this.worldX, this.worldY, this.game.tileSize, this.game.tileSize, '0xffffff');
         baseSprite.setAlpha(0);
+
+        // Curve overlay — pre-rendered atlas texture per inside-corner mask.
+        // Median jitter tint (~0.94 brightness) so the curve blends with the
+        // average tinted dirt tile next to it.
+        this.curveImage = this.game.add.image(this.worldX, this.worldY, this.game.tileAtlas.emptyCurveKey(0));
+        this.curveImage.setOrigin(0.5, 0.5);
+        this.curveImage.setDepth(0);
+        this.curveImage.setVisible(false);
+        const t = Math.round(0.94 * 255);
+        this.curveImage.setTint((t << 16) | (t << 8) | t);
+        this.lastCurveMask = -1;
+
+        // First refresh — neighbours may not exist yet, so retry shortly.
+        this.redrawCurve();
+        this.curveRefreshDelay = this.game.time.delayedCall(80, () => {
+            this.lastCurveMask = -1;
+            this.redrawCurve();
+        });
+
         return baseSprite;
     }
 
@@ -35,6 +105,8 @@ export class Empty extends Tile {
 
     destroy() {
         this.removeFromGroup();
+        if (this.curveImage) this.curveImage.destroy();
+        if (this.curveRefreshDelay) this.curveRefreshDelay.remove();
         this.sprite.destroy();
     }
 }

--- a/src/classes/empty.js
+++ b/src/classes/empty.js
@@ -15,79 +15,9 @@ export class Empty extends Tile {
         return this.game.emptyGroup.remove(this.sprite);
     }
 
-    isSolidAt(worldX, worldY) {
-        const ts = this.game.tileSize;
-        const cs = this.game.chunkSize;
-        const gcx = Math.floor(worldX / ts);
-        const gcy = Math.floor(worldY / ts);
-        const chunkX = Math.floor(gcx / cs) * cs;
-        const chunkY = Math.floor(gcy / cs) * cs;
-        const chunk = this.game.grid[`${chunkX}_${chunkY}`];
-        if (!chunk) return false;
-        const lx = ((gcx % cs) + cs) % cs;
-        const ly = ((gcy % cs) + cs) % cs;
-        const tile = chunk[ly]?.[lx];
-        if (!tile) return false;
-        // "Solid" for inside-corner curve purposes — anything dirt-like that
-        // forms part of a continuous wall mass.
-        return tile.id === 1 || tile.id === 5;
-    }
-
-    getCurveMask() {
-        const ts = this.game.tileSize;
-        const top = this.isSolidAt(this.worldX, this.worldY - ts);
-        const right = this.isSolidAt(this.worldX + ts, this.worldY);
-        const bottom = this.isSolidAt(this.worldX, this.worldY + ts);
-        const left = this.isSolidAt(this.worldX - ts, this.worldY);
-        let mask = 0;
-        if (top && left && this.isSolidAt(this.worldX - ts, this.worldY - ts)) mask |= 1;
-        if (top && right && this.isSolidAt(this.worldX + ts, this.worldY - ts)) mask |= 2;
-        if (bottom && left && this.isSolidAt(this.worldX - ts, this.worldY + ts)) mask |= 4;
-        if (bottom && right && this.isSolidAt(this.worldX + ts, this.worldY + ts)) mask |= 8;
-        return mask;
-    }
-
-    redrawCurve() {
-        if (!this.curveImage) return;
-        const mask = this.getCurveMask();
-        if (mask === this.lastCurveMask) return;
-        this.lastCurveMask = mask;
-        if (mask === 0) {
-            this.curveImage.setVisible(false);
-            return;
-        }
-        const key = this.game.tileAtlas.ensureEmptyCurveTexture(mask);
-        if (this.curveImage.texture.key !== key) this.curveImage.setTexture(key);
-        this.curveImage.setVisible(true);
-    }
-
-    checkState() {
-        super.checkState();
-        this.redrawCurve();
-    }
-
     createSprite() {
         let baseSprite = this.game.add.rectangle(this.worldX, this.worldY, this.game.tileSize, this.game.tileSize, '0xffffff');
         baseSprite.setAlpha(0);
-
-        // Curve overlay — pre-rendered atlas texture per inside-corner mask.
-        // Median jitter tint (~0.94 brightness) so the curve blends with the
-        // average tinted dirt tile next to it.
-        this.curveImage = this.game.add.image(this.worldX, this.worldY, this.game.tileAtlas.emptyCurveKey(0));
-        this.curveImage.setOrigin(0.5, 0.5);
-        this.curveImage.setDepth(0);
-        this.curveImage.setVisible(false);
-        const t = Math.round(0.94 * 255);
-        this.curveImage.setTint((t << 16) | (t << 8) | t);
-        this.lastCurveMask = -1;
-
-        // First refresh — neighbours may not exist yet, so retry shortly.
-        this.redrawCurve();
-        this.curveRefreshDelay = this.game.time.delayedCall(80, () => {
-            this.lastCurveMask = -1;
-            this.redrawCurve();
-        });
-
         return baseSprite;
     }
 
@@ -105,8 +35,6 @@ export class Empty extends Tile {
 
     destroy() {
         this.removeFromGroup();
-        if (this.curveImage) this.curveImage.destroy();
-        if (this.curveRefreshDelay) this.curveRefreshDelay.remove();
         this.sprite.destroy();
     }
 }

--- a/src/classes/tile.js
+++ b/src/classes/tile.js
@@ -30,7 +30,7 @@ export class Tile {
         this.sprite.cellY = this.cellY;
         this.sprite.chunkKey = this.chunkKey;
         this.borderGraphics = this.game.add.graphics();
-        this.borderGraphics.lineStyle(0.5, 0xFFA500, 1); // 2px white border
+        this.borderGraphics.lineStyle(1, 0xfff1c4, 1);
         this.borderGraphics.strokeRect(
             this.sprite.x - this.sprite.displayWidth / 2,
             this.sprite.y - this.sprite.displayHeight / 2,
@@ -139,6 +139,10 @@ export class Tile {
     }
 
     onMouseLeave() {
+        if (this.borderPulseTween) {
+            this.borderPulseTween.stop();
+            this.borderPulseTween = null;
+        }
         this.borderGraphics.setAlpha(0);
     }
 
@@ -171,6 +175,15 @@ export class Tile {
             const adj = this.checkAdjacentBlocks(metadata);
             if (adj) {
                 this.borderGraphics.setAlpha(1);
+                if (this.borderPulseTween) this.borderPulseTween.stop();
+                this.borderPulseTween = this.game.tweens.add({
+                    targets: this.borderGraphics,
+                    alpha: 0.55,
+                    duration: 700,
+                    ease: 'Sine.easeInOut',
+                    yoyo: true,
+                    repeat: -1
+                });
             }
         }
     }

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -270,8 +270,9 @@ export default class GameScene extends Phaser.Scene {
                     const liquidChildren = this.liquidGroup.getChildren();
                     const railChildren = this.railGroup.getChildren();
                     const soilChildren = this.soilGroup.getChildren();
+                    const buttressChildren = this.buttressGroup.getChildren();
                     // Combine arrays using spread syntax (more readable and possibly more optimized)
-                    const softSoil = [...emptyChildren, ...lightChildren, ...liquidChildren, ...railChildren, ...soilChildren];
+                    const softSoil = [...emptyChildren, ...lightChildren, ...liquidChildren, ...railChildren, ...soilChildren, ...buttressChildren];
                     const total = softSoil.length;
 
                     // Process a batch of blocks using a for loop.

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -21,7 +21,7 @@ export default class GameScene extends Phaser.Scene {
     }
 
     async create() {
-        this.lightColors = ["163,255,93", "228,163,32", "163,93,255", "253,196,124", '255,255,255'];
+        this.lightColors = ["163,255,93", "255,210,140", "163,93,255", "253,196,124", '255,247,230'];
         this.renderDistance = 3;
         this.railRotate = 45;
         this.fadeSpeed = 200;
@@ -373,6 +373,7 @@ export default class GameScene extends Phaser.Scene {
                 this.mineCartGroup.getChildren().forEach(mineCart => mineCart.cartRef.update());
             }
             this.controlsManager.handlePlayerMovement();
+            this.playerManager.updateVisuals(time, delta);
             this.lightingManager.updateLighting(delta);
             this.interactableGroup = [...this.liftControlGroup.getChildren()];
             this.uiManager.updateUI();

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -374,6 +374,9 @@ export default class GameScene extends Phaser.Scene {
             }
             this.controlsManager.handlePlayerMovement();
             this.playerManager.updateVisuals(time, delta);
+            if (this.ambientMoteEmitter) {
+                this.ambientMoteEmitter.setPosition(this.player.x, this.player.y - 8);
+            }
             this.lightingManager.updateLighting(delta);
             this.interactableGroup = [...this.liftControlGroup.getChildren()];
             this.uiManager.updateUI();

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -269,8 +269,9 @@ export default class GameScene extends Phaser.Scene {
                     const lightChildren = this.lightGroup.getChildren();
                     const liquidChildren = this.liquidGroup.getChildren();
                     const railChildren = this.railGroup.getChildren();
+                    const soilChildren = this.soilGroup.getChildren();
                     // Combine arrays using spread syntax (more readable and possibly more optimized)
-                    const softSoil = [...emptyChildren, ...lightChildren, ...liquidChildren, ...railChildren];
+                    const softSoil = [...emptyChildren, ...lightChildren, ...liquidChildren, ...railChildren, ...soilChildren];
                     const total = softSoil.length;
 
                     // Process a batch of blocks using a for loop.

--- a/src/scenes/MenuScene.js
+++ b/src/scenes/MenuScene.js
@@ -8,7 +8,7 @@ export default class MenuScene extends Phaser.Scene {
     }
 
     create() {
-        this.cameras.main.setBackgroundColor(0x05070b);
+        this.cameras.main.setBackgroundColor(0x0c0805);
 
         this.layout = this.computeLayout();
 
@@ -63,9 +63,9 @@ export default class MenuScene extends Phaser.Scene {
         const steps = 24;
         for (let i = 0; i < steps; i++) {
             const t = i / (steps - 1);
-            const top = Phaser.Display.Color.ValueToColor(0x0a0d14);
-            const mid = Phaser.Display.Color.ValueToColor(0x110a14);
-            const bot = Phaser.Display.Color.ValueToColor(0x1a0a08);
+            const top = Phaser.Display.Color.ValueToColor(0x14100c);
+            const mid = Phaser.Display.Color.ValueToColor(0x1a120c);
+            const bot = Phaser.Display.Color.ValueToColor(0x241308);
             const c1 = Phaser.Display.Color.Interpolate.ColorWithColor(top, mid, 1, Math.min(1, t * 2));
             const c2 = Phaser.Display.Color.Interpolate.ColorWithColor(mid, bot, 1, Math.max(0, t * 2 - 1));
             const color = (t < 0.5 ? c1 : c2);
@@ -76,7 +76,7 @@ export default class MenuScene extends Phaser.Scene {
 
         // Faint geological strata lines
         const strata = this.add.graphics();
-        strata.lineStyle(1, 0xff7a3a, 0.05);
+        strata.lineStyle(1, 0xffb274, 0.07);
         for (let y = 60; y < h; y += Phaser.Math.Between(40, 90)) {
             strata.beginPath();
             const segs = Math.ceil(w / 40);
@@ -88,11 +88,11 @@ export default class MenuScene extends Phaser.Scene {
         }
 
         // Distant cave silhouette layer (back)
-        this.drawCaveLayer(0x0a0810, 0.55, h * 0.55, 38);
+        this.drawCaveLayer(0x140d08, 0.55, h * 0.55, 38);
         // Mid silhouette
-        this.drawCaveLayer(0x080509, 0.85, h * 0.7, 60);
+        this.drawCaveLayer(0x0e0805, 0.85, h * 0.7, 60);
         // Foreground floor
-        this.drawCaveLayer(0x000000, 1, h * 0.88, 90);
+        this.drawCaveLayer(0x080402, 1, h * 0.88, 90);
 
         // Hanging stalactites at top
         const stalGfx = this.add.graphics();

--- a/src/scenes/PreloadScene.js
+++ b/src/scenes/PreloadScene.js
@@ -38,6 +38,7 @@ export default class PreloadScene extends Phaser.Scene {
         this.load.image('glowstick', 'images/glow-stick.png');
         this.load.image('rail', 'images/rail.png');
         this.load.image('minecart', 'images/mine-cart.png');
+        this.load.image('clouds', 'images/clouds-transparent.png');
     }
     // flat
     // diagonal_left

--- a/src/services/colourManager.js
+++ b/src/services/colourManager.js
@@ -37,4 +37,17 @@ function getColorForPercentage(percentage) {
     return Phaser.Display.Color.GetColor(interpolated.r, interpolated.g, interpolated.b);
 }
 
-export {darkenColor, getColorForPercentage};
+const lightenColor = function(hexColor, factor) {
+    hexColor = hexColor & 0xFFFFFF;
+    let r = (hexColor >> 16) & 0xFF;
+    let g = (hexColor >> 8) & 0xFF;
+    let b = hexColor & 0xFF;
+    let lightenFactor = Math.min(Math.max(factor / 100, 0), 1);
+    r = Math.round(r + (255 - r) * lightenFactor);
+    g = Math.round(g + (255 - g) * lightenFactor);
+    b = Math.round(b + (255 - b) * lightenFactor);
+    let lightenedHex = (r << 16) | (g << 8) | b;
+    return `0x${lightenedHex.toString(16).padStart(6, '0')}`;
+}
+
+export {darkenColor, lightenColor, getColorForPercentage};

--- a/src/services/controls.js
+++ b/src/services/controls.js
@@ -119,6 +119,24 @@ export default class ControlsManager {
 
     }
 
+    emitFootstepPuff() {
+        const player = this.game.player;
+        const emitter = this.game.footstepEmitter;
+        if (!emitter || !player?.body) return;
+
+        const grounded = player.body.blocked.down;
+        const moving = Math.abs(player.body.velocity.x) > 5;
+        if (!grounded || !moving || this.game.isFloating) return;
+
+        const now = this.game.time.now;
+        if (!this.lastFootstep) this.lastFootstep = 0;
+        if (now - this.lastFootstep < 280) return;
+        this.lastFootstep = now;
+
+        emitter.setPosition(player.x, player.body.y + 8.4);
+        emitter.explode(2);
+    }
+
     playerLooking() {
         const pointer = this.game.input.activePointer;
         if (!this.game.cameras.main) return;
@@ -147,6 +165,7 @@ export default class ControlsManager {
 
     handlePlayerMovement() {
         if (!this.game.player || !this.game.player.body) return;
+        this.emitFootstepPuff();
         this.game.isFloating = false;
         this.game.playerHead.x = this.game.player.body.x + 3;
         this.game.playerHead.y = this.game.player.body.y + 2.5;

--- a/src/services/lighting.js
+++ b/src/services/lighting.js
@@ -19,6 +19,34 @@ export default class LightingManager {
     initSky() {
         this.game.skyBox = this.game.add.rectangle(0, 0, 9999, 410, 0xf9e4c8);
         this.game.skyBox.setDepth(-999);
+        this.spawnClouds();
+    }
+
+    spawnClouds() {
+        if (!this.game.textures.exists('clouds')) return;
+        // Slow drifting clouds across the sky band. Spread out so they drift
+        // independently in front of the warm sky.
+        const skyTop = -80;
+        const skyBottom = (this.game.aboveGround * this.game.tileSize) - 40;
+        const range = 4000;
+        for (let i = 0; i < 6; i++) {
+            const x = Phaser.Math.Between(-range / 2, range / 2);
+            const y = Phaser.Math.Between(skyTop, skyBottom);
+            const cloud = this.game.add.image(x, y, 'clouds');
+            const scale = Phaser.Math.FloatBetween(0.18, 0.32);
+            cloud.setScale(scale);
+            cloud.setAlpha(Phaser.Math.FloatBetween(0.45, 0.75));
+            cloud.setDepth(-998);
+            const speed = Phaser.Math.FloatBetween(60000, 120000);
+            this.game.tweens.add({
+                targets: cloud,
+                x: x + range,
+                duration: speed,
+                ease: 'Linear',
+                repeat: -1,
+                onRepeat: () => { cloud.x = x; }
+            });
+        }
     }
 
     initLighting() {

--- a/src/services/lighting.js
+++ b/src/services/lighting.js
@@ -17,8 +17,7 @@ export default class LightingManager {
     }
 
     initSky() {
-        let skyCol = '#a6f5ff';
-        this.game.skyBox = this.game.add.rectangle(0, 0, 9999, 410, '0xa6f5ff');
+        this.game.skyBox = this.game.add.rectangle(0, 0, 9999, 410, 0xf9e4c8);
         this.game.skyBox.setDepth(-999);
     }
 
@@ -227,16 +226,16 @@ export default class LightingManager {
         if (this.game.skyBox) {
             // Helper linear interpolation function.
             function lerp(a, b, t) { return a + (b - a) * t; }
-            // Define the day tint based on your rectangle's initial color (0xa6f5ff).
-            // 0xa6f5ff in RGB is: r=166, g=245, b=255.
-            const dayTint = { r: 166, g: 245, b: 255 };
-            // Define a cosy warm night tint.
-            const nightTint = { r: 255, g: 209, b: 164 };
+            // Warm cream daytime sky (0xf9e4c8 = 249,228,200).
+            const dayTint = { r: 249, g: 228, b: 200 };
+            // Soft dusty-rose dusk for night.
+            const nightTint = { r: 232, g: 158, b: 130 };
 
-            // Interpolate between the night and day tints based on dayFactor.
-            const tintR = Math.round(lerp(nightTint.r, dayTint.r, dayFactor));
-            const tintG = Math.round(lerp(nightTint.g, dayTint.g, dayFactor));
-            const tintB = Math.round(lerp(nightTint.b, dayTint.b, dayFactor));
+            // Smoothstep the interpolation so dawn/dusk feels gentler than a linear lerp.
+            const t = dayFactor * dayFactor * (3 - 2 * dayFactor);
+            const tintR = Math.round(lerp(nightTint.r, dayTint.r, t));
+            const tintG = Math.round(lerp(nightTint.g, dayTint.g, t));
+            const tintB = Math.round(lerp(nightTint.b, dayTint.b, t));
             const tintColor = (tintR << 16) | (tintG << 8) | tintB;
 
             // For Phaser rectangles, use setFillStyle instead of setTint.
@@ -266,17 +265,27 @@ export default class LightingManager {
 
         const cachedCanvas = this.cachedCanvases[light.color] || this.cachedCanvases['255,255,255'];
 
+        // Soft outer bloom: gently lifts the dark in a wider area than the core light.
+        // This makes lamps feel like they breathe warmth into the cave instead of
+        // appearing as hard-edged cutouts.
+        const bloomRadius = radius * 1.9;
         ctx.globalCompositeOperation = "destination-out";
-        ctx.globalAlpha = light.intensity;
+        ctx.globalAlpha = light.intensity * 0.28;
+        ctx.drawImage(
+            cachedCanvas,
+            0, 0, cachedCanvas.width, cachedCanvas.height,
+            screenX - bloomRadius, screenY - bloomRadius, bloomRadius * 2, bloomRadius * 2
+        );
 
+        // Core light cutout.
+        ctx.globalAlpha = light.intensity;
         ctx.drawImage(
             cachedCanvas,
             0, 0, cachedCanvas.width, cachedCanvas.height,
             screenX - radius, screenY - radius, radius * 2, radius * 2
         );
 
-
-
+        // Warm color tint over the whole lit area.
         ctx.globalCompositeOperation = "normal";
         ctx.globalAlpha = light.neon ? 0.6 : 0.1;
 
@@ -286,7 +295,17 @@ export default class LightingManager {
             screenX - radius, screenY - radius, radius * 2, radius * 2
         );
 
+        // Wider, very soft warm halo for additional cosiness.
+        ctx.globalCompositeOperation = "lighter";
+        ctx.globalAlpha = light.neon ? 0.18 : 0.05;
+        ctx.drawImage(
+            cachedCanvas,
+            0, 0, cachedCanvas.width, cachedCanvas.height,
+            screenX - bloomRadius, screenY - bloomRadius, bloomRadius * 2, bloomRadius * 2
+        );
+
         ctx.globalAlpha = 1;
+        ctx.globalCompositeOperation = "normal";
     }
 
     getRays(worldX, worldY, radius) {

--- a/src/services/lighting.js
+++ b/src/services/lighting.js
@@ -263,7 +263,10 @@ export default class LightingManager {
 
         const ctx = this.game.lightCtx;
 
-        const cachedCanvas = this.cachedCanvases[light.color] || this.cachedCanvases['255,255,255'];
+        let cachedCanvas = this.cachedCanvases[light.color];
+        if (!cachedCanvas) {
+            cachedCanvas = this.createCachedLightTexture(light.color, 256, 10);
+        }
 
         // Soft outer bloom: gently lifts the dark in a wider area than the core light.
         // This makes lamps feel like they breathe warmth into the cave instead of

--- a/src/services/map.js
+++ b/src/services/map.js
@@ -21,6 +21,20 @@ export default class MapService {
             blendMode: 'NORMAL'
         });
         this.game.dustEmitter.setDepth(9999);
+
+        // Cosier footstep puff — slower, smaller, drifts up gently like kicked-up dust.
+        this.game.footstepEmitter = this.game.add.particles(0, 0, 'dust', {
+            lifespan: {min: 350, max: 650},
+            speed: {min: 4, max: 14},
+            angle: {min: 230, max: 310},
+            scale: {start: 0.06, end: 0.12},
+            alpha: {start: 0.35, end: 0},
+            gravityY: -10,
+            quantity: 1,
+            emitting: false,
+            blendMode: 'NORMAL'
+        });
+        this.game.footstepEmitter.setDepth(2);
         this.layerCount = 7;
         this.layerHeight = Math.floor(this.game.mapHeight / this.layerCount);
         this.emptyPool = new TilePool((params) => new Empty(params));

--- a/src/services/map.js
+++ b/src/services/map.js
@@ -524,7 +524,6 @@ export default class MapService {
         // Prevent duplicate rendering of chunks
         if (!this.game.grid[chunkKey] || this.game.loadedChunks.has(chunkKey)) return;
 
-        const newTilePositions = [];
         for (let y = 0; y < this.game.chunkSize; y++) {
             for (let x = 0; x < this.game.chunkSize; x++) {
                 let worldX = (cx + x) * this.game.tileSize;
@@ -532,18 +531,12 @@ export default class MapService {
                 let tileType = this.game.grid[chunkKey][y][x];
 
                 this.placeObject(tileType, worldX, worldY, {chunkKey: chunkKey, cellX: x, cellY: y});
-                newTilePositions.push({worldX, worldY});
             }
         }
-
-        // Once the new chunk is in place, ask each new tile's neighbours to
-        // re-evaluate their edges. Tiles at the chunk boundary in adjacent
-        // already-loaded chunks were drawn assuming this region was empty.
-        this.game.time.delayedCall(100, () => {
-            newTilePositions.forEach(({worldX, worldY}) => {
-                this.refreshNeighborEdges(worldX, worldY);
-            });
-        });
+        // Each new tile already self-evaluates its edges shortly after
+        // creation via its own delayed callback. We deliberately skip a
+        // bulk neighbour refresh here — it caused a frame hitch on chunk
+        // load, and any far-side artefact is outside the lit view radius.
     }
 
     unloadChunk(chunkKey) {

--- a/src/services/map.js
+++ b/src/services/map.js
@@ -470,9 +470,14 @@ export default class MapService {
     }
 
     refreshNeighborEdges(worldX, worldY) {
-        const adj = this.getAdjacentBlocks(worldX, worldY);
-        Object.values(adj).forEach(block => {
-            const ref = block?.tileRef;
+        // Refresh all 8 surrounding tiles so inner-corner diagonals update too.
+        const ts = this.game.tileSize;
+        if (!this.game.soilGroup?.children) return;
+        this.game.soilGroup.children.each(entity => {
+            const dx = entity.x - worldX;
+            const dy = entity.y - worldY;
+            if ((dx === 0 && dy === 0) || Math.abs(dx) > ts || Math.abs(dy) > ts) return;
+            const ref = entity.tileRef;
             if (ref?.redrawTile) {
                 ref.lastEdgeMask = -1;
                 ref.redrawTile();

--- a/src/services/map.js
+++ b/src/services/map.js
@@ -35,6 +35,25 @@ export default class MapService {
             blendMode: 'NORMAL'
         });
         this.game.footstepEmitter.setDepth(2);
+
+        // Ambient dust motes — slow drifty motes near the player to give the
+        // air some life. Additive so they catch warm light. Position is
+        // updated each frame so they always emit around the player.
+        this.game.ambientMoteEmitter = this.game.add.particles(0, 0, 'dust', {
+            lifespan: {min: 4000, max: 8000},
+            speedX: {min: -6, max: 6},
+            speedY: {min: -8, max: -2},
+            scale: {start: 0.04, end: 0.08},
+            alpha: {start: 0.3, end: 0},
+            frequency: 600,
+            quantity: 1,
+            blendMode: 'ADD',
+            emitZone: {
+                type: 'random',
+                source: new Phaser.Geom.Rectangle(-60, -40, 120, 80)
+            }
+        });
+        this.game.ambientMoteEmitter.setDepth(2.5);
         this.layerCount = 7;
         this.layerHeight = Math.floor(this.game.mapHeight / this.layerCount);
         this.emptyPool = new TilePool((params) => new Empty(params));

--- a/src/services/map.js
+++ b/src/services/map.js
@@ -470,19 +470,28 @@ export default class MapService {
     }
 
     refreshNeighborEdges(worldX, worldY) {
-        // Refresh all 8 surrounding tiles so inner-corner diagonals update too.
+        // Refresh all 8 surrounding solid tiles so silhouette edges and
+        // inner-corner curves update on dig/place.
         const ts = this.game.tileSize;
-        if (!this.game.soilGroup?.children) return;
-        this.game.soilGroup.children.each(entity => {
-            const dx = entity.x - worldX;
-            const dy = entity.y - worldY;
-            if ((dx === 0 && dy === 0) || Math.abs(dx) > ts || Math.abs(dy) > ts) return;
-            const ref = entity.tileRef;
-            if (ref?.redrawTile) {
-                ref.lastEdgeMask = -1;
-                ref.redrawTile();
-            }
-        });
+        const groups = [this.game.soilGroup, this.game.buttressGroup];
+        for (const group of groups) {
+            if (!group?.children) continue;
+            group.children.each(entity => {
+                const dx = entity.x - worldX;
+                const dy = entity.y - worldY;
+                if ((dx === 0 && dy === 0) || Math.abs(dx) > ts || Math.abs(dy) > ts) return;
+                const ref = entity.tileRef;
+                if (!ref) return;
+                if (ref.redrawTile) {
+                    ref.lastEdgeMask = -1;
+                    ref.redrawTile();
+                }
+                if (ref.refreshCurveOverlay) {
+                    ref.lastCurveMask = -1;
+                    ref.refreshCurveOverlay();
+                }
+            });
+        }
     }
 
     getTileAt(chunkKey, cellY, cellX) {

--- a/src/services/map.js
+++ b/src/services/map.js
@@ -1,6 +1,7 @@
 import * as ROT from "rot-js";
 import {Breakable, Light, Empty, Liquid, Buttress, Rail, LiftControl} from "../classes/tiles";
 import TilePool from "../classes/TilePool";
+import TileTextureAtlas from "./tileTextureAtlas";
 
 export default class MapService {
     constructor(tileSize = 32, chunkSize = 16, game) {
@@ -11,6 +12,7 @@ export default class MapService {
         this.game.loadedChunks = new Map();
         this.game.grid = this.game.grid || {};
         this.game.openSpaces = [];
+        this.game.tileAtlas = new TileTextureAtlas(this.game);
         this.game.dustEmitter = this.game.add.particles(0, 0, 'dust', {
             lifespan: {min: 200, max: 500},
             speed: {min: 20, max: 50},

--- a/src/services/map.js
+++ b/src/services/map.js
@@ -461,8 +461,21 @@ export default class MapService {
         this.game.grid[chunkKey][cellY][cellX] = {...tileType};
         if (cellItem?.tileRef) cellItem.tileRef.destroy(prefs);
         if (this.game.loadedChunks.has(chunkKey)) {
-            return this.placeObject(tileType, worldX, worldY, {chunkKey, cellY, cellX}, prefs);
+            const result = this.placeObject(tileType, worldX, worldY, {chunkKey, cellY, cellX}, prefs);
+            this.refreshNeighborEdges(worldX, worldY);
+            return result;
         }
+    }
+
+    refreshNeighborEdges(worldX, worldY) {
+        const adj = this.getAdjacentBlocks(worldX, worldY);
+        Object.values(adj).forEach(block => {
+            const ref = block?.tileRef;
+            if (ref?.redrawTile) {
+                ref.lastEdgeMask = -1;
+                ref.redrawTile();
+            }
+        });
     }
 
     getTileAt(chunkKey, cellY, cellX) {
@@ -511,6 +524,7 @@ export default class MapService {
         // Prevent duplicate rendering of chunks
         if (!this.game.grid[chunkKey] || this.game.loadedChunks.has(chunkKey)) return;
 
+        const newTilePositions = [];
         for (let y = 0; y < this.game.chunkSize; y++) {
             for (let x = 0; x < this.game.chunkSize; x++) {
                 let worldX = (cx + x) * this.game.tileSize;
@@ -518,8 +532,18 @@ export default class MapService {
                 let tileType = this.game.grid[chunkKey][y][x];
 
                 this.placeObject(tileType, worldX, worldY, {chunkKey: chunkKey, cellX: x, cellY: y});
+                newTilePositions.push({worldX, worldY});
             }
         }
+
+        // Once the new chunk is in place, ask each new tile's neighbours to
+        // re-evaluate their edges. Tiles at the chunk boundary in adjacent
+        // already-loaded chunks were drawn assuming this region was empty.
+        this.game.time.delayedCall(100, () => {
+            newTilePositions.forEach(({worldX, worldY}) => {
+                this.refreshNeighborEdges(worldX, worldY);
+            });
+        });
     }
 
     unloadChunk(chunkKey) {

--- a/src/services/playerManager.js
+++ b/src/services/playerManager.js
@@ -37,6 +37,13 @@ export default class PlayerManager {
         this.headBaseY = 0;
         this.bobPhase = 0;
         this.wasGrounded = true;
+        // Capture the scale that setDisplaySize produced — tweens must work
+        // relative to this, not absolute 1.0 which would blow the sprite up
+        // to its raw texture size.
+        this.playerBaseScaleX = this.game.player.scaleX;
+        this.playerBaseScaleY = this.game.player.scaleY;
+        this.headBaseScaleX = this.game.playerHead.scaleX;
+        this.headBaseScaleY = this.game.playerHead.scaleY;
 
         this.game.player.maxHealth = 100;
         this.game.player.maxEnergy = 100;
@@ -189,23 +196,32 @@ export default class PlayerManager {
         // and arriving with a noticeable downward velocity.
         if (grounded && !this.wasGrounded && this.lastAirVy > 60) {
             const intensity = Math.min(1, this.lastAirVy / 220);
-            this.game.tweens.killTweensOf([player, this.game.playerHead]);
+            const head = this.game.playerHead;
+            this.game.tweens.killTweensOf([player, head]);
+            const stretch = 1 + 0.18 * intensity;
+            const squash = 1 - 0.22 * intensity;
             this.game.tweens.add({
-                targets: [player, this.game.playerHead],
-                scaleX: 1 + 0.18 * intensity,
-                scaleY: 1 - 0.22 * intensity,
+                targets: player,
+                scaleX: this.playerBaseScaleX * stretch,
+                scaleY: this.playerBaseScaleY * squash,
                 duration: 90,
                 ease: 'Quad.easeOut',
                 yoyo: true,
-                onYoyo: (tween, target) => {
-                    target.scaleX = 1;
-                    target.scaleY = 1;
-                },
                 onComplete: () => {
-                    player.scaleX = 1;
-                    player.scaleY = 1;
-                    this.game.playerHead.scaleX = 1;
-                    this.game.playerHead.scaleY = 1;
+                    player.scaleX = this.playerBaseScaleX;
+                    player.scaleY = this.playerBaseScaleY;
+                }
+            });
+            this.game.tweens.add({
+                targets: head,
+                scaleX: this.headBaseScaleX * stretch,
+                scaleY: this.headBaseScaleY * squash,
+                duration: 90,
+                ease: 'Quad.easeOut',
+                yoyo: true,
+                onComplete: () => {
+                    head.scaleX = this.headBaseScaleX;
+                    head.scaleY = this.headBaseScaleY;
                 }
             });
         }

--- a/src/services/playerManager.js
+++ b/src/services/playerManager.js
@@ -246,17 +246,22 @@ export default class PlayerManager {
             this.bobPhase = 0;
         }
 
-        // Soft drop shadow — sits at the player's feet, fades and shrinks
-        // when airborne to sell weight.
+        // Soft drop shadow — anchored to the last ground position so it
+        // stays on the floor while the player jumps, then shrinks and
+        // fades as they rise.
         if (this.game.playerShadow) {
             const shadow = this.game.playerShadow;
+            if (grounded) {
+                this.lastGroundY = player.body.bottom;
+            }
+            const groundY = this.lastGroundY ?? player.body.bottom;
             shadow.x = player.x;
-            shadow.y = player.body.y + 8.2;
-            const airHeight = grounded ? 0 : Math.min(40, Math.abs(vy) * 0.15);
-            const t = 1 - Math.min(1, airHeight / 30);
-            shadow.scaleX = 0.6 + 0.4 * t;
-            shadow.scaleY = 0.6 + 0.4 * t;
-            shadow.alpha = 0.12 + 0.23 * t;
+            shadow.y = groundY + 0.2;
+            const airHeight = Math.max(0, groundY - player.body.bottom);
+            const t = 1 - Math.min(1, airHeight / 24);
+            shadow.scaleX = 0.55 + 0.45 * t;
+            shadow.scaleY = 0.55 + 0.45 * t;
+            shadow.alpha = 0.08 + 0.27 * t;
         }
     }
 

--- a/src/services/playerManager.js
+++ b/src/services/playerManager.js
@@ -25,6 +25,8 @@ export default class PlayerManager {
             repeat: -1
         });
 
+        this.game.playerShadow = this.game.add.ellipse(x, y + 4, 7, 2.2, 0x000000, 0.35);
+        this.game.playerShadow.setDepth(0.5);
         this.game.player = this.game.physics.add.sprite(x, y, 'player_stationary');
         this.game.playerHead = this.game.add.sprite(x, y, 'player_head');
         this.game.player.setDisplaySize(6, 8);
@@ -32,6 +34,9 @@ export default class PlayerManager {
         this.game.playerHead.setDepth(1);
         this.game.player.setDepth(2);
         this.game.player.setBounce(0.2);
+        this.headBaseY = 0;
+        this.bobPhase = 0;
+        this.wasGrounded = true;
 
         this.game.player.maxHealth = 100;
         this.game.player.maxEnergy = 100;
@@ -169,6 +174,71 @@ export default class PlayerManager {
                 this.dialogueLayer.parentNode.removeChild(this.dialogueLayer);
             }
         }, {once: true}); // Use { once: true } so the listener is removed automatically.
+    }
+
+    updateVisuals(time, delta) {
+        const player = this.game.player;
+        if (!player || !player.body) return;
+
+        const grounded = player.body.blocked.down;
+        const vy = player.body.velocity.y;
+        const vx = player.body.velocity.x;
+        const moving = Math.abs(vx) > 1;
+
+        // Squash on landing — only when transitioning from airborne to grounded
+        // and arriving with a noticeable downward velocity.
+        if (grounded && !this.wasGrounded && this.lastAirVy > 60) {
+            const intensity = Math.min(1, this.lastAirVy / 220);
+            this.game.tweens.killTweensOf([player, this.game.playerHead]);
+            this.game.tweens.add({
+                targets: [player, this.game.playerHead],
+                scaleX: 1 + 0.18 * intensity,
+                scaleY: 1 - 0.22 * intensity,
+                duration: 90,
+                ease: 'Quad.easeOut',
+                yoyo: true,
+                onYoyo: (tween, target) => {
+                    target.scaleX = 1;
+                    target.scaleY = 1;
+                },
+                onComplete: () => {
+                    player.scaleX = 1;
+                    player.scaleY = 1;
+                    this.game.playerHead.scaleX = 1;
+                    this.game.playerHead.scaleY = 1;
+                }
+            });
+        }
+
+        // Track peak downward velocity while airborne for landing intensity.
+        if (!grounded) {
+            this.lastAirVy = Math.max(this.lastAirVy || 0, vy);
+        } else {
+            this.lastAirVy = 0;
+        }
+        this.wasGrounded = grounded;
+
+        // Idle head bob — gentle 1px sine when stationary on the ground.
+        if (grounded && !moving) {
+            this.bobPhase += (delta || 16) * 0.0042;
+            const bob = Math.sin(this.bobPhase) * 0.5;
+            this.game.playerHead.y = player.body.y + 2.5 + bob;
+        } else {
+            this.bobPhase = 0;
+        }
+
+        // Soft drop shadow — sits at the player's feet, fades and shrinks
+        // when airborne to sell weight.
+        if (this.game.playerShadow) {
+            const shadow = this.game.playerShadow;
+            shadow.x = player.x;
+            shadow.y = player.body.y + 8.2;
+            const airHeight = grounded ? 0 : Math.min(40, Math.abs(vy) * 0.15);
+            const t = 1 - Math.min(1, airHeight / 30);
+            shadow.scaleX = 0.6 + 0.4 * t;
+            shadow.scaleY = 0.6 + 0.4 * t;
+            shadow.alpha = 0.12 + 0.23 * t;
+        }
     }
 
     teleportTo(x, y) {

--- a/src/services/playerManager.js
+++ b/src/services/playerManager.js
@@ -197,10 +197,13 @@ export default class PlayerManager {
         if (grounded && !this.wasGrounded && this.lastAirVy > 60) {
             const intensity = Math.min(1, this.lastAirVy / 220);
             const head = this.game.playerHead;
-            this.game.tweens.killTweensOf([player, head]);
+            // Stop only our own scale tweens — using killTweensOf on the
+            // sprite would also kill the spawn-in alpha fade from teleportTo.
+            if (this.squashTween) this.squashTween.stop();
+            if (this.headSquashTween) this.headSquashTween.stop();
             const stretch = 1 + 0.18 * intensity;
             const squash = 1 - 0.22 * intensity;
-            this.game.tweens.add({
+            this.squashTween = this.game.tweens.add({
                 targets: player,
                 scaleX: this.playerBaseScaleX * stretch,
                 scaleY: this.playerBaseScaleY * squash,
@@ -212,7 +215,7 @@ export default class PlayerManager {
                     player.scaleY = this.playerBaseScaleY;
                 }
             });
-            this.game.tweens.add({
+            this.headSquashTween = this.game.tweens.add({
                 targets: head,
                 scaleX: this.headBaseScaleX * stretch,
                 scaleY: this.headBaseScaleY * squash,

--- a/src/services/tileTextureAtlas.js
+++ b/src/services/tileTextureAtlas.js
@@ -64,6 +64,9 @@ export default class TileTextureAtlas {
     }
 
     generate() {
+        // Pre-generate the simple 4-bit (no-inner-corner) cases. Inner-corner
+        // variants (mask bits 16/32/64/128) are generated lazily on first use
+        // since most aren't needed in any given playthrough.
         for (let mask = 0; mask < 16; mask++) {
             for (let variant = 0; variant < this.variantCount; variant++) {
                 this.makeDirtTexture(mask, variant);
@@ -78,6 +81,15 @@ export default class TileTextureAtlas {
         return `tile_${kind}_${mask}_${variant}`;
     }
 
+    ensureTexture(kind, mask, variant) {
+        const key = this.keyFor(kind, mask, variant);
+        if (!this.game.textures.exists(key)) {
+            if (kind === 'grass') this.makeGrassTexture(mask, variant);
+            else this.makeDirtTexture(mask, variant);
+        }
+        return key;
+    }
+
     // Build a per-pixel filled mask for the body, applying corner cuts
     // where two adjacent sides face air, plus optional edge erosion for
     // variant-level silhouette variation.
@@ -86,6 +98,10 @@ export default class TileTextureAtlas {
         const right = !!(mask & 2);
         const bottom = !!(mask & 4);
         const left = !!(mask & 8);
+        const innerTL = !!(mask & 16);
+        const innerTR = !!(mask & 32);
+        const innerBL = !!(mask & 64);
+        const innerBR = !!(mask & 128);
         const ts = this.tileSize;
 
         const filled = [];
@@ -103,12 +119,20 @@ export default class TileTextureAtlas {
             }
         };
 
-        // 1-2 deep L-shape cuts at each exposed corner
+        // 1-2 deep L-shape cuts at each exposed (outside) corner
         const cornerDepth = () => 1 + (rng() > 0.5 ? 1 : 0);
         if (top && left)     cutCorner(0, 0, 1, 1, cornerDepth());
         if (top && right)    cutCorner(ts - 1, 0, -1, 1, cornerDepth());
         if (bottom && left)  cutCorner(0, ts - 1, 1, -1, cornerDepth());
         if (bottom && right) cutCorner(ts - 1, ts - 1, -1, -1, cornerDepth());
+
+        // Single-pixel chip at each INSIDE corner — where this tile's corner
+        // pokes into a concave cave corner. The dark outline picked up by
+        // the silhouette pass naturally rounds the cave's inside corner.
+        if (innerTL) filled[0][0] = false;
+        if (innerTR) filled[0][ts - 1] = false;
+        if (innerBL) filled[ts - 1][0] = false;
+        if (innerBR) filled[ts - 1][ts - 1] = false;
 
         // Tiny edge erosion — 0-1 chips per exposed side, away from corners
         const erodeEdge = (axis, isOpen) => {

--- a/src/services/tileTextureAtlas.js
+++ b/src/services/tileTextureAtlas.js
@@ -98,10 +98,6 @@ export default class TileTextureAtlas {
         const right = !!(mask & 2);
         const bottom = !!(mask & 4);
         const left = !!(mask & 8);
-        const innerTL = !!(mask & 16);
-        const innerTR = !!(mask & 32);
-        const innerBL = !!(mask & 64);
-        const innerBR = !!(mask & 128);
         const ts = this.tileSize;
 
         const filled = [];
@@ -125,14 +121,6 @@ export default class TileTextureAtlas {
         if (top && right)    cutCorner(ts - 1, 0, -1, 1, cornerDepth());
         if (bottom && left)  cutCorner(0, ts - 1, 1, -1, cornerDepth());
         if (bottom && right) cutCorner(ts - 1, ts - 1, -1, -1, cornerDepth());
-
-        // Single-pixel chip at each INSIDE corner — where this tile's corner
-        // pokes into a concave cave corner. The dark outline picked up by
-        // the silhouette pass naturally rounds the cave's inside corner.
-        if (innerTL) filled[0][0] = false;
-        if (innerTR) filled[0][ts - 1] = false;
-        if (innerBL) filled[ts - 1][0] = false;
-        if (innerBR) filled[ts - 1][ts - 1] = false;
 
         // Tiny edge erosion — 0-1 chips per exposed side, away from corners
         const erodeEdge = (axis, isOpen) => {
@@ -312,6 +300,60 @@ export default class TileTextureAtlas {
         ctx.clearRect(0, 0, this.tileSize, this.textureHeight);
         const filled = this.drawBody(ctx, mask, variant, this.dirtBaseColor);
         this.drawGrass(ctx, mask, variant, filled);
+        tex.refresh();
+    }
+
+    // ----- Inside-corner curves rendered into empty tiles -----
+    // When an empty tile sits in an inside cave corner (e.g. top + left
+    // neighbours and the top-left diagonal are all solid), it draws a
+    // 3-pixel L of dirt-coloured pixels in that corner so the cave's
+    // concave corner reads as rounded rather than 90°.
+
+    emptyCurveKey(mask) {
+        return `tile_emptycurve_${mask}`;
+    }
+
+    ensureEmptyCurveTexture(mask) {
+        const key = this.emptyCurveKey(mask);
+        if (this.game.textures.exists(key)) return key;
+        this.makeEmptyCurveTexture(mask, key);
+        return key;
+    }
+
+    makeEmptyCurveTexture(mask, key) {
+        const ts = this.tileSize;
+        const tex = this.game.textures.createCanvas(key, ts, ts);
+        const ctx = tex.context;
+        ctx.imageSmoothingEnabled = false;
+        ctx.clearRect(0, 0, ts, ts);
+
+        const mid = toCss(this.dirtBaseColor);
+        const outline = toCss(darken(this.dirtBaseColor, 55));
+
+        // Each set bit = a corner that needs a curve. The corner pixel is
+        // mid dirt; the two adjacent pixels along the cave wall are the
+        // dark silhouette outline so the curve blends into the dirt mass.
+        if (mask & 1) {           // top-left corner of the empty tile
+            ctx.fillStyle = mid;     ctx.fillRect(0, 0, 1, 1);
+            ctx.fillStyle = outline; ctx.fillRect(1, 0, 1, 1);
+            ctx.fillStyle = outline; ctx.fillRect(0, 1, 1, 1);
+        }
+        if (mask & 2) {           // top-right
+            ctx.fillStyle = mid;     ctx.fillRect(ts - 1, 0, 1, 1);
+            ctx.fillStyle = outline; ctx.fillRect(ts - 2, 0, 1, 1);
+            ctx.fillStyle = outline; ctx.fillRect(ts - 1, 1, 1, 1);
+        }
+        if (mask & 4) {           // bottom-left
+            ctx.fillStyle = mid;     ctx.fillRect(0, ts - 1, 1, 1);
+            ctx.fillStyle = outline; ctx.fillRect(1, ts - 1, 1, 1);
+            ctx.fillStyle = outline; ctx.fillRect(0, ts - 2, 1, 1);
+        }
+        if (mask & 8) {           // bottom-right
+            ctx.fillStyle = mid;     ctx.fillRect(ts - 1, ts - 1, 1, 1);
+            ctx.fillStyle = outline; ctx.fillRect(ts - 2, ts - 1, 1, 1);
+            ctx.fillStyle = outline; ctx.fillRect(ts - 1, ts - 2, 1, 1);
+        }
+
         tex.refresh();
     }
 }

--- a/src/services/tileTextureAtlas.js
+++ b/src/services/tileTextureAtlas.js
@@ -1,0 +1,207 @@
+// Pre-renders dirt and grass tile variants as Phaser canvas textures.
+// Each combination of (edge mask × variant) is rendered once at scene start
+// so individual tiles can use cheap Image sprites instead of redrawing
+// procedural Graphics every time their state changes.
+//
+// Texture layout:
+//   width  = tileSize (e.g. 10)
+//   height = tileSize + grassOverhang (e.g. 14)
+//
+// The bottom tileSize rows are the tile body (collision-aligned).
+// The top grassOverhang rows are reserved for grass blades that protrude
+// above the tile. They're transparent on dirt textures.
+
+const VARIANT_COUNT = 3;
+
+// Deterministic pseudo-random for stable variant generation across runs.
+function makeRng(seed) {
+    let s = seed | 0;
+    return () => {
+        s = (s * 1664525 + 1013904223) | 0;
+        return ((s >>> 0) % 100000) / 100000;
+    };
+}
+
+function toCss(hexInt) {
+    return '#' + ((hexInt & 0xffffff).toString(16).padStart(6, '0'));
+}
+
+function darken(hexInt, factor) {
+    const f = Math.min(Math.max(factor / 100, 0), 1);
+    let r = (hexInt >> 16) & 0xff;
+    let g = (hexInt >> 8) & 0xff;
+    let b = hexInt & 0xff;
+    r = Math.round(r * (1 - f));
+    g = Math.round(g * (1 - f));
+    b = Math.round(b * (1 - f));
+    return (r << 16) | (g << 8) | b;
+}
+
+function lighten(hexInt, factor) {
+    const f = Math.min(Math.max(factor / 100, 0), 1);
+    let r = (hexInt >> 16) & 0xff;
+    let g = (hexInt >> 8) & 0xff;
+    let b = hexInt & 0xff;
+    r = Math.round(r + (255 - r) * f);
+    g = Math.round(g + (255 - g) * f);
+    b = Math.round(b + (255 - b) * f);
+    return (r << 16) | (g << 8) | b;
+}
+
+export default class TileTextureAtlas {
+    constructor(game) {
+        this.game = game;
+        this.tileSize = game.tileSize;
+        this.grassOverhang = 4;
+        this.textureHeight = this.tileSize + this.grassOverhang;
+        this.variantCount = VARIANT_COUNT;
+
+        this.dirtBaseColor = 0x6e4525;
+        this.grassA = 0x6e9c47;
+        this.grassB = 0x88b85c;
+        this.grassDark = 0x4f7330;
+
+        this.generate();
+    }
+
+    generate() {
+        for (let mask = 0; mask < 16; mask++) {
+            for (let variant = 0; variant < this.variantCount; variant++) {
+                this.makeDirtTexture(mask, variant);
+                if (mask & 1) {
+                    this.makeGrassTexture(mask, variant);
+                }
+            }
+        }
+    }
+
+    keyFor(kind, mask, variant) {
+        return `tile_${kind}_${mask}_${variant}`;
+    }
+
+    drawBody(ctx, mask, variant, baseColor) {
+        const top = !!(mask & 1);
+        const right = !!(mask & 2);
+        const bottom = !!(mask & 4);
+        const left = !!(mask & 8);
+
+        const ts = this.tileSize;
+        const yOff = this.grassOverhang;
+        const rng = makeRng(mask * 17 + variant * 257 + 1);
+
+        const lightHex = lighten(baseColor, 22);
+        const dark1 = darken(baseColor, 22);
+        const dark2 = darken(baseColor, 40);
+
+        // Body fill
+        ctx.fillStyle = toCss(baseColor);
+        ctx.fillRect(0, yOff, ts, ts);
+
+        // Top edge — lighter row plus weathering pixels
+        if (top) {
+            ctx.fillStyle = toCss(lightHex);
+            ctx.fillRect(0, yOff, ts, 1);
+            const wear = 2 + Math.floor(rng() * 3);
+            ctx.fillStyle = toCss(dark1);
+            for (let i = 0; i < wear; i++) {
+                const px = Math.floor(rng() * ts);
+                ctx.fillRect(px, yOff, 1, 1);
+            }
+        }
+        // Bottom edge — darker row
+        if (bottom) {
+            ctx.globalAlpha = 0.85;
+            ctx.fillStyle = toCss(dark2);
+            ctx.fillRect(0, yOff + ts - 1, ts, 1);
+            ctx.globalAlpha = 1;
+        }
+        // Side edges
+        if (left) {
+            ctx.globalAlpha = 0.55;
+            ctx.fillStyle = toCss(dark1);
+            ctx.fillRect(0, yOff, 1, ts);
+            ctx.globalAlpha = 1;
+        }
+        if (right) {
+            ctx.globalAlpha = 0.55;
+            ctx.fillStyle = toCss(dark1);
+            ctx.fillRect(ts - 1, yOff, 1, ts);
+            ctx.globalAlpha = 1;
+        }
+        // Chipped corners
+        ctx.fillStyle = toCss(dark2);
+        if (top && left) ctx.fillRect(0, yOff, 1, 1);
+        if (top && right) ctx.fillRect(ts - 1, yOff, 1, 1);
+        if (bottom && left) ctx.fillRect(0, yOff + ts - 1, 1, 1);
+        if (bottom && right) ctx.fillRect(ts - 1, yOff + ts - 1, 1, 1);
+
+        // Body speckles for soil grain
+        const speckleCount = 4 + Math.floor(rng() * 3);
+        for (let i = 0; i < speckleCount; i++) {
+            const sx = 1 + Math.floor(rng() * (ts - 2));
+            const sy = yOff + 1 + Math.floor(rng() * (ts - 2));
+            const useLight = rng() > 0.78;
+            ctx.globalAlpha = useLight ? 0.7 : 0.85;
+            ctx.fillStyle = toCss(useLight ? lightHex : dark1);
+            ctx.fillRect(sx, sy, 1, 1);
+        }
+        ctx.globalAlpha = 1;
+    }
+
+    drawGrass(ctx, mask, variant) {
+        const ts = this.tileSize;
+        const yOff = this.grassOverhang;
+        const rng = makeRng(mask * 31 + variant * 911 + 7);
+
+        // Solid green band on the very top row of the body
+        ctx.fillStyle = toCss(this.grassA);
+        ctx.fillRect(0, yOff, ts, 1);
+
+        // Darker mottle pixels along the top row
+        ctx.fillStyle = toCss(this.grassDark);
+        const mottle = 2 + Math.floor(rng() * 3);
+        for (let i = 0; i < mottle; i++) {
+            const px = Math.floor(rng() * ts);
+            ctx.fillRect(px, yOff, 1, 1);
+        }
+
+        // Softer second row beneath the band
+        ctx.globalAlpha = 0.45;
+        ctx.fillStyle = toCss(this.grassA);
+        ctx.fillRect(0, yOff + 1, ts, 1);
+        ctx.globalAlpha = 1;
+
+        // Standing blades pushing up into the overhang region
+        const blades = 2 + Math.floor(rng() * 3);
+        for (let i = 0; i < blades; i++) {
+            const px = 1 + Math.floor(rng() * (ts - 2));
+            const blen = 1 + Math.floor(rng() * 3);
+            const useLight = rng() > 0.5;
+            ctx.fillStyle = toCss(useLight ? this.grassB : this.grassA);
+            ctx.fillRect(px, yOff - blen, 1, blen);
+        }
+    }
+
+    makeDirtTexture(mask, variant) {
+        const key = this.keyFor('dirt', mask, variant);
+        if (this.game.textures.exists(key)) return;
+        const tex = this.game.textures.createCanvas(key, this.tileSize, this.textureHeight);
+        const ctx = tex.context;
+        ctx.imageSmoothingEnabled = false;
+        ctx.clearRect(0, 0, this.tileSize, this.textureHeight);
+        this.drawBody(ctx, mask, variant, this.dirtBaseColor);
+        tex.refresh();
+    }
+
+    makeGrassTexture(mask, variant) {
+        const key = this.keyFor('grass', mask, variant);
+        if (this.game.textures.exists(key)) return;
+        const tex = this.game.textures.createCanvas(key, this.tileSize, this.textureHeight);
+        const ctx = tex.context;
+        ctx.imageSmoothingEnabled = false;
+        ctx.clearRect(0, 0, this.tileSize, this.textureHeight);
+        this.drawBody(ctx, mask, variant, this.dirtBaseColor);
+        this.drawGrass(ctx, mask, variant);
+        tex.refresh();
+    }
+}

--- a/src/services/tileTextureAtlas.js
+++ b/src/services/tileTextureAtlas.js
@@ -11,7 +11,7 @@
 //   the "tile seam" grain that makes a wall read as one mass
 // - 3 variants per edge mask for visual variety
 
-const VARIANT_COUNT = 3;
+const VARIANT_COUNT = 6;
 
 function makeRng(seed) {
     let s = seed | 0;
@@ -221,16 +221,22 @@ export default class TileTextureAtlas {
         seam(0, ts - 1,        !bottom && !left);
         seam(ts - 1, ts - 1,   !bottom && !right);
 
-        // Pass 3: body speckles — small interior pixels (not on edge) of
-        // mixed darker/lighter shades for soil grain.
-        const speckleCount = 3 + Math.floor(rng() * 3);
+        // Pass 3: body speckles — small interior pixels (not on edge) in
+        // a few different shades for richer soil grain. More variation per
+        // tile makes a wall of same-mask tiles feel less copy-paste.
+        const speckleCount = 6 + Math.floor(rng() * 4);
+        const dark3 = darken(baseColor, 18);
         for (let i = 0; i < speckleCount; i++) {
             const sx = 1 + Math.floor(rng() * (ts - 2));
             const sy = 1 + Math.floor(rng() * (ts - 2));
             if (!filled[sy][sx]) continue;
             if (this.isSilhouetteEdge(filled, sx, sy, mask)) continue;
-            const useLight = rng() > 0.78;
-            ctx.fillStyle = toCss(useLight ? hi : lo);
+            const shade = rng();
+            let color;
+            if (shade > 0.82) color = hi;
+            else if (shade > 0.55) color = dark3;
+            else color = lo;
+            ctx.fillStyle = toCss(color);
             ctx.fillRect(sx, yOff + sy, 1, 1);
         }
 

--- a/src/services/tileTextureAtlas.js
+++ b/src/services/tileTextureAtlas.js
@@ -1,19 +1,18 @@
-// Pre-renders dirt and grass tile variants as Phaser canvas textures.
-// Each combination of (edge mask × variant) is rendered once at scene start
-// so individual tiles can use cheap Image sprites instead of redrawing
-// procedural Graphics every time their state changes.
+// Pre-renders dirt and grass tile variants as Phaser canvas textures
+// at scene init. Each tile becomes a cheap Image sprite that just
+// references one of these atlas textures, swapping keys when its
+// neighbour state changes.
 //
-// Texture layout:
-//   width  = tileSize (e.g. 10)
-//   height = tileSize + grassOverhang (e.g. 14)
-//
-// The bottom tileSize rows are the tile body (collision-aligned).
-// The top grassOverhang rows are reserved for grass blades that protrude
-// above the tile. They're transparent on dirt textures.
+// Visual approach mirrors Terraria-style auto-tiles:
+// - sharp pixel-art square base
+// - corner cuts (1-2px L-shapes) where two adjacent sides face air
+// - dark outline traced around the resulting silhouette
+// - inner-corner darkening where two solid neighbours meet, giving
+//   the "tile seam" grain that makes a wall read as one mass
+// - 3 variants per edge mask for visual variety
 
 const VARIANT_COUNT = 3;
 
-// Deterministic pseudo-random for stable variant generation across runs.
 function makeRng(seed) {
     let s = seed | 0;
     return () => {
@@ -79,6 +78,81 @@ export default class TileTextureAtlas {
         return `tile_${kind}_${mask}_${variant}`;
     }
 
+    // Build a per-pixel filled mask for the body, applying corner cuts
+    // where two adjacent sides face air, plus optional edge erosion for
+    // variant-level silhouette variation.
+    buildFilled(mask, rng) {
+        const top = !!(mask & 1);
+        const right = !!(mask & 2);
+        const bottom = !!(mask & 4);
+        const left = !!(mask & 8);
+        const ts = this.tileSize;
+
+        const filled = [];
+        for (let py = 0; py < ts; py++) filled.push(new Array(ts).fill(true));
+
+        const cutCorner = (cornerX, cornerY, dirX, dirY, depth) => {
+            for (let i = 0; i <= depth; i++) {
+                for (let j = 0; j <= depth - i; j++) {
+                    const px = cornerX + dirX * i;
+                    const py = cornerY + dirY * j;
+                    if (filled[py] && filled[py][px] !== undefined) {
+                        filled[py][px] = false;
+                    }
+                }
+            }
+        };
+
+        // 1-2 deep L-shape cuts at each exposed corner
+        const cornerDepth = () => 1 + (rng() > 0.5 ? 1 : 0);
+        if (top && left)     cutCorner(0, 0, 1, 1, cornerDepth());
+        if (top && right)    cutCorner(ts - 1, 0, -1, 1, cornerDepth());
+        if (bottom && left)  cutCorner(0, ts - 1, 1, -1, cornerDepth());
+        if (bottom && right) cutCorner(ts - 1, ts - 1, -1, -1, cornerDepth());
+
+        // Tiny edge erosion — 0-1 chips per exposed side, away from corners
+        const erodeEdge = (axis, isOpen) => {
+            if (!isOpen) return;
+            if (rng() < 0.6) return;
+            const t = 3 + Math.floor(rng() * (ts - 6));
+            if (axis === 'top' && filled[0][t]) filled[0][t] = false;
+            else if (axis === 'bottom' && filled[ts - 1][t]) filled[ts - 1][t] = false;
+            else if (axis === 'left' && filled[t][0]) filled[t][0] = false;
+            else if (axis === 'right' && filled[t][ts - 1]) filled[t][ts - 1] = false;
+        };
+        erodeEdge('top', top);
+        erodeEdge('bottom', bottom);
+        erodeEdge('left', left);
+        erodeEdge('right', right);
+
+        return filled;
+    }
+
+    // A pixel is on the silhouette edge if any of its 4 neighbours is
+    // unfilled, or it's at the tile boundary on a side that faces air.
+    isSilhouetteEdge(filled, px, py, mask) {
+        if (!filled[py][px]) return false;
+        const top = !!(mask & 1);
+        const right = !!(mask & 2);
+        const bottom = !!(mask & 4);
+        const left = !!(mask & 8);
+        const ts = this.tileSize;
+
+        if (py === 0) { if (top) return true; }
+        else if (!filled[py - 1][px]) return true;
+
+        if (py === ts - 1) { if (bottom) return true; }
+        else if (!filled[py + 1][px]) return true;
+
+        if (px === 0) { if (left) return true; }
+        else if (!filled[py][px - 1]) return true;
+
+        if (px === ts - 1) { if (right) return true; }
+        else if (!filled[py][px + 1]) return true;
+
+        return false;
+    }
+
     drawBody(ctx, mask, variant, baseColor) {
         const top = !!(mask & 1);
         const right = !!(mask & 2);
@@ -89,96 +163,99 @@ export default class TileTextureAtlas {
         const yOff = this.grassOverhang;
         const rng = makeRng(mask * 17 + variant * 257 + 1);
 
-        const lightHex = lighten(baseColor, 22);
-        const dark1 = darken(baseColor, 22);
-        const dark2 = darken(baseColor, 40);
+        const mid = baseColor;
+        const hi = lighten(baseColor, 18);
+        const lo = darken(baseColor, 28);
+        const outline = darken(baseColor, 55);
 
-        // Body fill
-        ctx.fillStyle = toCss(baseColor);
-        ctx.fillRect(0, yOff, ts, ts);
+        const filled = this.buildFilled(mask, rng);
 
-        // Top edge — lighter row plus weathering pixels
-        if (top) {
-            ctx.fillStyle = toCss(lightHex);
-            ctx.fillRect(0, yOff, ts, 1);
-            const wear = 2 + Math.floor(rng() * 3);
-            ctx.fillStyle = toCss(dark1);
-            for (let i = 0; i < wear; i++) {
-                const px = Math.floor(rng() * ts);
-                ctx.fillRect(px, yOff, 1, 1);
+        // Pass 1: fill body pixels (mid colour where filled, dark outline
+        // where on the silhouette edge).
+        for (let py = 0; py < ts; py++) {
+            for (let px = 0; px < ts; px++) {
+                if (!filled[py][px]) continue;
+                const onEdge = this.isSilhouetteEdge(filled, px, py, mask);
+                ctx.fillStyle = toCss(onEdge ? outline : mid);
+                ctx.fillRect(px, yOff + py, 1, 1);
             }
         }
-        // Bottom edge — darker row
-        if (bottom) {
-            ctx.globalAlpha = 0.85;
-            ctx.fillStyle = toCss(dark2);
-            ctx.fillRect(0, yOff + ts - 1, ts, 1);
-            ctx.globalAlpha = 1;
-        }
-        // Side edges
-        if (left) {
-            ctx.globalAlpha = 0.55;
-            ctx.fillStyle = toCss(dark1);
-            ctx.fillRect(0, yOff, 1, ts);
-            ctx.globalAlpha = 1;
-        }
-        if (right) {
-            ctx.globalAlpha = 0.55;
-            ctx.fillStyle = toCss(dark1);
-            ctx.fillRect(ts - 1, yOff, 1, ts);
-            ctx.globalAlpha = 1;
-        }
-        // Chipped corners
-        ctx.fillStyle = toCss(dark2);
-        if (top && left) ctx.fillRect(0, yOff, 1, 1);
-        if (top && right) ctx.fillRect(ts - 1, yOff, 1, 1);
-        if (bottom && left) ctx.fillRect(0, yOff + ts - 1, 1, 1);
-        if (bottom && right) ctx.fillRect(ts - 1, yOff + ts - 1, 1, 1);
 
-        // Body speckles for soil grain
-        const speckleCount = 4 + Math.floor(rng() * 3);
+        // Pass 2: inner corner seam — where two adjacent sides are NOT
+        // exposed, the corner is interior. A single darker pixel there
+        // produces the Terraria-style "tile seam" grain when adjacent
+        // tiles tile next to one another.
+        const seam = (cornerX, cornerY, conds) => {
+            if (!conds) return;
+            if (filled[cornerY][cornerX]) {
+                ctx.fillStyle = toCss(lo);
+                ctx.fillRect(cornerX, yOff + cornerY, 1, 1);
+            }
+        };
+        seam(0, 0,             !top && !left);
+        seam(ts - 1, 0,        !top && !right);
+        seam(0, ts - 1,        !bottom && !left);
+        seam(ts - 1, ts - 1,   !bottom && !right);
+
+        // Pass 3: body speckles — small interior pixels (not on edge) of
+        // mixed darker/lighter shades for soil grain.
+        const speckleCount = 3 + Math.floor(rng() * 3);
         for (let i = 0; i < speckleCount; i++) {
             const sx = 1 + Math.floor(rng() * (ts - 2));
-            const sy = yOff + 1 + Math.floor(rng() * (ts - 2));
+            const sy = 1 + Math.floor(rng() * (ts - 2));
+            if (!filled[sy][sx]) continue;
+            if (this.isSilhouetteEdge(filled, sx, sy, mask)) continue;
             const useLight = rng() > 0.78;
-            ctx.globalAlpha = useLight ? 0.7 : 0.85;
-            ctx.fillStyle = toCss(useLight ? lightHex : dark1);
-            ctx.fillRect(sx, sy, 1, 1);
+            ctx.fillStyle = toCss(useLight ? hi : lo);
+            ctx.fillRect(sx, yOff + sy, 1, 1);
         }
-        ctx.globalAlpha = 1;
+
+        return filled;
     }
 
-    drawGrass(ctx, mask, variant) {
+    drawGrass(ctx, mask, variant, filled) {
         const ts = this.tileSize;
         const yOff = this.grassOverhang;
         const rng = makeRng(mask * 31 + variant * 911 + 7);
 
-        // Solid green band on the very top row of the body
-        ctx.fillStyle = toCss(this.grassA);
-        ctx.fillRect(0, yOff, ts, 1);
+        const top = !!(mask & 1);
+        if (!top) return;
 
-        // Darker mottle pixels along the top row
-        ctx.fillStyle = toCss(this.grassDark);
+        // Find the topmost filled pixel in each column — that's where
+        // the grass band sits, conforming to the silhouette.
+        const grassY = new Array(ts).fill(-1);
+        for (let px = 0; px < ts; px++) {
+            for (let py = 0; py < ts; py++) {
+                if (filled[py][px]) { grassY[px] = py; break; }
+            }
+        }
+
+        // Solid grass row along the top of the body
+        for (let px = 0; px < ts; px++) {
+            const py = grassY[px];
+            if (py < 0) continue;
+            ctx.fillStyle = toCss(this.grassA);
+            ctx.fillRect(px, yOff + py, 1, 1);
+        }
+        // Mottle with darker greens
         const mottle = 2 + Math.floor(rng() * 3);
         for (let i = 0; i < mottle; i++) {
             const px = Math.floor(rng() * ts);
-            ctx.fillRect(px, yOff, 1, 1);
+            const py = grassY[px];
+            if (py < 0) continue;
+            ctx.fillStyle = toCss(this.grassDark);
+            ctx.fillRect(px, yOff + py, 1, 1);
         }
-
-        // Softer second row beneath the band
-        ctx.globalAlpha = 0.45;
-        ctx.fillStyle = toCss(this.grassA);
-        ctx.fillRect(0, yOff + 1, ts, 1);
-        ctx.globalAlpha = 1;
-
         // Standing blades pushing up into the overhang region
         const blades = 2 + Math.floor(rng() * 3);
         for (let i = 0; i < blades; i++) {
             const px = 1 + Math.floor(rng() * (ts - 2));
+            const py = grassY[px];
+            if (py < 0) continue;
             const blen = 1 + Math.floor(rng() * 3);
             const useLight = rng() > 0.5;
             ctx.fillStyle = toCss(useLight ? this.grassB : this.grassA);
-            ctx.fillRect(px, yOff - blen, 1, blen);
+            ctx.fillRect(px, yOff + py - blen, 1, blen);
         }
     }
 
@@ -200,8 +277,8 @@ export default class TileTextureAtlas {
         const ctx = tex.context;
         ctx.imageSmoothingEnabled = false;
         ctx.clearRect(0, 0, this.tileSize, this.textureHeight);
-        this.drawBody(ctx, mask, variant, this.dirtBaseColor);
-        this.drawGrass(ctx, mask, variant);
+        const filled = this.drawBody(ctx, mask, variant, this.dirtBaseColor);
+        this.drawGrass(ctx, mask, variant, filled);
         tex.refresh();
     }
 }

--- a/src/services/tileTextureAtlas.js
+++ b/src/services/tileTextureAtlas.js
@@ -11,7 +11,7 @@
 //   the "tile seam" grain that makes a wall read as one mass
 // - 3 variants per edge mask for visual variety
 
-const VARIANT_COUNT = 6;
+const VARIANT_COUNT = 8;
 
 function makeRng(seed) {
     let s = seed | 0;
@@ -206,20 +206,23 @@ export default class TileTextureAtlas {
         }
 
         // Pass 2: inner corner seam — where two adjacent sides are NOT
-        // exposed, the corner is interior. A single darker pixel there
-        // produces the Terraria-style "tile seam" grain when adjacent
-        // tiles tile next to one another.
-        const seam = (cornerX, cornerY, conds) => {
-            if (!conds) return;
+        // exposed the corner is interior. We add a faint darker pixel at
+        // SOME of these corners (chosen per-variant) so adjacent tiles'
+        // meeting corners don't always form a uniform 2x2 dark square at
+        // every 4-tile junction. Use a softer darken than lo.
+        const seamShade = darken(baseColor, 16);
+        const seamBits = Math.floor(rng() * 16);
+        const seam = (cornerX, cornerY, conds, bit) => {
+            if (!conds || !(seamBits & bit)) return;
             if (filled[cornerY][cornerX]) {
-                ctx.fillStyle = toCss(lo);
+                ctx.fillStyle = toCss(seamShade);
                 ctx.fillRect(cornerX, yOff + cornerY, 1, 1);
             }
         };
-        seam(0, 0,             !top && !left);
-        seam(ts - 1, 0,        !top && !right);
-        seam(0, ts - 1,        !bottom && !left);
-        seam(ts - 1, ts - 1,   !bottom && !right);
+        seam(0, 0,             !top && !left,    1);
+        seam(ts - 1, 0,        !top && !right,   2);
+        seam(0, ts - 1,        !bottom && !left, 4);
+        seam(ts - 1, ts - 1,   !bottom && !right, 8);
 
         // Pass 3: body speckles — small interior pixels (not on edge) in
         // a few different shades for richer soil grain. More variation per

--- a/src/services/tileTextureAtlas.js
+++ b/src/services/tileTextureAtlas.js
@@ -303,57 +303,106 @@ export default class TileTextureAtlas {
         tex.refresh();
     }
 
-    // ----- Inside-corner curves rendered into empty tiles -----
-    // When an empty tile sits in an inside cave corner (e.g. top + left
-    // neighbours and the top-left diagonal are all solid), it draws a
-    // 3-pixel L of dirt-coloured pixels in that corner so the cave's
-    // concave corner reads as rounded rather than 90°.
+    // ----- Corner curve overlays for solid tiles -----
+    // Each solid tile can add a small overlay Image centred on its world
+    // position. The overlay's texture is the same size as the tile body
+    // plus a 2px overhang on each side (so e.g. 14x14 for a 10px tile).
+    // Curve pixels are drawn ONLY in the corner overhang regions — never
+    // in the body region — so the overlay sits cleanly outside the
+    // tile's bounds, extending into the adjacent diagonal cell.
+    //
+    // Pixels use the dark outline colour so they blend with the
+    // surrounding tile silhouette borders regardless of tile type.
 
-    emptyCurveKey(mask) {
-        return `tile_emptycurve_${mask}`;
+    cornerCurveOverhang() {
+        return 2;
     }
 
-    ensureEmptyCurveTexture(mask) {
-        const key = this.emptyCurveKey(mask);
-        if (this.game.textures.exists(key)) return key;
-        this.makeEmptyCurveTexture(mask, key);
+    cornerCurveSize() {
+        return this.tileSize + this.cornerCurveOverhang() * 2;
+    }
+
+    cornerCurveKey(mask) {
+        return `tile_corner_curve_${mask}`;
+    }
+
+    ensureCornerCurveTexture(mask) {
+        const key = this.cornerCurveKey(mask);
+        if (!this.game.textures.exists(key)) this.makeCornerCurveTexture(mask, key);
         return key;
     }
 
-    makeEmptyCurveTexture(mask, key) {
-        const ts = this.tileSize;
-        const tex = this.game.textures.createCanvas(key, ts, ts);
+    makeCornerCurveTexture(mask, key) {
+        const size = this.cornerCurveSize();
+        const tex = this.game.textures.createCanvas(key, size, size);
         const ctx = tex.context;
         ctx.imageSmoothingEnabled = false;
-        ctx.clearRect(0, 0, ts, ts);
+        ctx.clearRect(0, 0, size, size);
 
-        const mid = toCss(this.dirtBaseColor);
         const outline = toCss(darken(this.dirtBaseColor, 55));
+        ctx.fillStyle = outline;
 
-        // Each set bit = a corner that needs a curve. The corner pixel is
-        // mid dirt; the two adjacent pixels along the cave wall are the
-        // dark silhouette outline so the curve blends into the dirt mass.
-        if (mask & 1) {           // top-left corner of the empty tile
-            ctx.fillStyle = mid;     ctx.fillRect(0, 0, 1, 1);
-            ctx.fillStyle = outline; ctx.fillRect(1, 0, 1, 1);
-            ctx.fillStyle = outline; ctx.fillRect(0, 1, 1, 1);
+        // 3-pixel L per corner. The "near" pixel sits diagonally adjacent
+        // to the tile body; the other two extend along the cave walls
+        // formed by the two solid neighbours.
+        if (mask & 1) {                         // top-left
+            ctx.fillRect(1, 1, 1, 1);
+            ctx.fillRect(0, 1, 1, 1);
+            ctx.fillRect(1, 0, 1, 1);
         }
-        if (mask & 2) {           // top-right
-            ctx.fillStyle = mid;     ctx.fillRect(ts - 1, 0, 1, 1);
-            ctx.fillStyle = outline; ctx.fillRect(ts - 2, 0, 1, 1);
-            ctx.fillStyle = outline; ctx.fillRect(ts - 1, 1, 1, 1);
+        if (mask & 2) {                         // top-right
+            ctx.fillRect(size - 2, 1, 1, 1);
+            ctx.fillRect(size - 1, 1, 1, 1);
+            ctx.fillRect(size - 2, 0, 1, 1);
         }
-        if (mask & 4) {           // bottom-left
-            ctx.fillStyle = mid;     ctx.fillRect(0, ts - 1, 1, 1);
-            ctx.fillStyle = outline; ctx.fillRect(1, ts - 1, 1, 1);
-            ctx.fillStyle = outline; ctx.fillRect(0, ts - 2, 1, 1);
+        if (mask & 4) {                         // bottom-left
+            ctx.fillRect(1, size - 2, 1, 1);
+            ctx.fillRect(0, size - 2, 1, 1);
+            ctx.fillRect(1, size - 1, 1, 1);
         }
-        if (mask & 8) {           // bottom-right
-            ctx.fillStyle = mid;     ctx.fillRect(ts - 1, ts - 1, 1, 1);
-            ctx.fillStyle = outline; ctx.fillRect(ts - 2, ts - 1, 1, 1);
-            ctx.fillStyle = outline; ctx.fillRect(ts - 1, ts - 2, 1, 1);
+        if (mask & 8) {                         // bottom-right
+            ctx.fillRect(size - 2, size - 2, 1, 1);
+            ctx.fillRect(size - 1, size - 2, 1, 1);
+            ctx.fillRect(size - 2, size - 1, 1, 1);
         }
 
         tex.refresh();
+    }
+
+    // True when the cell at (worldX, worldY) is a solid wall-forming tile.
+    isSolidAt(worldX, worldY) {
+        const ts = this.tileSize;
+        const cs = this.game.chunkSize;
+        const gcx = Math.floor(worldX / ts);
+        const gcy = Math.floor(worldY / ts);
+        const chunkX = Math.floor(gcx / cs) * cs;
+        const chunkY = Math.floor(gcy / cs) * cs;
+        const chunk = this.game.grid[`${chunkX}_${chunkY}`];
+        if (!chunk) return false;
+        const lx = ((gcx % cs) + cs) % cs;
+        const ly = ((gcy % cs) + cs) % cs;
+        const tile = chunk[ly]?.[lx];
+        if (!tile) return false;
+        // Anything that forms part of a continuous wall mass.
+        return tile.id === 1 || tile.id === 5;
+    }
+
+    // For a tile centred at (worldX, worldY): compute the 4-bit mask of
+    // corners where this tile is at an inside cave corner — both adjacent
+    // sides are solid neighbours AND the diagonal cell is open. These are
+    // the corners where the tile should extend curve pixels into the
+    // diagonal open cell.
+    cornerCurveMaskFor(worldX, worldY) {
+        const ts = this.tileSize;
+        const top = this.isSolidAt(worldX, worldY - ts);
+        const right = this.isSolidAt(worldX + ts, worldY);
+        const bottom = this.isSolidAt(worldX, worldY + ts);
+        const left = this.isSolidAt(worldX - ts, worldY);
+        let mask = 0;
+        if (top && left && !this.isSolidAt(worldX - ts, worldY - ts)) mask |= 1;
+        if (top && right && !this.isSolidAt(worldX + ts, worldY - ts)) mask |= 2;
+        if (bottom && left && !this.isSolidAt(worldX - ts, worldY + ts)) mask |= 4;
+        if (bottom && right && !this.isSolidAt(worldX + ts, worldY + ts)) mask |= 8;
+        return mask;
     }
 }


### PR DESCRIPTION
## Summary
This PR introduces a procedural tile texture atlas system that pre-renders dirt and grass tile variants with Terraria-style auto-tiling, along with comprehensive visual polish including player animations, improved lighting, and environmental details.

## Key Changes

### Tile Texture Atlas System
- **New `TileTextureAtlas` service** (`src/services/tileTextureAtlas.js`): Pre-renders 8 variants of each tile edge mask as Phaser canvas textures at scene init
  - Generates sharp pixel-art tile bodies with corner cuts where adjacent sides face air
  - Adds dark outlines and inner-corner seaming for visual cohesion
  - Includes procedural speckles and grain for visual variety
  - Lazy-generates inner-corner variants (masks 16/32/64/128) on first use
  - Renders grass overlays on top tiles near the surface with mottle and standing blades
  - Generates corner curve overlays for inside corners that extend into diagonal open cells

### Tile Rendering Updates
- **`Breakable` class**: Refactored to use atlas textures instead of solid color rectangles
  - Implements `redrawTile()` to swap texture keys based on edge mask changes
  - Adds `refreshCurveOverlay()` to manage inside-corner curve overlays
  - Implements procedural detail overlays (worms, fossils, pebble clusters) using positional hashing
  - Per-tile tint jitter combined with hardness-driven color shifts (softer = brighter/warmer)
  - Grass texture used for tiles near surface with top edge exposed

- **`Buttress` class**: Added curve overlay support matching Breakable behavior

- **`Tile` class**: Updated border styling to use warm cream color (`0xfff1c4`)

### Player Animation & Polish
- **`PlayerManager` updates**:
  - Added player shadow (ellipse at depth 0.5)
  - Implemented landing squash animation with intensity based on fall velocity
  - Added idle head bob (gentle 1px sine wave when stationary)
  - Soft drop shadow that stays on ground during jumps
  - Captured base scale values for proper tween scaling

- **`ControlsManager`**: Added `emitFootstepPuff()` for footstep particle effects when moving on ground

### Lighting & Environment
- **`LightingManager` updates**:
  - Changed sky color from cyan (`0xa6f5ff`) to warm cream (`0xf9e4c8`)
  - Added `spawnClouds()` to render drifting cloud sprites across the sky
  - Updated day/night tint interpolation with smoothstep easing for gentler transitions
  - Improved light texture caching and bloom effects

- **`MapService`**: 
  - Instantiates `TileTextureAtlas` at map init
  - Added `footstepEmitter` for slower, drifting kicked-up dust
  - Added `ambientMoteEmitter` for slow additive dust motes near player
  - Implemented `refreshNeighborEdges()` to update adjacent tiles when tiles are placed/destroyed

### Color & Atmosphere
- Updated light colors in `GameScene` to warmer palette (orange/cream instead of cool tones)
- Added `lightenColor()` utility to `colourManager.js`
- Menu scene background darkened slightly (`0x0c0805`)

### CI/CD
- Added GitHub Actions workflow (`.github/workflows/preview.yml`) for automatic preview deployments on `claude/**` branches

## Implementation Details
- Tile variants use seeded RNG based on mask and variant index for deterministic but varied appearance
- Edge masks use 4-bit encoding: bit 0=top, 1=right, 2=bottom, 3=left
- Positional hashing (`posHash()`) in Breakable ensures consistent per-tile details across saves
- Curve overlays use separate small textures (tile size + 4px overhang) to avoid overlapping body pixels
- Grass textures only generated when top edge is exposed and tile is near surface
- All tile texture generation is lazy-loaded except the initial 16 basic masks (0-15)

https://claude.ai/code/session_016EHL3PEBkZk5ZC64DBS6Ki