### PR TITLE
Add mining rig terminal UI and rope extension system

### DIFF
--- a/src/classes/liftControl.js
+++ b/src/classes/liftControl.js
@@ -10,8 +10,26 @@ export class LiftControl extends Tile {
         this.game.craneManager.moveTo(this.worldY, this);
     }
 
+    teleportToLift() {
+        const cm = this.game.craneManager;
+        if (!cm) return;
+        // Land the player just above the platform's collider top so gravity
+        // settles them onto the platform and the existing collider takes over.
+        const x = cm.craneFlat.x;
+        const y = cm.craneFlat.body.y - 6;
+        this.game.playerManager.teleportTo(x, y);
+    }
+
     get interactionText() {
         return 'Call Lift';
+    }
+
+    get secondaryInteractionText() {
+        return 'Teleport to Lift';
+    }
+
+    secondaryAction() {
+        this.teleportToLift();
     }
 
     moving(direction) {

--- a/src/classes/liftControl.js
+++ b/src/classes/liftControl.js
@@ -10,6 +10,10 @@ export class LiftControl extends Tile {
         this.game.craneManager.moveTo(this.worldY, this);
     }
 
+    get interactionText() {
+        return 'Call Lift';
+    }
+
     moving(direction) {
         if (direction === "up") {
             this.switchSprite.setFrame(1);

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -386,7 +386,7 @@ export default class GameScene extends Phaser.Scene {
             const playerX = this.player.x + playerOffset;
             const playerY = this.player.y + playerOffset;
             this.playerLight.setPosition(Math.round(playerX), Math.round(playerY));
-            // this.craneManager.update();
+            this.craneManager?.update();
             if (this.glowSticks.length) {
                 this.glowSticks.forEach(glowStick => glowStick.update());
             }

--- a/src/services/controls.js
+++ b/src/services/controls.js
@@ -21,6 +21,11 @@ export default class ControlsManager {
                     this.game.showInteractionPrompt();
                 }
             }
+            if (e.key === "q") {
+                if (this.game.showSecondaryInteractionPrompt) {
+                    this.game.showSecondaryInteractionPrompt();
+                }
+            }
         });
 
         window.addEventListener("mousedown", (e) => {
@@ -185,10 +190,17 @@ export default class ControlsManager {
             this.game.isFloating = true;
         });
         this.game.showInteractionPrompt = false;
+        this.game.showSecondaryInteractionPrompt = null;
+        this.game.secondaryInteractionText = null;
 
         this.game.physics.overlap(this.game.player, this.game.interactableGroup, (obj1, obj2) => {
-            this.game.interactionText = obj2?.tileRef?.interactionText || 'Interact';
-            this.game.showInteractionPrompt = () => obj2?.tileRef?.callCrane();
+            const ref = obj2?.tileRef;
+            this.game.interactionText = ref?.interactionText || 'Interact';
+            this.game.showInteractionPrompt = () => ref?.callCrane();
+            if (ref?.secondaryAction) {
+                this.game.secondaryInteractionText = ref.secondaryInteractionText || null;
+                this.game.showSecondaryInteractionPrompt = () => ref.secondaryAction();
+            }
         });
 
         this.game.mineCartGroup.getChildren().forEach(child => {
@@ -290,7 +302,7 @@ export default class ControlsManager {
             const playerY = this.game.player.body.y - 5;
 
             const textX = playerX;
-            const textY = playerY - 5;
+            const textY = playerY - (this.game.secondaryInteractionText ? 9 : 5);
 
             const style = {
                 font: '3px',
@@ -299,11 +311,17 @@ export default class ControlsManager {
                 padding: {left: 3, right: 3, top: 2, bottom: 1}
             };
 
+            const primary = `E to ${this.game.interactionText || 'Interact'}`;
+            const secondary = this.game.secondaryInteractionText
+                ? `\nQ to ${this.game.secondaryInteractionText}`
+                : '';
+            const promptText = primary + secondary;
+
             if (!this.interactionText) {
-                this.interactionText = this.game.add.text(textX, textY, `E to ${this.game.interactionText || 'Interact'}`, style);
+                this.interactionText = this.game.add.text(textX, textY, promptText, style);
                 // this.interactionText.setOrigin(0.5);
             } else {
-                this.interactionText.setText(`E to ${this.game.interactionText || 'Interact'}`);
+                this.interactionText.setText(promptText);
                 this.interactionText.setPosition(textX, textY);
                 this.interactionText.setDepth(999999);
             }

--- a/src/services/controls.js
+++ b/src/services/controls.js
@@ -187,6 +187,7 @@ export default class ControlsManager {
         this.game.showInteractionPrompt = false;
 
         this.game.physics.overlap(this.game.player, this.game.interactableGroup, (obj1, obj2) => {
+            this.game.interactionText = obj2?.tileRef?.interactionText || 'Interact';
             this.game.showInteractionPrompt = () => obj2?.tileRef?.callCrane();
         });
 

--- a/src/services/craneManager.js
+++ b/src/services/craneManager.js
@@ -75,7 +75,12 @@ export default class CraneManager {
                 else if (direction === 'down') this.controlPanel.setFrame(2);
                 else this.controlPanel.setFrame(0);
             },
-            // The hovered-block hooks expect these on every tileRef.
+            // The panel isn't a placed grid tile, so chunk-unload, hover, and
+            // the periodic checkState pass should all no-op here. Stubs keep
+            // the Tile-shaped interface so those callers don't have to
+            // special-case the platform panel.
+            destroy: () => {},
+            checkState: () => {},
             onMouseEnter: () => {},
             onMouseLeave: () => {},
             onClick: () => {}

--- a/src/services/craneManager.js
+++ b/src/services/craneManager.js
@@ -69,6 +69,12 @@ export default class CraneManager {
 
         this.controlPanel.tileRef = {
             interactionText: 'Use Terminal',
+            // getAdjacentBlocks scans every entityChildren group, so the
+            // panel can show up as a neighbour of a real tile being
+            // destroyed; that path reads tileDetails.attachedTo, so we
+            // need an object here even though the panel never participates
+            // in attachment chains.
+            tileDetails: {},
             callCrane: () => this.liftTerminal.toggle(),
             moving: (direction) => {
                 if (direction === 'up') this.controlPanel.setFrame(1);

--- a/src/services/craneManager.js
+++ b/src/services/craneManager.js
@@ -10,8 +10,10 @@ export default class CraneManager {
         this.ropeColor = '0x6B3E22';
         let color = '#6b3e22'
         const width = (this.game.chasmRange[1] - this.game.chasmRange[0]) * 10;
+        const platformX = (this.game.chasmRange[0] * 10) + width / 2;
+        const platformY = (this.game.aboveGround * 10) + 10;
         // this.craneFlat = this.game.add.image(1500, 210, 'wood');
-        this.craneFlat = this.game.add.image(((this.game.chasmRange[0] * 10) + width / 2), (this.game.aboveGround * 10) + 10, 'wood');
+        this.craneFlat = this.game.add.image(platformX, platformY, 'wood');
         this.craneFlat.setDisplaySize(width - 15, 5);
         this.craneFlat.setDepth(3);
         this.game.craneGroup.add(this.craneFlat);
@@ -38,13 +40,96 @@ export default class CraneManager {
         this.ropeThree.setRotation(degrees_to_radians(-45))
         this.ropeThree.setDepth(2);
 
+        this.createPlatformButton(platformX, platformY);
+
+        // Snapshot the platform's surface position so the on-platform button
+        // can return the player to a pixel-perfect "back at the top" state.
+        this.surfaceState = this._snapshotState();
+        // Last activated wall-mounted lift point. Pressing the on-platform
+        // button toggles between this and the surface.
+        this.savedDeepState = null;
+    }
+
+    createPlatformButton(platformX, platformY) {
+        // Lift-control spritesheet: frame 0 idle, 1 going up, 2 going down.
+        this.platformButton = this.game.add.sprite(platformX, platformY - 7, 'lift-control');
+        this.platformButton.setDisplaySize(this.game.tileSize, this.game.tileSize);
+        this.platformButton.setDepth(4);
+        this.platformButton.setFrame(0);
+        this.game.liftControlGroup.add(this.platformButton);
+
+        this.platformButton.tileRef = {
+            callCrane: () => this.activatePlatformButton(),
+            moving: (direction) => {
+                if (direction === 'up') {
+                    this.platformButton.setFrame(1);
+                } else if (direction === 'down') {
+                    this.platformButton.setFrame(2);
+                } else {
+                    this.platformButton.setFrame(0);
+                }
+            },
+            // The hovered-block hooks expect these to exist on every tileRef.
+            onMouseEnter: () => {},
+            onMouseLeave: () => {},
+            onClick: () => {}
+        };
+    }
+
+    activatePlatformButton() {
+        if (this.moving) return;
+        const currentBodyY = this.craneFlat.body.y;
+        let target;
+        if (this.savedDeepState && Math.abs(currentBodyY - this.savedDeepState.craneFlatBodyY) > 1) {
+            target = this.savedDeepState;
+        } else if (Math.abs(currentBodyY - this.surfaceState.craneFlatBodyY) > 1) {
+            target = this.surfaceState;
+        } else {
+            return;
+        }
+        this._moveCrane(target, this.platformButton.tileRef);
     }
 
     moveTo(y, liftControl) {
+        const target = this._stateForDepth(y);
+        // Remember any non-surface destination so the on-platform button can
+        // bring the player back to it after returning to the top.
+        if (Math.abs(target.craneFlatBodyY - this.surfaceState.craneFlatBodyY) > 1) {
+            this.savedDeepState = target;
+        }
+        this._moveCrane(target, liftControl);
+    }
+
+    _snapshotState() {
+        return {
+            craneFlatY: this.craneFlat.y,
+            craneFlatBodyY: this.craneFlat.body.y,
+            ropeTwoY: this.ropeTwo.y,
+            ropeThreeY: this.ropeThree.y,
+            ropeHeight: this.rope.height,
+            platformButtonY: this.platformButton.y,
+            platformButtonBodyY: this.platformButton.body ? this.platformButton.body.y : this.platformButton.y
+        };
+    }
+
+    _stateForDepth(y) {
+        return {
+            craneFlatY: y + 7.4,
+            craneFlatBodyY: y + 5,
+            ropeTwoY: y - 10,
+            ropeThreeY: y - 10,
+            ropeHeight: y - this.rope.y - 15,
+            platformButtonY: y + 7.4 - 7,
+            platformButtonBodyY: y + 5 - 7
+        };
+    }
+
+    _moveCrane(target, liftControl) {
         if (this.moving) return;
-        if (y + 5 > this.craneFlat.body.y) {
+        const currentBodyY = this.craneFlat.body.y;
+        if (target.craneFlatBodyY > currentBodyY) {
             liftControl.moving('down');
-        } else if (y + 5 < this.craneFlat.body.y) {
+        } else if (target.craneFlatBodyY < currentBodyY) {
             liftControl.moving('up');
         } else {
             liftControl.moving();
@@ -54,7 +139,7 @@ export default class CraneManager {
 
         this.game.tweens.add({
             targets: [this.craneFlat],
-            y: y + 7.4,
+            y: target.craneFlatY,
             duration: this.liftSpeed, // Duration in ms; adjust as needed
             ease: 'ease-out',
             onComplete: () => {
@@ -65,25 +150,40 @@ export default class CraneManager {
 
         this.game.tweens.add({
             targets: [this.craneFlat.body],
-            y: y + 5,
+            y: target.craneFlatBodyY,
             duration: this.liftSpeed, // Duration in ms; adjust as needed
             ease: 'ease-out'
         });
 
         this.game.tweens.add({
             targets: [this.ropeTwo, this.ropeThree],
-            y: y - 10,
+            y: target.ropeTwoY,
             duration: this.liftSpeed, // Duration in ms; adjust as needed
             ease: 'ease-out'
         });
 
         this.game.tweens.add({
             targets: [this.rope],
-            height: y - this.rope.y - 15,
+            height: target.ropeHeight,
             duration: this.liftSpeed, // Duration in ms; adjust as needed
             ease: 'ease-out'
         });
 
+        this.game.tweens.add({
+            targets: [this.platformButton],
+            y: target.platformButtonY,
+            duration: this.liftSpeed,
+            ease: 'ease-out'
+        });
+
+        if (this.platformButton.body) {
+            this.game.tweens.add({
+                targets: [this.platformButton.body],
+                y: target.platformButtonBodyY,
+                duration: this.liftSpeed,
+                ease: 'ease-out'
+            });
+        }
     }
 
 }

--- a/src/services/craneManager.js
+++ b/src/services/craneManager.js
@@ -8,9 +8,11 @@ function degrees_to_radians(degrees) {
 export default class CraneManager {
     constructor(scene) {
         // Lift moves at a constant velocity: travel time scales with the
-        // distance covered. Tuned so a one-level jump (~300 units) takes a
-        // little over a second; full-shaft moves take proportionally longer.
-        this.liftMsPerUnit = 4;
+        // distance covered. Kept just below the player's terminal fall
+        // velocity (~100 px/s) so the platform never out-paces a falling
+        // player and the ride feels like a deliberate descent. Higher
+        // value = slower lift.
+        this.liftMsPerUnit = 12;
         // Floor so very short corrections still animate visibly instead of
         // snapping in a single frame.
         this.liftMinDurationMs = 150;

--- a/src/services/craneManager.js
+++ b/src/services/craneManager.js
@@ -104,6 +104,39 @@ export default class CraneManager {
     }
 
     /**
+     * Per-frame upkeep. The platform's static body is tweened, but Phaser
+     * Arcade has no concept of "moving platforms" — when the lift descends
+     * faster than gravity, the player gets left in mid-air for a beat and
+     * then catches up. This sticks the player to the platform top whenever
+     * they're horizontally over it and not actively jumping, so descending
+     * trips look continuous.
+     */
+    update() {
+        if (!this.moving) return;
+        const player = this.game.player;
+        const lift = this.craneFlat;
+        if (!player?.body || !lift?.body) return;
+
+        const halfLiftW = lift.body.width / 2;
+        const halfPlayerW = player.body.width / 2;
+        const horizOverlap = Math.abs(player.x - lift.x) <= halfLiftW + halfPlayerW;
+        if (!horizOverlap) return;
+
+        const playerBottom = player.body.y + player.body.height;
+        const liftTop = lift.body.y;
+        const gap = liftTop - playerBottom;
+
+        // Only snap when the lift has dropped out from under the player
+        // and they aren't moving upward (jumping / being pushed). Negative
+        // gap means the collider is already resolving an overlap, so leave
+        // it alone.
+        if (gap > 0 && gap <= 16 && player.body.velocity.y >= 0) {
+            player.body.y = liftTop - player.body.height;
+            player.body.velocity.y = 0;
+        }
+    }
+
+    /**
      * Travel to a level chosen from the on-platform terminal. Gated by the
      * rig's current rope length so the player can't drop past their reach.
      */

--- a/src/services/craneManager.js
+++ b/src/services/craneManager.js
@@ -7,7 +7,13 @@ function degrees_to_radians(degrees) {
 
 export default class CraneManager {
     constructor(scene) {
-        this.liftSpeed = 3000;
+        // Lift moves at a constant velocity: travel time scales with the
+        // distance covered. Tuned so a one-level jump (~300 units) takes a
+        // little over a second; full-shaft moves take proportionally longer.
+        this.liftMsPerUnit = 4;
+        // Floor so very short corrections still animate visibly instead of
+        // snapping in a single frame.
+        this.liftMinDurationMs = 150;
         this.game = scene;
         this.ropeColor = '0x6B3E22';
         let color = '#6b3e22'
@@ -161,11 +167,18 @@ export default class CraneManager {
         }
         this.moving = true;
 
+        const distance = Math.abs(target.craneFlatBodyY - currentBodyY);
+        const duration = Math.max(this.liftMinDurationMs, distance * this.liftMsPerUnit);
+        // Linear so velocity is constant within the trip — no easing means
+        // the platform looks like it's running on a real cable rather than
+        // a UI animation that smoothly slows to a stop.
+        const ease = 'Linear';
+
         this.game.tweens.add({
             targets: [this.craneFlat],
             y: target.craneFlatY,
-            duration: this.liftSpeed,
-            ease: 'ease-out',
+            duration,
+            ease,
             onComplete: () => {
                 liftControl.moving();
                 this.moving = false;
@@ -175,37 +188,37 @@ export default class CraneManager {
         this.game.tweens.add({
             targets: [this.craneFlat.body],
             y: target.craneFlatBodyY,
-            duration: this.liftSpeed,
-            ease: 'ease-out'
+            duration,
+            ease
         });
 
         this.game.tweens.add({
             targets: [this.ropeTwo, this.ropeThree],
             y: target.ropeTwoY,
-            duration: this.liftSpeed,
-            ease: 'ease-out'
+            duration,
+            ease
         });
 
         this.game.tweens.add({
             targets: [this.rope],
             height: target.ropeHeight,
-            duration: this.liftSpeed,
-            ease: 'ease-out'
+            duration,
+            ease
         });
 
         this.game.tweens.add({
             targets: [this.controlPanel],
             y: target.controlPanelY,
-            duration: this.liftSpeed,
-            ease: 'ease-out'
+            duration,
+            ease
         });
 
         if (this.controlPanel.body) {
             this.game.tweens.add({
                 targets: [this.controlPanel.body],
                 y: target.controlPanelBodyY,
-                duration: this.liftSpeed,
-                ease: 'ease-out'
+                duration,
+                ease
             });
         }
     }

--- a/src/services/craneManager.js
+++ b/src/services/craneManager.js
@@ -133,7 +133,10 @@ export default class CraneManager {
         // gap means the collider is already resolving an overlap, so leave
         // it alone.
         if (gap > 0 && gap <= 16 && player.body.velocity.y >= 0) {
-            player.body.y = liftTop - player.body.height;
+            // Set the sprite, not the body — Arcade's preUpdate copies the
+            // sprite into the body each frame, so body.y assignments get
+            // clobbered and produce the visible stutter.
+            player.y = liftTop - player.body.height / 2;
             player.body.velocity.y = 0;
         }
     }
@@ -209,22 +212,28 @@ export default class CraneManager {
         // a UI animation that smoothly slows to a stop.
         const ease = 'Linear';
 
+        // Sync each static body to its sprite every tween tick. Tweening
+        // the body and the sprite separately let them drift apart by one
+        // frame, which read as stutter — especially because the player's
+        // snap and the sprite's render don't share the same position.
+        const syncCraneBody = () => {
+            if (this.craneFlat.body) this.craneFlat.body.updateFromGameObject();
+        };
+        const syncPanelBody = () => {
+            if (this.controlPanel.body) this.controlPanel.body.updateFromGameObject();
+        };
+
         this.game.tweens.add({
             targets: [this.craneFlat],
             y: target.craneFlatY,
             duration,
             ease,
+            onUpdate: syncCraneBody,
             onComplete: () => {
+                syncCraneBody();
                 liftControl.moving();
                 this.moving = false;
             }
-        });
-
-        this.game.tweens.add({
-            targets: [this.craneFlat.body],
-            y: target.craneFlatBodyY,
-            duration,
-            ease
         });
 
         this.game.tweens.add({
@@ -245,17 +254,10 @@ export default class CraneManager {
             targets: [this.controlPanel],
             y: target.controlPanelY,
             duration,
-            ease
+            ease,
+            onUpdate: syncPanelBody,
+            onComplete: syncPanelBody
         });
-
-        if (this.controlPanel.body) {
-            this.game.tweens.add({
-                targets: [this.controlPanel.body],
-                y: target.controlPanelBodyY,
-                duration,
-                ease
-            });
-        }
     }
 
 }

--- a/src/services/craneManager.js
+++ b/src/services/craneManager.js
@@ -1,3 +1,5 @@
+import LiftTerminal from './liftTerminal';
+
 function degrees_to_radians(degrees) {
     let pi = Math.PI;
     return degrees * (pi / 180);
@@ -12,6 +14,7 @@ export default class CraneManager {
         const width = (this.game.chasmRange[1] - this.game.chasmRange[0]) * 10;
         const platformX = (this.game.chasmRange[0] * 10) + width / 2;
         const platformY = (this.game.aboveGround * 10) + 10;
+        this.platformWidth = width;
         // this.craneFlat = this.game.add.image(1500, 210, 'wood');
         this.craneFlat = this.game.add.image(platformX, platformY, 'wood');
         this.craneFlat.setDisplaySize(width - 15, 5);
@@ -40,63 +43,73 @@ export default class CraneManager {
         this.ropeThree.setRotation(degrees_to_radians(-45))
         this.ropeThree.setDepth(2);
 
-        this.createPlatformButton(platformX, platformY);
+        this.createControlPanel(platformX, platformY);
 
-        // Snapshot the platform's surface position so the on-platform button
-        // can return the player to a pixel-perfect "back at the top" state.
+        // Snapshot initial visual state so "return to surface" via the
+        // terminal lands the platform exactly back where it started.
         this.surfaceState = this._snapshotState();
-        // Last activated wall-mounted lift point. Pressing the on-platform
-        // button toggles between this and the surface.
-        this.savedDeepState = null;
+
+        // Terminal owns rope length, resource count, and the level UI.
+        this.liftTerminal = new LiftTerminal(this);
     }
 
-    createPlatformButton(platformX, platformY) {
-        // Lift-control spritesheet: frame 0 idle, 1 going up, 2 going down.
-        this.platformButton = this.game.add.sprite(platformX, platformY - 7, 'lift-control');
-        this.platformButton.setDisplaySize(this.game.tileSize, this.game.tileSize);
-        this.platformButton.setDepth(4);
-        this.platformButton.setFrame(0);
-        this.game.liftControlGroup.add(this.platformButton);
+    createControlPanel(platformX, platformY) {
+        // Mining-rig control panel: lives on the right edge of the platform
+        // and opens the terminal when the player presses E next to it.
+        // Reuses the lift-control spritesheet (frames 0/1/2 = idle/up/down).
+        const panelX = platformX + (this.platformWidth / 2) - 12;
+        this.controlPanel = this.game.add.sprite(panelX, platformY - 7, 'lift-control');
+        this.controlPanel.setDisplaySize(this.game.tileSize, this.game.tileSize);
+        this.controlPanel.setDepth(4);
+        this.controlPanel.setFrame(0);
+        // Marker so the terminal can filter this entry out of the levels
+        // list — every other liftControlGroup member is a placed wall switch.
+        this.controlPanel.isPlatformPanel = true;
+        this.game.liftControlGroup.add(this.controlPanel);
 
-        this.platformButton.tileRef = {
-            callCrane: () => this.activatePlatformButton(),
+        this.controlPanel.tileRef = {
+            interactionText: 'Use Terminal',
+            callCrane: () => this.liftTerminal.toggle(),
             moving: (direction) => {
-                if (direction === 'up') {
-                    this.platformButton.setFrame(1);
-                } else if (direction === 'down') {
-                    this.platformButton.setFrame(2);
-                } else {
-                    this.platformButton.setFrame(0);
-                }
+                if (direction === 'up') this.controlPanel.setFrame(1);
+                else if (direction === 'down') this.controlPanel.setFrame(2);
+                else this.controlPanel.setFrame(0);
             },
-            // The hovered-block hooks expect these to exist on every tileRef.
+            // The hovered-block hooks expect these on every tileRef.
             onMouseEnter: () => {},
             onMouseLeave: () => {},
             onClick: () => {}
         };
     }
 
-    activatePlatformButton() {
-        if (this.moving) return;
-        const currentBodyY = this.craneFlat.body.y;
-        let target;
-        if (this.savedDeepState && Math.abs(currentBodyY - this.savedDeepState.craneFlatBodyY) > 1) {
-            target = this.savedDeepState;
-        } else if (Math.abs(currentBodyY - this.surfaceState.craneFlatBodyY) > 1) {
-            target = this.surfaceState;
-        } else {
-            return;
-        }
-        this._moveCrane(target, this.platformButton.tileRef);
+    surfaceWorldY() {
+        return this.surfaceState.craneFlatBodyY - 5;
     }
 
-    moveTo(y, liftControl) {
+    /**
+     * Travel to a level chosen from the on-platform terminal. Gated by the
+     * rig's current rope length so the player can't drop past their reach.
+     */
+    travelToLevel(y) {
+        if (this.moving) return;
+        if (!this.liftTerminal.canReach(y)) return;
         const target = this._stateForDepth(y);
-        // Remember any non-surface destination so the on-platform button can
-        // bring the player back to it after returning to the top.
-        if (Math.abs(target.craneFlatBodyY - this.surfaceState.craneFlatBodyY) > 1) {
-            this.savedDeepState = target;
+        this._moveCrane(target, this.controlPanel.tileRef);
+    }
+
+    /**
+     * Wall-mounted lift switches summon the platform to themselves as a
+     * "call lift here" beacon. Same rope-length gate as the terminal.
+     */
+    moveTo(y, liftControl) {
+        if (this.moving) return;
+        if (!this.liftTerminal.canReach(y)) {
+            // Out of rope — drop the call. TODO: visual/audio feedback so
+            // the player knows the rig can't reach here yet.
+            liftControl.moving();
+            return;
         }
+        const target = this._stateForDepth(y);
         this._moveCrane(target, liftControl);
     }
 
@@ -107,8 +120,8 @@ export default class CraneManager {
             ropeTwoY: this.ropeTwo.y,
             ropeThreeY: this.ropeThree.y,
             ropeHeight: this.rope.height,
-            platformButtonY: this.platformButton.y,
-            platformButtonBodyY: this.platformButton.body ? this.platformButton.body.y : this.platformButton.y
+            controlPanelY: this.controlPanel.y,
+            controlPanelBodyY: this.controlPanel.body ? this.controlPanel.body.y : this.controlPanel.y
         };
     }
 
@@ -119,8 +132,8 @@ export default class CraneManager {
             ropeTwoY: y - 10,
             ropeThreeY: y - 10,
             ropeHeight: y - this.rope.y - 15,
-            platformButtonY: y + 7.4 - 7,
-            platformButtonBodyY: y + 5 - 7
+            controlPanelY: y + 7.4 - 7,
+            controlPanelBodyY: y + 5 - 7
         };
     }
 
@@ -140,7 +153,7 @@ export default class CraneManager {
         this.game.tweens.add({
             targets: [this.craneFlat],
             y: target.craneFlatY,
-            duration: this.liftSpeed, // Duration in ms; adjust as needed
+            duration: this.liftSpeed,
             ease: 'ease-out',
             onComplete: () => {
                 liftControl.moving();
@@ -151,35 +164,35 @@ export default class CraneManager {
         this.game.tweens.add({
             targets: [this.craneFlat.body],
             y: target.craneFlatBodyY,
-            duration: this.liftSpeed, // Duration in ms; adjust as needed
+            duration: this.liftSpeed,
             ease: 'ease-out'
         });
 
         this.game.tweens.add({
             targets: [this.ropeTwo, this.ropeThree],
             y: target.ropeTwoY,
-            duration: this.liftSpeed, // Duration in ms; adjust as needed
+            duration: this.liftSpeed,
             ease: 'ease-out'
         });
 
         this.game.tweens.add({
             targets: [this.rope],
             height: target.ropeHeight,
-            duration: this.liftSpeed, // Duration in ms; adjust as needed
-            ease: 'ease-out'
-        });
-
-        this.game.tweens.add({
-            targets: [this.platformButton],
-            y: target.platformButtonY,
             duration: this.liftSpeed,
             ease: 'ease-out'
         });
 
-        if (this.platformButton.body) {
+        this.game.tweens.add({
+            targets: [this.controlPanel],
+            y: target.controlPanelY,
+            duration: this.liftSpeed,
+            ease: 'ease-out'
+        });
+
+        if (this.controlPanel.body) {
             this.game.tweens.add({
-                targets: [this.platformButton.body],
-                y: target.platformButtonBodyY,
+                targets: [this.controlPanel.body],
+                y: target.controlPanelBodyY,
                 duration: this.liftSpeed,
                 ease: 'ease-out'
             });

--- a/src/services/liftTerminal.js
+++ b/src/services/liftTerminal.js
@@ -267,13 +267,7 @@ export default class LiftTerminal {
         this.fields.extendIncrement.textContent = String(this.extendIncrement);
         this.fields.extendCost.textContent = String(this.extendCost);
 
-        // Levels are wall-mounted lift controls placed by the player along
-        // the shaft. The on-platform panel itself is filtered out via the
-        // isPlatformPanel marker that CraneManager sets on its sprite.
-        const levels = this.game.liftControlGroup.getChildren()
-            .filter(c => !c.isPlatformPanel)
-            .map(c => ({ entity: c, worldY: c.tileRef?.worldY ?? c.y }))
-            .sort((a, b) => a.worldY - b.worldY);
+        const levels = this._scanLevelsFromGrid();
 
         const list = this.fields.levels;
         list.innerHTML = '';
@@ -303,6 +297,48 @@ export default class LiftTerminal {
             });
             list.appendChild(btn);
         });
+    }
+
+    /**
+     * Scan the saved grid for every lift-control tile and dedupe by row.
+     *
+     * Sourcing from liftControlGroup only sees sprites in currently-loaded
+     * chunks, so faraway levels would disappear after the player descended.
+     * The grid is the source of truth and persists regardless of render
+     * distance. Lift controls are auto-placed on both chasm walls at the
+     * same Y, so we merge entries that share a row into a single level.
+     */
+    _scanLevelsFromGrid() {
+        const tileSize = this.game.tileSize;
+        const liftId = this.game.tileTypes?.liftControl?.id;
+        const grid = this.game.grid;
+        if (liftId == null || !grid) return [];
+
+        const seenRows = new Set();
+        const levels = [];
+
+        for (const chunkKey of Object.keys(grid)) {
+            const chunkArray = grid[chunkKey];
+            if (!chunkArray) continue;
+            const [chunkStartCellX, chunkStartCellY] = chunkKey.split('_').map(Number);
+            for (let cy = 0; cy < chunkArray.length; cy++) {
+                const row = chunkArray[cy];
+                if (!row) continue;
+                for (let cx = 0; cx < row.length; cx++) {
+                    const cell = row[cx];
+                    if (!cell || cell.id !== liftId) continue;
+                    const cellAbsY = chunkStartCellY + cy;
+                    if (seenRows.has(cellAbsY)) continue;
+                    seenRows.add(cellAbsY);
+                    levels.push({
+                        worldX: (chunkStartCellX + cx) * tileSize,
+                        worldY: cellAbsY * tileSize
+                    });
+                }
+            }
+        }
+        levels.sort((a, b) => a.worldY - b.worldY);
+        return levels;
     }
 
     destroy() {

--- a/src/services/liftTerminal.js
+++ b/src/services/liftTerminal.js
@@ -1,0 +1,313 @@
+// Mining-rig control terminal.
+//
+// Opens when the player interacts with the on-platform control panel.
+// Renders a Fallout-style green-on-black HTML overlay so the small
+// monospace text stays sharp regardless of the canvas zoom (same approach
+// the rest of the HUD uses, see src/services/uiManager.js).
+//
+// Crafting / upgrade hookups (TODO):
+// - "Metal rope" is the resource that extends the rig's reach. The flow we
+//   want long-term is: ore (existing mining system) -> smelt to ingots ->
+//   craft into metal rope segments -> consumed here when the player presses
+//   EXTEND ROPE.
+// - For now we hold a placeholder `metal` count on the terminal itself and
+//   deduct from it on extend. When the crafting/upgrade system lands, swap
+//   the placeholder reads/writes for real inventory ops at the marked
+//   spots below.
+// - `maxExtension` should also be persisted with the save game when the
+//   save system is updated to include rig state.
+
+const TERMINAL_GREEN = '#33ff33';
+const TERMINAL_DIM = '#1a8a1a';
+const TERMINAL_BG = 'rgba(0, 16, 0, 0.97)';
+const STYLE_ID = 'lift-terminal-styles';
+
+function injectStyles() {
+    if (document.getElementById(STYLE_ID)) return;
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://fonts.googleapis.com/css2?family=VT323&family=Share+Tech+Mono&display=swap';
+    document.head.appendChild(link);
+
+    const style = document.createElement('style');
+    style.id = STYLE_ID;
+    style.textContent = `
+        .lift-terminal {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            width: 480px;
+            max-height: 80vh;
+            overflow-y: auto;
+            background: ${TERMINAL_BG};
+            border: 2px solid ${TERMINAL_GREEN};
+            box-shadow: 0 0 30px rgba(51, 255, 51, 0.4),
+                        inset 0 0 60px rgba(51, 255, 51, 0.05);
+            font-family: 'VT323', 'Share Tech Mono', monospace;
+            color: ${TERMINAL_GREEN};
+            padding: 18px 22px 16px;
+            z-index: 2000;
+            text-shadow: 0 0 4px rgba(51, 255, 51, 0.6);
+            user-select: none;
+        }
+        .lift-terminal::after {
+            content: '';
+            position: absolute;
+            inset: 0;
+            background: repeating-linear-gradient(
+                to bottom,
+                rgba(0,0,0,0) 0,
+                rgba(0,0,0,0) 2px,
+                rgba(0,0,0,0.18) 2px,
+                rgba(0,0,0,0.18) 3px
+            );
+            pointer-events: none;
+        }
+        .lift-terminal-title {
+            font-size: 22px;
+            letter-spacing: 0.14em;
+            text-align: center;
+            margin: 0 0 2px;
+        }
+        .lift-terminal-sub {
+            font-size: 13px;
+            color: ${TERMINAL_DIM};
+            text-align: center;
+            margin-bottom: 12px;
+            letter-spacing: 0.2em;
+        }
+        .lift-terminal-section {
+            margin: 10px 0;
+            font-size: 16px;
+            line-height: 1.5;
+        }
+        .lift-terminal-section h3 {
+            font-size: 15px;
+            font-weight: normal;
+            margin: 0 0 4px 0;
+            border-bottom: 1px dashed ${TERMINAL_DIM};
+            padding-bottom: 2px;
+            letter-spacing: 0.12em;
+        }
+        .lift-terminal-row {
+            display: flex;
+            justify-content: space-between;
+        }
+        .lift-terminal-btn {
+            display: block;
+            width: 100%;
+            box-sizing: border-box;
+            background: transparent;
+            border: 1px solid ${TERMINAL_GREEN};
+            color: ${TERMINAL_GREEN};
+            font-family: inherit;
+            font-size: 16px;
+            text-align: left;
+            padding: 5px 10px;
+            margin: 4px 0;
+            cursor: pointer;
+            letter-spacing: 0.08em;
+            transition: background 80ms;
+            text-shadow: inherit;
+        }
+        .lift-terminal-btn:hover:not(:disabled) {
+            background: rgba(51, 255, 51, 0.15);
+        }
+        .lift-terminal-btn:disabled {
+            color: ${TERMINAL_DIM};
+            border-color: ${TERMINAL_DIM};
+            cursor: not-allowed;
+        }
+        .lift-terminal-btn .right { float: right; }
+        .lift-terminal-actions {
+            display: flex;
+            gap: 10px;
+            margin-top: 12px;
+        }
+        .lift-terminal-actions .lift-terminal-btn { margin: 0; flex: 1; }
+        .lift-terminal-empty {
+            color: ${TERMINAL_DIM};
+            font-size: 14px;
+            padding: 4px 0;
+        }
+    `;
+    document.head.appendChild(style);
+}
+
+export default class LiftTerminal {
+    constructor(craneManager) {
+        injectStyles();
+        this.craneManager = craneManager;
+        this.game = craneManager.game;
+        this.isOpen = false;
+
+        // TODO(crafting): replace placeholder with real metal-rope inventory.
+        // The player will craft rope segments from smelted ore and consume
+        // them here. For now, treat as fully stocked.
+        this.metal = 9999;
+        this.extendCost = 50;
+        this.extendIncrement = 100;
+        // How far below the surface the rig's rope can reach (world units).
+        // TODO(persistence): persist with save game once rig state is saved.
+        this.maxExtension = 0;
+
+        this.buildDom();
+
+        // Tear the DOM overlay down when the scene stops so we don't leak
+        // a stale terminal into the menu / next game.
+        this.game.events.once('shutdown', () => this.destroy());
+        this.game.events.once('destroy', () => this.destroy());
+    }
+
+    buildDom() {
+        const root = document.createElement('div');
+        root.className = 'lift-terminal';
+        root.style.display = 'none';
+        root.innerHTML = `
+            <div class="lift-terminal-title">ROOBOO MINING RIG / TERMINAL</div>
+            <div class="lift-terminal-sub">SYS-LINK ESTABLISHED</div>
+            <div class="lift-terminal-section">
+                <h3>RIG STATUS</h3>
+                <div class="lift-terminal-row"><span>CURRENT DEPTH</span><span data-field="depth">--</span></div>
+                <div class="lift-terminal-row"><span>ROPE LENGTH</span><span data-field="rope">--</span></div>
+                <div class="lift-terminal-row"><span>STATUS</span><span data-field="status">--</span></div>
+            </div>
+            <div class="lift-terminal-section">
+                <h3>RESOURCES</h3>
+                <div class="lift-terminal-row"><span>METAL ROPE STOCK</span><span data-field="metal">--</span></div>
+                <button class="lift-terminal-btn" data-action="extend">
+                    EXTEND ROPE +<span data-field="extendIncrement">--</span>m
+                    <span class="right">COST <span data-field="extendCost">--</span></span>
+                </button>
+            </div>
+            <div class="lift-terminal-section">
+                <h3>LEVELS</h3>
+                <div data-field="levels"></div>
+            </div>
+            <div class="lift-terminal-actions">
+                <button class="lift-terminal-btn" data-action="close">[ DISCONNECT ]</button>
+            </div>
+        `;
+        document.body.appendChild(root);
+        this.root = root;
+        this.fields = {
+            depth: root.querySelector('[data-field="depth"]'),
+            rope: root.querySelector('[data-field="rope"]'),
+            status: root.querySelector('[data-field="status"]'),
+            metal: root.querySelector('[data-field="metal"]'),
+            extendIncrement: root.querySelector('[data-field="extendIncrement"]'),
+            extendCost: root.querySelector('[data-field="extendCost"]'),
+            levels: root.querySelector('[data-field="levels"]'),
+        };
+
+        root.querySelector('[data-action="extend"]').addEventListener('click', () => this.extendRope());
+        root.querySelector('[data-action="close"]').addEventListener('click', () => this.close());
+
+        // Stop terminal-internal input from leaking to the canvas so the
+        // player doesn't swing tools / change toolbar slot while clicking
+        // through the menu.
+        const swallow = (e) => e.stopPropagation();
+        root.addEventListener('mousedown', swallow);
+        root.addEventListener('mouseup', swallow);
+        root.addEventListener('wheel', swallow);
+    }
+
+    toggle() {
+        if (this.isOpen) this.close(); else this.open();
+    }
+
+    open() {
+        if (this.isOpen) return;
+        this.isOpen = true;
+        this.game.freezePlayer = true;
+        this.root.style.display = 'block';
+        this.refresh();
+    }
+
+    close() {
+        if (!this.isOpen) return;
+        this.isOpen = false;
+        this.game.freezePlayer = false;
+        this.root.style.display = 'none';
+    }
+
+    extendRope() {
+        if (this.craneManager.moving) return;
+        if (this.metal < this.extendCost) return;
+        // TODO(crafting): deduct from real metal-rope inventory once available.
+        this.metal -= this.extendCost;
+        this.maxExtension += this.extendIncrement;
+        this.refresh();
+    }
+
+    travelTo(worldY) {
+        this.close();
+        this.craneManager.travelToLevel(worldY);
+    }
+
+    maxReachableY() {
+        return this.craneManager.surfaceWorldY() + this.maxExtension;
+    }
+
+    canReach(worldY) {
+        return worldY <= this.maxReachableY() + 1;
+    }
+
+    refresh() {
+        const cm = this.craneManager;
+        const surfaceY = cm.surfaceWorldY();
+        const currentY = cm.craneFlat.body.y - 5;
+        const currentDepth = Math.max(0, Math.round(currentY - surfaceY));
+
+        this.fields.depth.textContent = `-${currentDepth} M`;
+        this.fields.rope.textContent = `-${Math.round(this.maxExtension)} M`;
+        this.fields.status.textContent = cm.moving ? 'IN MOTION' : 'IDLE';
+        this.fields.metal.textContent = String(this.metal);
+        this.fields.extendIncrement.textContent = String(this.extendIncrement);
+        this.fields.extendCost.textContent = String(this.extendCost);
+
+        // Levels are wall-mounted lift controls placed by the player along
+        // the shaft. The on-platform panel itself is filtered out via the
+        // isPlatformPanel marker that CraneManager sets on its sprite.
+        const levels = this.game.liftControlGroup.getChildren()
+            .filter(c => !c.isPlatformPanel)
+            .map(c => ({ entity: c, worldY: c.tileRef?.worldY ?? c.y }))
+            .sort((a, b) => a.worldY - b.worldY);
+
+        const list = this.fields.levels;
+        list.innerHTML = '';
+
+        if (levels.length === 0) {
+            const empty = document.createElement('div');
+            empty.className = 'lift-terminal-empty';
+            empty.textContent = '> NO LIFT CONTROLS DETECTED IN SHAFT.';
+            list.appendChild(empty);
+            return;
+        }
+
+        levels.forEach((lvl, i) => {
+            const depth = Math.round(lvl.worldY - surfaceY);
+            const reachable = this.canReach(lvl.worldY);
+            const atHere = Math.abs(currentY - lvl.worldY) < 1;
+            const btn = document.createElement('button');
+            btn.className = 'lift-terminal-btn';
+            btn.disabled = !reachable || atHere || cm.moving;
+            const tag = !reachable ? 'LOCKED' : (atHere ? 'CURRENT' : 'TRAVEL');
+            const num = String(i + 1).padStart(2, '0');
+            const depthLabel = depth >= 0 ? `-${depth}m` : `+${-depth}m`;
+            btn.innerHTML =
+                `LVL ${num} &nbsp; ${depthLabel}<span class="right">[ ${tag} ]</span>`;
+            btn.addEventListener('click', () => {
+                if (!btn.disabled) this.travelTo(lvl.worldY);
+            });
+            list.appendChild(btn);
+        });
+    }
+
+    destroy() {
+        this.close();
+        this.root?.remove();
+        this.root = null;
+    }
+}

--- a/src/services/playerManager.js
+++ b/src/services/playerManager.js
@@ -34,6 +34,10 @@ export default class PlayerManager {
         this.game.playerHead.setDepth(1);
         this.game.player.setDepth(2);
         this.game.player.setBounce(0.2);
+        // Cap downward velocity so the player falls at a consistent speed
+        // instead of accelerating without limit. Gravity still pulls them
+        // toward this terminal velocity, then holds it steady.
+        this.game.player.body.maxVelocity.y = 100;
         this.headBaseY = 0;
         this.bobPhase = 0;
         this.wasGrounded = true;


### PR DESCRIPTION
## Summary
Implements a Fallout-style terminal interface for controlling the mining rig's descent depth, along with a rope extension mechanic that gates how far below the surface the platform can travel.

## Key Changes

- **New LiftTerminal service** (`src/services/liftTerminal.js`): 
  - Renders a green-on-black retro terminal overlay with Fallout aesthetic
  - Displays rig status (current depth, rope length, movement state)
  - Shows discovered lift-control levels scanned from the game grid
  - Implements rope extension system with resource cost (placeholder metal inventory)
  - Prevents player input leakage to canvas while terminal is open

- **Enhanced CraneManager** (`src/services/craneManager.js`):
  - Refactored lift movement to use constant velocity (12ms per unit) instead of fixed duration
  - Added `travelToLevel()` for terminal-initiated descents
  - Integrated rope-length gating: lift calls are rejected if target exceeds `maxExtension`
  - Implemented player-sticking logic in `update()` to keep player on platform during descent
  - Added control panel sprite on the platform that opens the terminal
  - Snapshot surface state on initialization for "return to surface" functionality
  - Synchronized sprite and body positions during tweens to prevent visual stutter

- **Control Panel Integration** (`src/services/craneManager.js`):
  - Platform-mounted control panel sprite with interaction text
  - Implements `tileRef` interface for seamless integration with existing interaction system
  - Animates frame changes (idle/up/down) to reflect lift movement direction

- **Interaction System Updates** (`src/services/controls.js`):
  - Added secondary interaction support (Q key) for lift controls
  - Extended interaction prompts to show both primary and secondary actions
  - Made interaction text dynamic based on tile type

- **LiftControl Enhancements** (`src/classes/liftControl.js`):
  - Added `teleportToLift()` method for Q-key secondary action
  - Implemented `secondaryInteractionText` and `secondaryAction()` properties
  - Added `interactionText` getter for dynamic prompt display

- **Player Manager** (`src/services/playerManager.js`):
  - Added terminal velocity cap for consistent falling speed

## Notable Implementation Details

- Terminal scans the game grid directly (not sprite groups) to find lift-control tiles, ensuring faraway levels remain accessible even after chunks unload
- Lift-control tiles on both chasm walls at the same Y-coordinate are deduplicated into single level entries
- Rope extension uses placeholder `metal` inventory; designed to swap for real crafting system once available
- Linear easing on lift tweens creates constant-velocity movement that feels mechanical rather than animated
- Player snapping to platform only occurs when horizontally overlapped, not actively jumping, and the platform has dropped below them

https://claude.ai/code/session_01LvWaqo3d9UJ9mCzsWTDdvx