### PR TITLE
Add fog of war, minimap, and interactive world map systems

### DIFF
--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -225,6 +225,10 @@ export default class GameScene extends Phaser.Scene {
         if (this.newGame) {
             this.mapService.generateMap();
         }
+        // Patch top-of-shaft wall switches into the grid for both new and
+        // pre-existing saves so the player always has a "call lift to
+        // surface" point at the very top.
+        this.mapService.ensureSurfaceLiftControls();
 
         window.setTimeout(async () => {
             this.playerManager = new PlayerManager(this);

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -382,10 +382,6 @@ export default class GameScene extends Phaser.Scene {
             this.lightingManager.updateLighting(delta);
             this.interactableGroup = [...this.liftControlGroup.getChildren()];
             this.uiManager.updateUI();
-            const playerOffset = 0;
-            const playerX = this.player.x + playerOffset;
-            const playerY = this.player.y + playerOffset;
-            this.playerLight.setPosition(Math.round(playerX), Math.round(playerY));
             this.craneManager?.update();
             if (this.glowSticks.length) {
                 this.glowSticks.forEach(glowStick => glowStick.update());

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -422,6 +422,11 @@ export default class GameScene extends Phaser.Scene {
             if (this.mineCartGroup.getChildren().length) {
                 this.mineCartGroup.getChildren().forEach(mineCart => mineCart.cartRef.update());
             }
+            // Crane runs first so the player's sprite + body Y are pinned
+            // to the lift before handlePlayerMovement reads body.y to
+            // place the head and tool sprites — otherwise the head lags
+            // the player by one frame and produces visible stutter.
+            this.craneManager?.update();
             this.controlsManager.handlePlayerMovement();
             this.playerManager.updateVisuals(time, delta);
             if (this.ambientMoteEmitter) {
@@ -433,7 +438,6 @@ export default class GameScene extends Phaser.Scene {
             this.revealFogAroundPlayer(time);
             this.minimapManager?.update(time);
             this.mapViewManager?.draw();
-            this.craneManager?.update();
             if (this.glowSticks.length) {
                 this.glowSticks.forEach(glowStick => glowStick.update());
             }

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -11,6 +11,8 @@ import InventoryManager from "../services/InventoryManager";
 import InventoryItem from "../classes/InventoryItem";
 import CraneManager from "../services/craneManager";
 import MinimapManager from "../services/minimapManager";
+import MapViewManager from "../services/mapViewManager";
+import FogOfWar from "../services/fogOfWar";
 
 const batchSize = 100;
 let currentIndex = 0;
@@ -241,8 +243,18 @@ export default class GameScene extends Phaser.Scene {
             // this.physics.add.collider(this.player, this.glowStickGroup);
             this.toolBarManager = new ToolbarManager(this);
             this.defaultGravityY = this.player.body.gravity.y;
+            this.fogOfWar = new FogOfWar(this.mapWidth, this.mapHeight);
+            if (this.savedFog) {
+                this.fogOfWar.deserialize(this.savedFog);
+                this.savedFog = null;
+            }
+            this.fogRevealRadius = 12;
+            this._lastFogRevealMs = 0;
+            this.mapMarkers = this.savedMarkers || [];
+            this.savedMarkers = null;
             this.uiManager = new UiManager(this);
             this.minimapManager = new MinimapManager(this);
+            this.mapViewManager = new MapViewManager(this);
             this.toolBarManager.addItemToSlot(0, pickaxe);
             // this.toolBarManager.addItemToSlot(1, glowStick);
             this.toolBarManager.addItemToSlot(2, lamp);
@@ -304,18 +316,25 @@ export default class GameScene extends Phaser.Scene {
     async saveGame(user, gridData) {
         try {
             const compressedData = LZString.compressToUTF16(JSON.stringify(gridData));
+            const fog = this.fogOfWar?.serialize() || null;
+            const markers = this.mapMarkers || [];
 
             if (this.electronAPI?.isElectron) {
-                await this.electronAPI.saveGame({grid: gridData, playerData: {x: this.player.x, y: this.player.y}});
+                await this.electronAPI.saveGame({
+                    grid: gridData,
+                    playerData: {x: this.player.x, y: this.player.y},
+                    fog,
+                    markers,
+                });
             } else {
-                await this.saveGameToCloud(user, compressedData);
+                await this.saveGameToCloud(user, compressedData, fog, markers);
             }
         } catch (error) {
             console.error("Error saving game:", error);
         }
     }
 
-    async saveGameToCloud(user, gridData) {
+    async saveGameToCloud(user, gridData, fog, markers) {
         if (!user) {
             console.error("User not authenticated");
             return;
@@ -327,13 +346,28 @@ export default class GameScene extends Phaser.Scene {
         const playerSaveRef = doc(db, "game_saves", user.uid, "player_data", "position");
 
         batch.set(gameSaveRef, {data: gridData});
-        batch.set(playerSaveRef, {x: this.player.x, y: this.player.y});
+        batch.set(playerSaveRef, {
+            x: this.player.x,
+            y: this.player.y,
+            fog: fog || null,
+            markers: markers || [],
+        });
 
         try {
-            await batch.commit(); // Execute the batch write
+            await batch.commit();
         } catch (error) {
             console.error("Error saving data: ", error);
         }
+    }
+
+    revealFogAroundPlayer(time) {
+        if (!this.fogOfWar || !this.player) return;
+        if (time - this._lastFogRevealMs < 90) return;
+        this._lastFogRevealMs = time;
+        const tileSize = this.tileSize || 10;
+        const tx = Math.floor(this.player.x / tileSize);
+        const ty = Math.floor(this.player.y / tileSize);
+        this.fogOfWar.revealCircle(tx, ty, this.fogRevealRadius);
     }
 
     convertValuesToStrings(obj) {
@@ -357,10 +391,22 @@ export default class GameScene extends Phaser.Scene {
             }
 
             this.newGame = data.newGame;
-            if (data.playerData?.length > 0 && !data.newGame) {
-                this.playerX = Math.round(data.playerData[0].x);
-                this.playerY = Math.round(data.playerData[0].y);
+            if (data.playerData && !data.newGame) {
+                let positionDoc = null;
+                if (Array.isArray(data.playerData) && data.playerData.length > 0) {
+                    positionDoc = data.playerData.find(d => d.id === 'position') || data.playerData[0];
+                } else if (typeof data.playerData === 'object') {
+                    positionDoc = data.playerData;
+                }
+                if (positionDoc) {
+                    if (positionDoc.x != null) this.playerX = Math.round(positionDoc.x);
+                    if (positionDoc.y != null) this.playerY = Math.round(positionDoc.y);
+                    if (positionDoc.fog) this.savedFog = positionDoc.fog;
+                    if (Array.isArray(positionDoc.markers)) this.savedMarkers = positionDoc.markers;
+                }
             }
+            if (!data.newGame && data.fog) this.savedFog = data.fog;
+            if (!data.newGame && Array.isArray(data.markers)) this.savedMarkers = data.markers;
 
             this.user = data.user;
         }
@@ -384,7 +430,9 @@ export default class GameScene extends Phaser.Scene {
             this.lightingManager.updateLighting(delta);
             this.interactableGroup = [...this.liftControlGroup.getChildren()];
             this.uiManager.updateUI();
+            this.revealFogAroundPlayer(time);
             this.minimapManager?.update(time);
+            this.mapViewManager?.draw();
             this.craneManager?.update();
             if (this.glowSticks.length) {
                 this.glowSticks.forEach(glowStick => glowStick.update());

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -10,6 +10,7 @@ import ToolbarManager from "../services/toolBarManager";
 import InventoryManager from "../services/InventoryManager";
 import InventoryItem from "../classes/InventoryItem";
 import CraneManager from "../services/craneManager";
+import MinimapManager from "../services/minimapManager";
 
 const batchSize = 100;
 let currentIndex = 0;
@@ -241,6 +242,7 @@ export default class GameScene extends Phaser.Scene {
             this.toolBarManager = new ToolbarManager(this);
             this.defaultGravityY = this.player.body.gravity.y;
             this.uiManager = new UiManager(this);
+            this.minimapManager = new MinimapManager(this);
             this.toolBarManager.addItemToSlot(0, pickaxe);
             // this.toolBarManager.addItemToSlot(1, glowStick);
             this.toolBarManager.addItemToSlot(2, lamp);
@@ -382,6 +384,7 @@ export default class GameScene extends Phaser.Scene {
             this.lightingManager.updateLighting(delta);
             this.interactableGroup = [...this.liftControlGroup.getChildren()];
             this.uiManager.updateUI();
+            this.minimapManager?.update(time);
             this.craneManager?.update();
             if (this.glowSticks.length) {
                 this.glowSticks.forEach(glowStick => glowStick.update());

--- a/src/scenes/MenuScene.js
+++ b/src/scenes/MenuScene.js
@@ -559,6 +559,8 @@ export default class MenuScene extends Phaser.Scene {
             this.scene.start("GameScene", {
                 grid: this.savedData.grid,
                 playerData: this.savedData.playerData,
+                fog: this.savedData.fog,
+                markers: this.savedData.markers,
             });
         } else {
             await this.loadGameFromCloud();

--- a/src/services/controls.js
+++ b/src/services/controls.js
@@ -110,9 +110,6 @@ export default class ControlsManager {
             if (e.key === "c") {
                 this.game.glowStickCol = (this.game.glowStickCol + 1) % this.game.glowStickCols.length;
             }
-            if (e.key === "t") {
-                this.game.playerLight.off = !this.game.playerLight.off;
-            }
             if (e.key === "p") {
                 this.game.playerManager.teleportTo()
             }

--- a/src/services/craneManager.js
+++ b/src/services/craneManager.js
@@ -107,37 +107,66 @@ export default class CraneManager {
 
     /**
      * Per-frame upkeep. The platform's static body is tweened, but Phaser
-     * Arcade has no concept of "moving platforms" — when the lift descends
-     * faster than gravity, the player gets left in mid-air for a beat and
-     * then catches up. This sticks the player to the platform top whenever
-     * they're horizontally over it and not actively jumping, so descending
-     * trips look continuous.
+     * Arcade has no concept of "moving platforms" — and the platform body is
+     * only 5px thick, so when it ascends faster than collision resolution
+     * can push the player, they tunnel through and fall below. To make
+     * trips feel solid, carry the player along with the platform manually
+     * on both up and down trips: zero their vertical velocity and pin their
+     * sprite to the lift top whenever they're horizontally over it and not
+     * actively jumping. Arcade's preUpdate copies the sprite into the body
+     * each frame, so writing to `player.y` (not `body.y`) is what sticks.
      */
     update() {
+        const lift = this.craneFlat;
+        if (!lift?.body) {
+            this._lastLiftBodyY = null;
+            return;
+        }
+
+        const liftBodyY = lift.body.y;
+        const prevLiftBodyY = this._lastLiftBodyY;
+        this._lastLiftBodyY = liftBodyY;
+
         if (!this.moving) return;
         const player = this.game.player;
-        const lift = this.craneFlat;
-        if (!player?.body || !lift?.body) return;
+        if (!player?.body) return;
 
         const halfLiftW = lift.body.width / 2;
         const halfPlayerW = player.body.width / 2;
         const horizOverlap = Math.abs(player.x - lift.x) <= halfLiftW + halfPlayerW;
         if (!horizOverlap) return;
 
-        const playerBottom = player.body.y + player.body.height;
-        const liftTop = lift.body.y;
-        const gap = liftTop - playerBottom;
+        // Player is jumping off — let Arcade physics take over.
+        if (player.body.velocity.y < -10) return;
 
-        // Only snap when the lift has dropped out from under the player
-        // and they aren't moving upward (jumping / being pushed). Negative
-        // gap means the collider is already resolving an overlap, so leave
-        // it alone.
-        if (gap > 0 && gap <= 16 && player.body.velocity.y >= 0) {
-            // Set the sprite, not the body — Arcade's preUpdate copies the
-            // sprite into the body each frame, so body.y assignments get
-            // clobbered and produce the visible stutter.
-            player.y = liftTop - player.body.height / 2;
+        const playerBottom = player.body.y + player.body.height;
+        // Generous tolerance so a frame hitch (which can move the platform
+        // many pixels in one tick) doesn't drop the player off the rig.
+        const tolerance = 16;
+
+        // Treat the player as "riding" if they were sitting on the platform
+        // either before or after the tween's last position update. Either
+        // bound catches the player whether the lift is rising into them or
+        // dropping away beneath them.
+        const wasOnTop = prevLiftBodyY != null && Math.abs(playerBottom - prevLiftBodyY) <= tolerance;
+        const isOnTop = Math.abs(playerBottom - liftBodyY) <= tolerance;
+
+        if (wasOnTop || isOnTop) {
+            player.y = liftBodyY - player.body.height / 2;
             player.body.velocity.y = 0;
+            return;
+        }
+
+        // Lift descended out from under a stationary player — close gaps up
+        // to ~16px so a brief lag still ends with them standing on the
+        // platform instead of in mid-air.
+        const dy = prevLiftBodyY != null ? liftBodyY - prevLiftBodyY : 0;
+        if (dy > 0) {
+            const gap = liftBodyY - playerBottom;
+            if (gap > 0 && gap <= 16 && player.body.velocity.y >= 0) {
+                player.y = liftBodyY - player.body.height / 2;
+                player.body.velocity.y = 0;
+            }
         }
     }
 

--- a/src/services/craneManager.js
+++ b/src/services/craneManager.js
@@ -106,68 +106,73 @@ export default class CraneManager {
     }
 
     /**
-     * Per-frame upkeep. The platform's static body is tweened, but Phaser
-     * Arcade has no concept of "moving platforms" — and the platform body is
-     * only 5px thick, so when it ascends faster than collision resolution
-     * can push the player, they tunnel through and fall below. To make
-     * trips feel solid, carry the player along with the platform manually
-     * on both up and down trips: zero their vertical velocity and pin their
-     * sprite to the lift top whenever they're horizontally over it and not
-     * actively jumping. Arcade's preUpdate copies the sprite into the body
-     * each frame, so writing to `player.y` (not `body.y`) is what sticks.
+     * While the platform is moving and the player is on it, lock them to
+     * the lift's top each frame. The player is captured as a "rider" the
+     * first frame they're detected on the platform (here or in
+     * `_moveCrane`), which flips `freezePlayer` so input/gravity/Arcade
+     * collision are all suspended for the trip — much more reliable than
+     * asking Arcade to keep resolving collisions against a 5px static body
+     * that moves several pixels per frame. Both `player.y` (used for
+     * render) and `player.body.y` (read by `handlePlayerMovement` for
+     * head/tool placement in the same frame) are written so everything
+     * stays in sync.
      */
     update() {
         const lift = this.craneFlat;
-        if (!lift?.body) {
-            this._lastLiftBodyY = null;
-            return;
-        }
-
-        const liftBodyY = lift.body.y;
-        const prevLiftBodyY = this._lastLiftBodyY;
-        this._lastLiftBodyY = liftBodyY;
-
+        if (!lift?.body) return;
         if (!this.moving) return;
+
         const player = this.game.player;
         if (!player?.body) return;
 
+        if (!this.playerRiding) {
+            const halfLiftW = lift.body.width / 2;
+            const halfPlayerW = player.body.width / 2;
+            const horizOverlap = Math.abs(player.x - lift.x) <= halfLiftW + halfPlayerW;
+            const playerBottom = player.body.y + player.body.height;
+            // Only attach when the player is actually standing on the
+            // platform — within a few px of its top and not moving upward.
+            const onTop = horizOverlap
+                && Math.abs(playerBottom - lift.body.y) <= 8
+                && player.body.velocity.y >= 0;
+            if (!onTop) return;
+            this._captureRider();
+        }
+
+        const liftTop = lift.body.y;
+        player.y = liftTop - player.body.height / 2;
+        player.body.y = liftTop - player.body.height;
+        player.body.velocity.x = 0;
+        player.body.velocity.y = 0;
+    }
+
+    _captureRider() {
+        if (this.playerRiding) return;
+        this.playerRiding = true;
+        this._priorFreezePlayer = !!this.game.freezePlayer;
+        this.game.freezePlayer = true;
+        this.game.player.anims?.play('stationary', true);
+    }
+
+    _releaseRider() {
+        if (!this.playerRiding) return;
+        this.playerRiding = false;
+        this.game.freezePlayer = this._priorFreezePlayer;
+        this._priorFreezePlayer = false;
+    }
+
+    _tryCaptureRiderAtStart() {
+        const player = this.game.player;
+        const lift = this.craneFlat;
+        if (!player?.body || !lift?.body) return;
         const halfLiftW = lift.body.width / 2;
         const halfPlayerW = player.body.width / 2;
         const horizOverlap = Math.abs(player.x - lift.x) <= halfLiftW + halfPlayerW;
-        if (!horizOverlap) return;
-
-        // Player is jumping off — let Arcade physics take over.
-        if (player.body.velocity.y < -10) return;
-
         const playerBottom = player.body.y + player.body.height;
-        // Generous tolerance so a frame hitch (which can move the platform
-        // many pixels in one tick) doesn't drop the player off the rig.
-        const tolerance = 16;
-
-        // Treat the player as "riding" if they were sitting on the platform
-        // either before or after the tween's last position update. Either
-        // bound catches the player whether the lift is rising into them or
-        // dropping away beneath them.
-        const wasOnTop = prevLiftBodyY != null && Math.abs(playerBottom - prevLiftBodyY) <= tolerance;
-        const isOnTop = Math.abs(playerBottom - liftBodyY) <= tolerance;
-
-        if (wasOnTop || isOnTop) {
-            player.y = liftBodyY - player.body.height / 2;
-            player.body.velocity.y = 0;
-            return;
-        }
-
-        // Lift descended out from under a stationary player — close gaps up
-        // to ~16px so a brief lag still ends with them standing on the
-        // platform instead of in mid-air.
-        const dy = prevLiftBodyY != null ? liftBodyY - prevLiftBodyY : 0;
-        if (dy > 0) {
-            const gap = liftBodyY - playerBottom;
-            if (gap > 0 && gap <= 16 && player.body.velocity.y >= 0) {
-                player.y = liftBodyY - player.body.height / 2;
-                player.body.velocity.y = 0;
-            }
-        }
+        // 16px to forgive small jitter and the player just-grounded after
+        // landing on the lift.
+        const onTop = horizOverlap && Math.abs(playerBottom - lift.body.y) <= 16;
+        if (onTop) this._captureRider();
     }
 
     /**
@@ -233,6 +238,10 @@ export default class CraneManager {
             return;
         }
         this.moving = true;
+        // Capture the player as a rider up-front if they're standing on
+        // the platform when the trip begins. Late joiners (walking onto a
+        // moving lift) are caught by the per-frame check in update().
+        this._tryCaptureRiderAtStart();
 
         const distance = Math.abs(target.craneFlatBodyY - currentBodyY);
         const duration = Math.max(this.liftMinDurationMs, distance * this.liftMsPerUnit);
@@ -262,6 +271,7 @@ export default class CraneManager {
                 syncCraneBody();
                 liftControl.moving();
                 this.moving = false;
+                this._releaseRider();
             }
         });
 

--- a/src/services/fogOfWar.js
+++ b/src/services/fogOfWar.js
@@ -1,0 +1,66 @@
+// Bit-packed exploration tracking. Each tile in the world has one bit; set
+// once the tile has been within the player's reveal radius. Persisted as a
+// base64-encoded byte array on save.
+
+export default class FogOfWar {
+    constructor(width, height) {
+        this.width = width;
+        this.height = height;
+        this.totalBits = width * height;
+        this.bytes = new Uint8Array(Math.ceil(this.totalBits / 8));
+        this.version = 1;
+    }
+
+    has(tx, ty) {
+        if (tx < 0 || ty < 0 || tx >= this.width || ty >= this.height) return false;
+        const idx = ty * this.width + tx;
+        return (this.bytes[idx >> 3] & (1 << (idx & 7))) !== 0;
+    }
+
+    set(tx, ty) {
+        if (tx < 0 || ty < 0 || tx >= this.width || ty >= this.height) return false;
+        const idx = ty * this.width + tx;
+        const byteIdx = idx >> 3;
+        const mask = 1 << (idx & 7);
+        if ((this.bytes[byteIdx] & mask) === 0) {
+            this.bytes[byteIdx] |= mask;
+            this.version++;
+            return true;
+        }
+        return false;
+    }
+
+    revealCircle(tx, ty, radius) {
+        const r2 = radius * radius;
+        for (let dy = -radius; dy <= radius; dy++) {
+            for (let dx = -radius; dx <= radius; dx++) {
+                if (dx * dx + dy * dy <= r2) {
+                    this.set(tx + dx, ty + dy);
+                }
+            }
+        }
+    }
+
+    serialize() {
+        let binary = '';
+        const chunk = 0x8000;
+        for (let i = 0; i < this.bytes.length; i += chunk) {
+            binary += String.fromCharCode.apply(null, this.bytes.subarray(i, i + chunk));
+        }
+        return btoa(binary);
+    }
+
+    deserialize(b64) {
+        if (!b64) return;
+        try {
+            const binary = atob(b64);
+            const len = Math.min(binary.length, this.bytes.length);
+            for (let i = 0; i < len; i++) {
+                this.bytes[i] = binary.charCodeAt(i);
+            }
+            this.version++;
+        } catch (err) {
+            console.warn('Failed to load fog of war', err);
+        }
+    }
+}

--- a/src/services/map.js
+++ b/src/services/map.js
@@ -148,6 +148,34 @@ export default class MapService {
         // this.setRandomElement(this.game.tileTypes.stone, 100000);
     }
 
+    /**
+     * Ensure both chasm walls have a lift-control switch at the surface
+     * row (the platform's home depth). Idempotent and safe to call on
+     * loaded saves — tiles are only swapped in when the cell isn't
+     * already a lift control, so existing wiring is preserved.
+     */
+    ensureSurfaceLiftControls() {
+        const liftId = this.game.tileTypes?.liftControl?.id;
+        const grid = this.game.grid;
+        if (liftId == null || !grid) return;
+        const ty = this.game.aboveGround + 1;
+        const cs = this.game.chunkSize;
+        const walls = [this.game.chasmRange[0], this.game.chasmRange[1]];
+        for (const tx of walls) {
+            const chunkX = Math.floor(tx / cs) * cs;
+            const chunkY = Math.floor(ty / cs) * cs;
+            const chunk = grid[`${chunkX}_${chunkY}`];
+            if (!chunk) continue;
+            const localX = tx % cs;
+            const localY = ty % cs;
+            const row = chunk[localY];
+            if (!row) continue;
+            const cell = row[localX];
+            if (!cell || cell.id === liftId) continue;
+            row[localX] = { ...this.game.tileTypes.liftControl };
+        }
+    }
+
     updateRegion(xStart, xEnd, tileType) {
         // Loop over every cell column from xStart to xEnd.
         for (let cellX = xStart; cellX <= xEnd; cellX++) {

--- a/src/services/mapViewManager.js
+++ b/src/services/mapViewManager.js
@@ -1,0 +1,486 @@
+import { HUD } from './uiManager.js';
+
+const TILE_COLORS = {
+    1: '#5a3d2b',
+    2: '#2c5d8a',
+    3: '#6f6f6f',
+    4: '#ffd76a',
+    5: '#a07a4f',
+    6: '#9aa3aa',
+    7: '#5b9dff',
+};
+const SKY_COLOR = 'rgba(58, 78, 110, 0.6)';
+const VOID_COLOR = 'rgba(8, 10, 15, 1)';
+const FOG_COLOR = 'rgba(8, 10, 15, 1)';
+
+const MARKER_PALETTE = ['#ef4444', '#f59e0b', '#22c55e', '#5b9dff', '#a855f7', '#ec4899', '#eab308'];
+
+export default class MapViewManager {
+    constructor(scene) {
+        this.game = scene;
+        this.visible = false;
+        this.scale = 2;
+        this.minScale = 1;
+        this.maxScale = 8;
+        this.cameraTileX = 0;
+        this.cameraTileY = 0;
+        this.dragging = false;
+        this.dragStart = null;
+        this.dragMoved = false;
+        this.markerColorIndex = 0;
+        this.cacheCanvas = null;
+        this.cacheFogVersion = -1;
+        this.create();
+        this.attachInputs();
+    }
+
+    get markers() {
+        if (!this.game.mapMarkers) this.game.mapMarkers = [];
+        return this.game.mapMarkers;
+    }
+
+    create() {
+        const overlay = document.createElement('div');
+        overlay.id = 'mapViewOverlay';
+        Object.assign(overlay.style, {
+            position: 'fixed',
+            inset: '0',
+            display: 'none',
+            zIndex: '2500',
+            background: 'radial-gradient(ellipse at center, rgba(10,12,18,0.92) 0%, rgba(0,0,0,0.96) 100%)',
+            backdropFilter: 'blur(6px) saturate(110%)',
+            WebkitBackdropFilter: 'blur(6px) saturate(110%)',
+            opacity: '0',
+            transition: 'opacity 160ms ease',
+            fontFamily: HUD.font,
+        });
+        this.overlay = overlay;
+
+        const header = document.createElement('div');
+        Object.assign(header.style, {
+            position: 'absolute',
+            top: '20px',
+            left: '50%',
+            transform: 'translateX(-50%)',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '10px',
+            padding: '10px 18px',
+            background: HUD.panelBg,
+            border: HUD.panelBorder,
+            borderRadius: HUD.panelRadius,
+            backdropFilter: HUD.panelBlur,
+            WebkitBackdropFilter: HUD.panelBlur,
+            boxShadow: HUD.panelShadow,
+        });
+        const title = document.createElement('div');
+        title.textContent = 'World Map';
+        Object.assign(title.style, {
+            fontSize: '13px',
+            fontWeight: '600',
+            color: HUD.text,
+            letterSpacing: '0.10em',
+            textTransform: 'uppercase',
+        });
+        header.appendChild(title);
+        const dot = document.createElement('span');
+        Object.assign(dot.style, {
+            width: '5px', height: '5px', borderRadius: '50%',
+            background: HUD.accent, boxShadow: `0 0 8px ${HUD.accent}`,
+        });
+        header.insertBefore(dot, title);
+        overlay.appendChild(header);
+
+        const hint = document.createElement('div');
+        hint.innerHTML = `
+            <span><kbd style="${kbdStyle()}">M</kbd> close</span>
+            <span><kbd style="${kbdStyle()}">drag</kbd> pan</span>
+            <span><kbd style="${kbdStyle()}">scroll</kbd> zoom</span>
+            <span><kbd style="${kbdStyle()}">click</kbd> add marker</span>
+            <span><kbd style="${kbdStyle()}">right click</kbd> remove</span>
+            <span><kbd style="${kbdStyle()}">C</kbd> cycle color</span>
+        `;
+        Object.assign(hint.style, {
+            position: 'absolute',
+            bottom: '20px',
+            left: '50%',
+            transform: 'translateX(-50%)',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '14px',
+            padding: '8px 16px',
+            background: HUD.panelBg,
+            border: HUD.panelBorder,
+            borderRadius: HUD.panelRadius,
+            backdropFilter: HUD.panelBlur,
+            WebkitBackdropFilter: HUD.panelBlur,
+            color: HUD.textMuted,
+            fontSize: '11px',
+            letterSpacing: '0.04em',
+        });
+        overlay.appendChild(hint);
+
+        this.colorChip = document.createElement('div');
+        Object.assign(this.colorChip.style, {
+            position: 'absolute',
+            top: '20px',
+            right: '20px',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '8px',
+            padding: '8px 12px',
+            background: HUD.panelBg,
+            border: HUD.panelBorder,
+            borderRadius: HUD.panelRadius,
+            backdropFilter: HUD.panelBlur,
+            WebkitBackdropFilter: HUD.panelBlur,
+            color: HUD.textMuted,
+            fontSize: '11px',
+            letterSpacing: '0.04em',
+        });
+        const swatch = document.createElement('span');
+        swatch.id = 'mapMarkerSwatch';
+        Object.assign(swatch.style, {
+            width: '14px', height: '14px', borderRadius: '4px',
+            border: '1px solid rgba(255,255,255,0.18)',
+            background: MARKER_PALETTE[0],
+        });
+        const swLabel = document.createElement('span');
+        swLabel.textContent = 'MARKER';
+        this.colorChip.appendChild(swatch);
+        this.colorChip.appendChild(swLabel);
+        this.swatch = swatch;
+        overlay.appendChild(this.colorChip);
+
+        this.coordLabel = document.createElement('div');
+        Object.assign(this.coordLabel.style, {
+            position: 'absolute',
+            top: '20px',
+            left: '20px',
+            padding: '8px 12px',
+            background: HUD.panelBg,
+            border: HUD.panelBorder,
+            borderRadius: HUD.panelRadius,
+            backdropFilter: HUD.panelBlur,
+            WebkitBackdropFilter: HUD.panelBlur,
+            color: HUD.textMuted,
+            fontFamily: HUD.fontMono,
+            fontSize: '11px',
+            letterSpacing: '0.04em',
+        });
+        this.coordLabel.textContent = 'X 0  Y 0';
+        overlay.appendChild(this.coordLabel);
+
+        this.canvas = document.createElement('canvas');
+        Object.assign(this.canvas.style, {
+            position: 'absolute',
+            inset: '0',
+            width: '100%',
+            height: '100%',
+            cursor: 'crosshair',
+            imageRendering: 'pixelated',
+        });
+        overlay.appendChild(this.canvas);
+        this.ctx = this.canvas.getContext('2d');
+
+        document.body.appendChild(overlay);
+    }
+
+    attachInputs() {
+        document.addEventListener('keydown', (e) => {
+            if (e.key.toLowerCase() === 'm') {
+                this.toggle();
+                return;
+            }
+            if (!this.visible) return;
+            if (e.key === 'Escape') this.toggle();
+            if (e.key.toLowerCase() === 'c') {
+                this.markerColorIndex = (this.markerColorIndex + 1) % MARKER_PALETTE.length;
+                this.swatch.style.background = MARKER_PALETTE[this.markerColorIndex];
+            }
+        });
+
+        window.addEventListener('resize', () => { if (this.visible) this.resizeCanvas(); });
+
+        this.canvas.addEventListener('mousedown', (e) => {
+            if (e.button === 2) {
+                this.handleRightClick(e);
+                return;
+            }
+            this.dragging = true;
+            this.dragMoved = false;
+            this.dragStart = { x: e.clientX, y: e.clientY, camX: this.cameraTileX, camY: this.cameraTileY };
+        });
+        this.canvas.addEventListener('contextmenu', (e) => e.preventDefault());
+        window.addEventListener('mousemove', (e) => {
+            if (!this.visible) return;
+            this.updateCoordLabel(e.clientX, e.clientY);
+            if (!this.dragging) return;
+            const dx = e.clientX - this.dragStart.x;
+            const dy = e.clientY - this.dragStart.y;
+            if (Math.abs(dx) + Math.abs(dy) > 3) this.dragMoved = true;
+            this.cameraTileX = this.dragStart.camX - dx / this.scale;
+            this.cameraTileY = this.dragStart.camY - dy / this.scale;
+            this.clampCamera();
+            this.draw();
+        });
+        window.addEventListener('mouseup', (e) => {
+            if (!this.visible || !this.dragging) return;
+            this.dragging = false;
+            if (!this.dragMoved && e.button === 0) {
+                this.handleLeftClick(e);
+            }
+        });
+        this.canvas.addEventListener('wheel', (e) => {
+            if (!this.visible) return;
+            e.preventDefault();
+            const factor = e.deltaY < 0 ? 1.2 : 1 / 1.2;
+            this.zoomAt(e.clientX, e.clientY, factor);
+        }, { passive: false });
+    }
+
+    toggle() {
+        if (this.visible) this.close();
+        else this.open();
+    }
+
+    open() {
+        this.visible = true;
+        this.overlay.style.display = 'block';
+        this.resizeCanvas();
+        const tileSize = this.game.tileSize || 10;
+        if (this.game.player) {
+            this.cameraTileX = this.game.player.x / tileSize;
+            this.cameraTileY = this.game.player.y / tileSize;
+        }
+        this.clampCamera();
+        requestAnimationFrame(() => { this.overlay.style.opacity = '1'; });
+        // Always rebuild on open so tile edits made since the last open
+        // (digging, placing) are reflected.
+        this.invalidateCache();
+        this.draw();
+        if (this.game.freezePlayer !== undefined) {
+            this._priorFreeze = this.game.freezePlayer;
+            this.game.freezePlayer = true;
+        }
+    }
+
+    close() {
+        this.visible = false;
+        this.overlay.style.opacity = '0';
+        setTimeout(() => { if (!this.visible) this.overlay.style.display = 'none'; }, 160);
+        if (this._priorFreeze !== undefined) {
+            this.game.freezePlayer = this._priorFreeze;
+            this._priorFreeze = undefined;
+        }
+    }
+
+    resizeCanvas() {
+        const w = window.innerWidth;
+        const h = window.innerHeight;
+        this.canvas.width = w;
+        this.canvas.height = h;
+    }
+
+    clampCamera() {
+        const w = this.game.mapWidth || 1;
+        const h = this.game.mapHeight || 1;
+        this.cameraTileX = Math.max(0, Math.min(w, this.cameraTileX));
+        this.cameraTileY = Math.max(0, Math.min(h, this.cameraTileY));
+    }
+
+    zoomAt(screenX, screenY, factor) {
+        const tile = this.screenToTile(screenX, screenY);
+        const newScale = Math.max(this.minScale, Math.min(this.maxScale, this.scale * factor));
+        if (newScale === this.scale) return;
+        this.scale = newScale;
+        const newTile = this.screenToTile(screenX, screenY);
+        this.cameraTileX += tile.x - newTile.x;
+        this.cameraTileY += tile.y - newTile.y;
+        this.clampCamera();
+        this.draw();
+    }
+
+    screenToTile(screenX, screenY) {
+        const cw = this.canvas.width;
+        const ch = this.canvas.height;
+        const tx = (screenX - cw / 2) / this.scale + this.cameraTileX;
+        const ty = (screenY - ch / 2) / this.scale + this.cameraTileY;
+        return { x: tx, y: ty };
+    }
+
+    tileToScreen(tx, ty) {
+        const cw = this.canvas.width;
+        const ch = this.canvas.height;
+        return {
+            x: (tx - this.cameraTileX) * this.scale + cw / 2,
+            y: (ty - this.cameraTileY) * this.scale + ch / 2,
+        };
+    }
+
+    updateCoordLabel(screenX, screenY) {
+        const tile = this.screenToTile(screenX, screenY);
+        const x = Math.round(tile.x);
+        const y = Math.round(tile.y);
+        const aboveGround = this.game.aboveGround || 20;
+        this.coordLabel.textContent = `X ${x}  Y ${y}  DEPTH ${Math.max(0, y - aboveGround)}m`;
+    }
+
+    handleLeftClick(e) {
+        const tile = this.screenToTile(e.clientX, e.clientY);
+        const tx = Math.round(tile.x);
+        const ty = Math.round(tile.y);
+        const fog = this.game.fogOfWar;
+        if (fog && !fog.has(tx, ty)) return;
+        for (let i = 0; i < this.markers.length; i++) {
+            const m = this.markers[i];
+            const sp = this.tileToScreen(m.x, m.y);
+            if (Math.hypot(sp.x - e.clientX, sp.y - e.clientY) < 12) return;
+        }
+        this.markers.push({ x: tx, y: ty, color: MARKER_PALETTE[this.markerColorIndex] });
+        this.draw();
+    }
+
+    handleRightClick(e) {
+        for (let i = this.markers.length - 1; i >= 0; i--) {
+            const m = this.markers[i];
+            const sp = this.tileToScreen(m.x, m.y);
+            if (Math.hypot(sp.x - e.clientX, sp.y - e.clientY) < 12) {
+                this.markers.splice(i, 1);
+                this.draw();
+                return;
+            }
+        }
+    }
+
+    invalidateCache() {
+        this.cacheFogVersion = -1;
+    }
+
+    rebuildCache() {
+        const w = this.game.mapWidth;
+        const h = this.game.mapHeight;
+        const chunkSize = this.game.chunkSize || 6;
+        const aboveGround = this.game.aboveGround || 20;
+        const fog = this.game.fogOfWar;
+
+        if (!this.cacheCanvas) {
+            this.cacheCanvas = document.createElement('canvas');
+            this.cacheCanvas.width = w;
+            this.cacheCanvas.height = h;
+        }
+        const cctx = this.cacheCanvas.getContext('2d');
+        cctx.fillStyle = FOG_COLOR;
+        cctx.fillRect(0, 0, w, h);
+
+        const imgData = cctx.getImageData(0, 0, w, h);
+        const data = imgData.data;
+        for (let ty = 0; ty < h; ty++) {
+            for (let tx = 0; tx < w; tx++) {
+                if (fog && !fog.has(tx, ty)) continue;
+                const chunkX = Math.floor(tx / chunkSize) * chunkSize;
+                const chunkY = Math.floor(ty / chunkSize) * chunkSize;
+                const chunk = this.game.grid[`${chunkX}_${chunkY}`];
+                if (!chunk) continue;
+                const localX = tx % chunkSize;
+                const localY = ty % chunkSize;
+                const tile = chunk[localY] && chunk[localY][localX];
+                if (!tile) continue;
+                const id = tile.id;
+                const idx = (ty * w + tx) * 4;
+                if (id == null || id === 0) {
+                    if (ty < aboveGround) {
+                        data[idx] = 58; data[idx + 1] = 78; data[idx + 2] = 110; data[idx + 3] = 153;
+                    }
+                    continue;
+                }
+                const color = TILE_COLORS[id] || '#444';
+                const rgb = hexToRgb(color);
+                data[idx] = rgb.r; data[idx + 1] = rgb.g; data[idx + 2] = rgb.b; data[idx + 3] = 255;
+            }
+        }
+        cctx.putImageData(imgData, 0, 0);
+    }
+
+    draw() {
+        if (!this.visible) return;
+        const ctx = this.ctx;
+        const cw = this.canvas.width;
+        const ch = this.canvas.height;
+        ctx.fillStyle = VOID_COLOR;
+        ctx.fillRect(0, 0, cw, ch);
+
+        const fog = this.game.fogOfWar;
+        const fogVersion = fog ? fog.version : 0;
+        if (!this.cacheCanvas || fogVersion !== this.cacheFogVersion) {
+            this.rebuildCache();
+            this.cacheFogVersion = fogVersion;
+        }
+
+        const w = this.game.mapWidth;
+        const h = this.game.mapHeight;
+        const dx = (-this.cameraTileX) * this.scale + cw / 2;
+        const dy = (-this.cameraTileY) * this.scale + ch / 2;
+        ctx.imageSmoothingEnabled = false;
+        ctx.drawImage(this.cacheCanvas, 0, 0, w, h, dx, dy, w * this.scale, h * this.scale);
+
+        // Player marker
+        if (this.game.player) {
+            const tileSize = this.game.tileSize || 10;
+            const px = this.game.player.x / tileSize;
+            const py = this.game.player.y / tileSize;
+            const sp = this.tileToScreen(px, py);
+            ctx.beginPath();
+            ctx.arc(sp.x, sp.y, 7, 0, Math.PI * 2);
+            ctx.fillStyle = 'rgba(0,0,0,0.7)';
+            ctx.fill();
+            ctx.beginPath();
+            ctx.arc(sp.x, sp.y, 5, 0, Math.PI * 2);
+            ctx.fillStyle = '#ffffff';
+            ctx.fill();
+            ctx.beginPath();
+            ctx.arc(sp.x, sp.y, 3, 0, Math.PI * 2);
+            ctx.fillStyle = HUD.accent;
+            ctx.fill();
+        }
+
+        // Custom markers
+        for (const m of this.markers) {
+            const sp = this.tileToScreen(m.x, m.y);
+            if (sp.x < -20 || sp.y < -20 || sp.x > cw + 20 || sp.y > ch + 20) continue;
+            ctx.beginPath();
+            ctx.moveTo(sp.x, sp.y - 10);
+            ctx.lineTo(sp.x - 6, sp.y - 2);
+            ctx.lineTo(sp.x + 6, sp.y - 2);
+            ctx.closePath();
+            ctx.fillStyle = m.color;
+            ctx.fill();
+            ctx.lineWidth = 1.5;
+            ctx.strokeStyle = 'rgba(0,0,0,0.7)';
+            ctx.stroke();
+            ctx.beginPath();
+            ctx.arc(sp.x, sp.y - 1, 1.5, 0, Math.PI * 2);
+            ctx.fillStyle = 'rgba(255,255,255,0.9)';
+            ctx.fill();
+        }
+    }
+
+    destroy() {
+        this.overlay?.remove();
+        this.overlay = null;
+        this.cacheCanvas = null;
+    }
+}
+
+function kbdStyle() {
+    return `font-family:${HUD.fontMono};font-size:9px;font-weight:600;color:${HUD.text};background:rgba(255,255,255,0.10);border:1px solid rgba(255,255,255,0.16);border-radius:4px;padding:1px 5px;margin:0 4px 0 0;`;
+}
+
+function hexToRgb(hex) {
+    const v = hex.replace('#', '');
+    const num = parseInt(v.length === 3
+        ? v.split('').map(c => c + c).join('')
+        : v, 16);
+    return { r: (num >> 16) & 0xff, g: (num >> 8) & 0xff, b: num & 0xff };
+}
+

--- a/src/services/minimapManager.js
+++ b/src/services/minimapManager.js
@@ -1,17 +1,42 @@
 import { HUD } from './uiManager.js';
 
 const TILE_COLORS = {
-    1: '#5a3d2b',   // soil
-    2: '#2c5d8a',   // liquid
-    3: '#6f6f6f',   // stone
-    4: '#ffd76a',   // light
-    5: '#a07a4f',   // buttress
-    6: '#9aa3aa',   // rail
-    7: '#5b9dff',   // lift control
+    1: '#5a3d2b',
+    2: '#2c5d8a',
+    3: '#6f6f6f',
+    4: '#ffd76a',
+    5: '#a07a4f',
+    6: '#9aa3aa',
+    7: '#5b9dff',
 };
 
 const SKY_COLOR = 'rgba(58, 78, 110, 0.55)';
 const VOID_COLOR = 'rgba(10, 13, 18, 0.95)';
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+const STAT_LAYOUT = [
+    { key: 'health', max: 'maxHealth', color: HUD.health, icon: 'heart',   start: 100, end: 150 },
+    { key: 'energy', max: 'maxEnergy', color: HUD.energy, icon: 'bolt',    start: 155, end: 205 },
+    { key: 'breath', max: 'maxBreath', color: HUD.breath, icon: 'droplet', start: 210, end: 260 },
+];
+
+function polar(cx, cy, r, angleDeg) {
+    const rad = (angleDeg - 90) * Math.PI / 180;
+    return { x: cx + r * Math.cos(rad), y: cy + r * Math.sin(rad) };
+}
+
+function arcPath(cx, cy, r, startAngleDeg, endAngleDeg) {
+    const start = polar(cx, cy, r, startAngleDeg);
+    const end = polar(cx, cy, r, endAngleDeg);
+    const largeArc = endAngleDeg - startAngleDeg > 180 ? 1 : 0;
+    return `M ${start.x.toFixed(2)} ${start.y.toFixed(2)} A ${r} ${r} 0 ${largeArc} 1 ${end.x.toFixed(2)} ${end.y.toFixed(2)}`;
+}
+
+const STAT_ICONS = {
+    heart:   '<path d="M12 21s-7-4.35-9.5-8.5C.5 8.5 3 4 7 4c2 0 3.5 1 5 3 1.5-2 3-3 5-3 4 0 6.5 4.5 4.5 8.5C19 16.65 12 21 12 21z"/>',
+    bolt:    '<path d="M13 2L3 14h7l-1 8 11-12h-7l1-8z"/>',
+    droplet: '<path d="M12 3s6 7 6 11a6 6 0 1 1-12 0c0-4 6-11 6-11z"/>',
+};
 
 export default class MinimapManager {
     constructor(scene) {
@@ -19,7 +44,9 @@ export default class MinimapManager {
         this.tilesPerSide = 64;
         this.pxPerTile = 2;
         this.size = this.tilesPerSide * this.pxPerTile;
-        this.displaySize = 184;
+        this.mapDisplaySize = 184;
+        this.frameSize = 232;
+        this.statRadius = (this.mapDisplaySize / 2) + 14;
         this.updateInterval = 80;
         this._lastUpdate = 0;
         this.create();
@@ -30,13 +57,24 @@ export default class MinimapManager {
         wrap.id = 'minimapContainer';
         Object.assign(wrap.style, {
             position: 'absolute',
-            left: '18px',
-            bottom: '18px',
-            width: `${this.displaySize}px`,
-            height: `${this.displaySize}px`,
+            left: '14px',
+            bottom: '14px',
+            width: `${this.frameSize}px`,
+            height: `${this.frameSize}px`,
             zIndex: '999',
             pointerEvents: 'none',
         });
+
+        const inner = document.createElement('div');
+        Object.assign(inner.style, {
+            position: 'absolute',
+            left: `${(this.frameSize - this.mapDisplaySize) / 2}px`,
+            top: `${(this.frameSize - this.mapDisplaySize) / 2}px`,
+            width: `${this.mapDisplaySize}px`,
+            height: `${this.mapDisplaySize}px`,
+        });
+        wrap.appendChild(inner);
+        this.inner = inner;
 
         const ring = document.createElement('div');
         Object.assign(ring.style, {
@@ -49,7 +87,7 @@ export default class MinimapManager {
             backdropFilter: 'blur(10px)',
             WebkitBackdropFilter: 'blur(10px)',
         });
-        wrap.appendChild(ring);
+        inner.appendChild(ring);
 
         this.canvas = document.createElement('canvas');
         this.canvas.width = this.size;
@@ -63,14 +101,17 @@ export default class MinimapManager {
             imageRendering: 'pixelated',
             opacity: '0.95',
         });
-        wrap.appendChild(this.canvas);
+        inner.appendChild(this.canvas);
         this.ctx = this.canvas.getContext('2d');
+
+        this.statSvg = this.createStatRing();
+        wrap.appendChild(this.statSvg);
 
         const compass = document.createElement('div');
         compass.textContent = 'N';
         Object.assign(compass.style, {
             position: 'absolute',
-            top: '-7px',
+            top: '8px',
             left: '50%',
             transform: 'translate(-50%, -50%)',
             fontFamily: HUD.fontMono,
@@ -84,13 +125,14 @@ export default class MinimapManager {
             letterSpacing: '0.12em',
             textShadow: '0 1px 2px rgba(0,0,0,0.7)',
             boxShadow: '0 4px 10px rgba(0,0,0,0.4)',
+            zIndex: '2',
         });
         wrap.appendChild(compass);
 
         this.depthLabel = document.createElement('div');
         Object.assign(this.depthLabel.style, {
             position: 'absolute',
-            bottom: '-22px',
+            bottom: '-4px',
             left: '50%',
             transform: 'translateX(-50%)',
             fontFamily: HUD.fontMono,
@@ -100,16 +142,113 @@ export default class MinimapManager {
             letterSpacing: '0.10em',
             textShadow: '0 1px 2px rgba(0,0,0,0.7)',
             whiteSpace: 'nowrap',
+            zIndex: '2',
         });
         this.depthLabel.textContent = 'DEPTH 0m';
         wrap.appendChild(this.depthLabel);
+
+        const hint = document.createElement('div');
+        hint.innerHTML = `<kbd style="font-family:${HUD.fontMono};font-size:9px;font-weight:600;color:${HUD.text};background:rgba(255,255,255,0.10);border:1px solid rgba(255,255,255,0.16);border-radius:4px;padding:1px 5px;">M</kbd> map`;
+        Object.assign(hint.style, {
+            position: 'absolute',
+            top: '50%',
+            right: '-4px',
+            transform: 'translate(100%, -50%)',
+            fontFamily: HUD.font,
+            fontSize: '10px',
+            color: HUD.textMuted,
+            display: 'flex',
+            alignItems: 'center',
+            gap: '4px',
+            whiteSpace: 'nowrap',
+            zIndex: '2',
+        });
+        wrap.appendChild(hint);
 
         document.body.appendChild(wrap);
         this.wrapper = wrap;
     }
 
+    createStatRing() {
+        const svg = document.createElementNS(SVG_NS, 'svg');
+        svg.setAttribute('width', this.frameSize);
+        svg.setAttribute('height', this.frameSize);
+        svg.setAttribute('viewBox', `0 0 ${this.frameSize} ${this.frameSize}`);
+        Object.assign(svg.style, {
+            position: 'absolute',
+            inset: '0',
+            pointerEvents: 'none',
+            overflow: 'visible',
+        });
+
+        const cx = this.frameSize / 2;
+        const cy = this.frameSize / 2;
+        const r = this.statRadius;
+
+        this.statElems = {};
+        for (const stat of STAT_LAYOUT) {
+            const bg = document.createElementNS(SVG_NS, 'path');
+            bg.setAttribute('d', arcPath(cx, cy, r, stat.start, stat.end));
+            bg.setAttribute('stroke', 'rgba(255,255,255,0.10)');
+            bg.setAttribute('stroke-width', '5');
+            bg.setAttribute('stroke-linecap', 'round');
+            bg.setAttribute('fill', 'none');
+            svg.appendChild(bg);
+
+            const fg = document.createElementNS(SVG_NS, 'path');
+            fg.setAttribute('d', arcPath(cx, cy, r, stat.start, stat.end));
+            fg.setAttribute('stroke', stat.color);
+            fg.setAttribute('stroke-width', '5');
+            fg.setAttribute('stroke-linecap', 'round');
+            fg.setAttribute('fill', 'none');
+            fg.style.filter = `drop-shadow(0 0 4px ${stat.color})`;
+            fg.style.transition = 'stroke-dasharray 240ms ease, stroke 240ms ease';
+            svg.appendChild(fg);
+
+            const iconAngle = (stat.start + stat.end) / 2;
+            const iconPos = polar(cx, cy, r, iconAngle);
+            const iconG = document.createElementNS(SVG_NS, 'g');
+            iconG.setAttribute('transform', `translate(${iconPos.x.toFixed(2)} ${iconPos.y.toFixed(2)})`);
+            const iconBg = document.createElementNS(SVG_NS, 'circle');
+            iconBg.setAttribute('r', '8');
+            iconBg.setAttribute('fill', 'rgba(8,10,15,0.95)');
+            iconBg.setAttribute('stroke', 'rgba(255,255,255,0.18)');
+            iconBg.setAttribute('stroke-width', '1');
+            iconG.appendChild(iconBg);
+            const iconShape = document.createElementNS(SVG_NS, 'g');
+            iconShape.setAttribute('transform', 'translate(-5 -5) scale(0.42)');
+            iconShape.innerHTML = STAT_ICONS[stat.icon];
+            iconShape.setAttribute('fill', stat.color);
+            iconG.appendChild(iconShape);
+            svg.appendChild(iconG);
+
+            this.statElems[stat.key] = { fg, stat };
+        }
+
+        return svg;
+    }
+
+    updateStats() {
+        const player = this.game.player;
+        if (!player) return;
+        for (const stat of STAT_LAYOUT) {
+            const elems = this.statElems[stat.key];
+            if (!elems) continue;
+            const max = player[stat.max] || 100;
+            const current = Math.max(0, Math.min(player[stat.key] ?? max, max));
+            const pct = current / max;
+            const path = elems.fg;
+            const length = path.getTotalLength ? path.getTotalLength() : 100;
+            path.setAttribute('stroke-dasharray', `${(length * pct).toFixed(2)} ${length.toFixed(2)}`);
+            const lowColor = pct < 0.3 ? HUD.healthLow : (pct < 0.6 ? HUD.healthMid : stat.color);
+            path.setAttribute('stroke', stat.key === 'breath' ? stat.color : lowColor);
+            path.style.filter = `drop-shadow(0 0 4px ${path.getAttribute('stroke')})`;
+        }
+    }
+
     update(time) {
         if (!this.game.player || !this.game.grid) return;
+        this.updateStats();
         if (time - this._lastUpdate < this.updateInterval) return;
         this._lastUpdate = time;
 
@@ -122,6 +261,7 @@ export default class MinimapManager {
         const startX = playerTileX - half;
         const startY = playerTileY - half;
         const aboveGround = this.game.aboveGround || 20;
+        const fog = this.game.fogOfWar;
 
         ctx.fillStyle = VOID_COLOR;
         ctx.fillRect(0, 0, this.size, this.size);
@@ -133,6 +273,7 @@ export default class MinimapManager {
             for (let col = 0; col < this.tilesPerSide; col++) {
                 const tileX = startX + col;
                 if (tileX < 0 || tileX >= this.game.mapWidth) continue;
+                if (fog && !fog.has(tileX, tileY)) continue;
                 const chunkX = Math.floor(tileX / chunkSize) * chunkSize;
                 const chunkY = Math.floor(tileY / chunkSize) * chunkSize;
                 const chunk = this.game.grid[`${chunkX}_${chunkY}`];

--- a/src/services/minimapManager.js
+++ b/src/services/minimapManager.js
@@ -1,0 +1,178 @@
+import { HUD } from './uiManager.js';
+
+const TILE_COLORS = {
+    1: '#5a3d2b',   // soil
+    2: '#2c5d8a',   // liquid
+    3: '#6f6f6f',   // stone
+    4: '#ffd76a',   // light
+    5: '#a07a4f',   // buttress
+    6: '#9aa3aa',   // rail
+    7: '#5b9dff',   // lift control
+};
+
+const SKY_COLOR = 'rgba(58, 78, 110, 0.55)';
+const VOID_COLOR = 'rgba(10, 13, 18, 0.95)';
+
+export default class MinimapManager {
+    constructor(scene) {
+        this.game = scene;
+        this.tilesPerSide = 64;
+        this.pxPerTile = 2;
+        this.size = this.tilesPerSide * this.pxPerTile;
+        this.displaySize = 184;
+        this.updateInterval = 80;
+        this._lastUpdate = 0;
+        this.create();
+    }
+
+    create() {
+        const wrap = document.createElement('div');
+        wrap.id = 'minimapContainer';
+        Object.assign(wrap.style, {
+            position: 'absolute',
+            left: '18px',
+            bottom: '18px',
+            width: `${this.displaySize}px`,
+            height: `${this.displaySize}px`,
+            zIndex: '999',
+            pointerEvents: 'none',
+        });
+
+        const ring = document.createElement('div');
+        Object.assign(ring.style, {
+            position: 'absolute',
+            inset: '0',
+            borderRadius: '50%',
+            border: '2px solid rgba(236, 240, 248, 0.16)',
+            background: 'radial-gradient(circle at center, rgba(16,19,26,0.55) 0%, rgba(8,10,15,0.85) 75%, rgba(0,0,0,0.95) 100%)',
+            boxShadow: '0 14px 32px rgba(0,0,0,0.55), inset 0 0 0 1px rgba(0,0,0,0.55)',
+            backdropFilter: 'blur(10px)',
+            WebkitBackdropFilter: 'blur(10px)',
+        });
+        wrap.appendChild(ring);
+
+        this.canvas = document.createElement('canvas');
+        this.canvas.width = this.size;
+        this.canvas.height = this.size;
+        Object.assign(this.canvas.style, {
+            position: 'absolute',
+            inset: '6px',
+            width: 'calc(100% - 12px)',
+            height: 'calc(100% - 12px)',
+            borderRadius: '50%',
+            imageRendering: 'pixelated',
+            opacity: '0.95',
+        });
+        wrap.appendChild(this.canvas);
+        this.ctx = this.canvas.getContext('2d');
+
+        const compass = document.createElement('div');
+        compass.textContent = 'N';
+        Object.assign(compass.style, {
+            position: 'absolute',
+            top: '-7px',
+            left: '50%',
+            transform: 'translate(-50%, -50%)',
+            fontFamily: HUD.fontMono,
+            fontSize: '10px',
+            fontWeight: '600',
+            color: HUD.text,
+            background: 'rgba(16,19,26,0.92)',
+            border: '1px solid rgba(255,255,255,0.18)',
+            borderRadius: '999px',
+            padding: '2px 8px',
+            letterSpacing: '0.12em',
+            textShadow: '0 1px 2px rgba(0,0,0,0.7)',
+            boxShadow: '0 4px 10px rgba(0,0,0,0.4)',
+        });
+        wrap.appendChild(compass);
+
+        this.depthLabel = document.createElement('div');
+        Object.assign(this.depthLabel.style, {
+            position: 'absolute',
+            bottom: '-22px',
+            left: '50%',
+            transform: 'translateX(-50%)',
+            fontFamily: HUD.fontMono,
+            fontSize: '10px',
+            fontWeight: '600',
+            color: HUD.textMuted,
+            letterSpacing: '0.10em',
+            textShadow: '0 1px 2px rgba(0,0,0,0.7)',
+            whiteSpace: 'nowrap',
+        });
+        this.depthLabel.textContent = 'DEPTH 0m';
+        wrap.appendChild(this.depthLabel);
+
+        document.body.appendChild(wrap);
+        this.wrapper = wrap;
+    }
+
+    update(time) {
+        if (!this.game.player || !this.game.grid) return;
+        if (time - this._lastUpdate < this.updateInterval) return;
+        this._lastUpdate = time;
+
+        const ctx = this.ctx;
+        const tileSize = this.game.tileSize || 10;
+        const chunkSize = this.game.chunkSize || 6;
+        const playerTileX = Math.floor(this.game.player.x / tileSize);
+        const playerTileY = Math.floor(this.game.player.y / tileSize);
+        const half = this.tilesPerSide / 2;
+        const startX = playerTileX - half;
+        const startY = playerTileY - half;
+        const aboveGround = this.game.aboveGround || 20;
+
+        ctx.fillStyle = VOID_COLOR;
+        ctx.fillRect(0, 0, this.size, this.size);
+
+        for (let row = 0; row < this.tilesPerSide; row++) {
+            const tileY = startY + row;
+            if (tileY < 0 || tileY >= this.game.mapHeight) continue;
+            const drawY = row * this.pxPerTile;
+            for (let col = 0; col < this.tilesPerSide; col++) {
+                const tileX = startX + col;
+                if (tileX < 0 || tileX >= this.game.mapWidth) continue;
+                const chunkX = Math.floor(tileX / chunkSize) * chunkSize;
+                const chunkY = Math.floor(tileY / chunkSize) * chunkSize;
+                const chunk = this.game.grid[`${chunkX}_${chunkY}`];
+                if (!chunk) continue;
+                const localX = tileX % chunkSize;
+                const localY = tileY % chunkSize;
+                const tile = chunk[localY] && chunk[localY][localX];
+                if (!tile) continue;
+
+                const id = tile.id;
+                const drawX = col * this.pxPerTile;
+                if (id == null || id === 0) {
+                    if (tileY < aboveGround) {
+                        ctx.fillStyle = SKY_COLOR;
+                        ctx.fillRect(drawX, drawY, this.pxPerTile, this.pxPerTile);
+                    }
+                    continue;
+                }
+                ctx.fillStyle = TILE_COLORS[id] || '#444';
+                ctx.fillRect(drawX, drawY, this.pxPerTile, this.pxPerTile);
+            }
+        }
+
+        const cx = (playerTileX - startX) * this.pxPerTile;
+        const cy = (playerTileY - startY) * this.pxPerTile;
+        ctx.fillStyle = 'rgba(255,255,255,0.95)';
+        ctx.beginPath();
+        ctx.arc(cx, cy, 3.4, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.fillStyle = HUD.accent;
+        ctx.beginPath();
+        ctx.arc(cx, cy, 2.2, 0, Math.PI * 2);
+        ctx.fill();
+
+        const depth = Math.max(0, playerTileY - aboveGround);
+        this.depthLabel.textContent = `DEPTH ${depth}m`;
+    }
+
+    destroy() {
+        this.wrapper?.remove();
+        this.wrapper = null;
+    }
+}

--- a/src/services/playerManager.js
+++ b/src/services/playerManager.js
@@ -57,9 +57,6 @@ export default class PlayerManager {
         this.game.player.energy = this.game.player.maxEnergy;
         this.game.player.breath = this.game.player.maxBreath;
         this.game.player.hitPower = this.game.player.maxHitPower;
-        this.game.playerLight = this.game.lightingManager.addLight(this.game.player.x, this.game.player.y, 30, 1, this.game.lightColors[1], false);
-        // this.game.playerLight.off = true;
-        this.game.playerLightFaux = this.game.lightingManager.addLight(this.game.player.x, this.game.player.y, 0, 1, this.game.lightColors[1], false);
         this.game.physics.add.collider(this.game.player, this.game.soilGroup, () => {
             const fallSpeed = this.game.lastFallSpeed || 0;
             const safeSpeed = 180;
@@ -275,8 +272,6 @@ export default class PlayerManager {
         const relativePos = {x: x || this.game.startPoint.x, y: y || this.game.startPoint.y};
         this.game.player.x = relativePos.x;
         this.game.player.y = relativePos.y;
-        this.game.playerLight.setPosition(this.game.player.x + this.game.playerSize / 2, this.game.player.y + this.game.playerSize / 2);
-        this.game.playerLightFaux.setPosition(this.game.player.x + this.game.playerSize / 2, this.game.player.y + this.game.playerSize / 2);
         this.game.freezePlayer = true;
         this.game.cameras.main.stopFollow();
         this.game.cameras.main.setScroll(relativePos.x, relativePos.y);

--- a/src/services/toolBarManager.js
+++ b/src/services/toolBarManager.js
@@ -1,5 +1,18 @@
 import { HUD } from './uiManager.js';
 
+function describeArc(cx, cy, outerR, innerR, startAngle, endAngle) {
+    const x1 = cx + outerR * Math.cos(startAngle);
+    const y1 = cy + outerR * Math.sin(startAngle);
+    const x2 = cx + outerR * Math.cos(endAngle);
+    const y2 = cy + outerR * Math.sin(endAngle);
+    const x3 = cx + innerR * Math.cos(endAngle);
+    const y3 = cy + innerR * Math.sin(endAngle);
+    const x4 = cx + innerR * Math.cos(startAngle);
+    const y4 = cy + innerR * Math.sin(startAngle);
+    const largeArc = endAngle - startAngle > Math.PI ? 1 : 0;
+    return `M ${x1} ${y1} A ${outerR} ${outerR} 0 ${largeArc} 1 ${x2} ${y2} L ${x3} ${y3} A ${innerR} ${innerR} 0 ${largeArc} 0 ${x4} ${y4} Z`;
+}
+
 export default class ToolbarManager {
     /**
      * @param {Phaser.Scene} scene - Your game scene.
@@ -35,9 +48,223 @@ export default class ToolbarManager {
                 const index = parseInt(e.key, 10) - 1;
                 this.setSelected(index);
             }
+            if (e.key === 'Shift' && !e.repeat && !this.wheelOpen) {
+                this.openWheel();
+            }
+        });
+        document.addEventListener('keyup', (e) => {
+            if (e.key === 'Shift' && this.wheelOpen) {
+                this.closeWheel(true);
+            }
+        });
+        document.addEventListener('mousemove', (e) => {
+            if (this.wheelOpen) {
+                this.updateWheelHighlight(e.clientX, e.clientY);
+            }
+        });
+        window.addEventListener('blur', () => {
+            if (this.wheelOpen) this.closeWheel(false);
         });
 
         this.render();
+    }
+
+    openWheel() {
+        this.wheelOpen = true;
+        this.wheelHighlightIndex = -1;
+        if (!this.wheelOverlay) this.createWheelOverlay();
+        this.wheelOverlay.style.display = 'flex';
+        // Animate in
+        requestAnimationFrame(() => {
+            this.wheelOverlay.style.opacity = '1';
+            this.wheelInner.style.transform = 'scale(1)';
+        });
+        this.renderWheel();
+    }
+
+    closeWheel(applySelection) {
+        if (!this.wheelOpen) return;
+        this.wheelOpen = false;
+        if (applySelection && this.wheelHighlightIndex >= 0) {
+            this.setSelected(this.wheelHighlightIndex);
+        }
+        if (this.wheelOverlay) {
+            this.wheelOverlay.style.opacity = '0';
+            this.wheelInner.style.transform = 'scale(0.92)';
+            const overlay = this.wheelOverlay;
+            setTimeout(() => {
+                if (!this.wheelOpen) overlay.style.display = 'none';
+            }, 140);
+        }
+    }
+
+    createWheelOverlay() {
+        this.wheelOverlay = document.createElement('div');
+        Object.assign(this.wheelOverlay.style, {
+            position: 'fixed',
+            inset: '0',
+            display: 'none',
+            alignItems: 'center',
+            justifyContent: 'center',
+            pointerEvents: 'none',
+            zIndex: '2000',
+            background: 'radial-gradient(circle at center, rgba(0,0,0,0.45) 0%, rgba(0,0,0,0) 60%)',
+            opacity: '0',
+            transition: 'opacity 140ms ease',
+        });
+        this.wheelInner = document.createElement('div');
+        Object.assign(this.wheelInner.style, {
+            position: 'relative',
+            width: '320px',
+            height: '320px',
+            transform: 'scale(0.92)',
+            transition: 'transform 140ms ease',
+        });
+        this.wheelOverlay.appendChild(this.wheelInner);
+        document.body.appendChild(this.wheelOverlay);
+    }
+
+    renderWheel() {
+        if (!this.wheelInner) return;
+        this.wheelInner.innerHTML = '';
+        const size = 320;
+        const cx = size / 2;
+        const cy = size / 2;
+        const outerR = size / 2 - 4;
+        const innerR = 50;
+        const slotsCount = this.numSlots;
+        const sliceAngle = (2 * Math.PI) / slotsCount;
+        // Slot 0 centered at the top: top angle is -PI/2; sector spans (-PI/2 - half, -PI/2 + half)
+        const startOffset = -Math.PI / 2 - sliceAngle / 2;
+
+        const svgNS = 'http://www.w3.org/2000/svg';
+        const svg = document.createElementNS(svgNS, 'svg');
+        svg.setAttribute('width', size);
+        svg.setAttribute('height', size);
+        svg.setAttribute('viewBox', `0 0 ${size} ${size}`);
+        svg.style.position = 'absolute';
+        svg.style.inset = '0';
+        svg.style.filter = 'drop-shadow(0 8px 24px rgba(0,0,0,0.55))';
+
+        for (let i = 0; i < slotsCount; i++) {
+            const a0 = startOffset + i * sliceAngle;
+            const a1 = startOffset + (i + 1) * sliceAngle;
+            const selected = i === this.wheelHighlightIndex;
+            const path = describeArc(cx, cy, outerR, innerR, a0, a1);
+            const pathEl = document.createElementNS(svgNS, 'path');
+            pathEl.setAttribute('d', path);
+            pathEl.setAttribute('fill', selected ? 'rgba(91,157,255,0.32)' : 'rgba(16,19,26,0.78)');
+            pathEl.setAttribute('stroke', selected ? '#5b9dff' : 'rgba(255,255,255,0.10)');
+            pathEl.setAttribute('stroke-width', selected ? '2' : '1');
+            svg.appendChild(pathEl);
+        }
+        this.wheelInner.appendChild(svg);
+
+        const iconR = (innerR + outerR) / 2;
+        for (let i = 0; i < slotsCount; i++) {
+            const item = this.slots[i];
+            const angle = startOffset + (i + 0.5) * sliceAngle;
+            const x = cx + Math.cos(angle) * iconR;
+            const y = cy + Math.sin(angle) * iconR;
+            const wrap = document.createElement('div');
+            const selected = i === this.wheelHighlightIndex;
+            Object.assign(wrap.style, {
+                position: 'absolute',
+                left: `${x}px`,
+                top: `${y}px`,
+                transform: `translate(-50%, -50%) ${selected ? 'scale(1.15)' : 'scale(1)'}`,
+                width: '52px',
+                height: '52px',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                color: selected ? HUD.accent : HUD.textDim,
+                fontFamily: HUD.fontMono,
+                fontSize: '11px',
+                fontWeight: '600',
+                opacity: item ? '1' : (selected ? '0.9' : '0.4'),
+                transition: 'transform 120ms ease, color 120ms ease, opacity 120ms ease',
+                pointerEvents: 'none',
+            });
+            if (item) {
+                const img = document.createElement('img');
+                img.src = item.imageUrl;
+                Object.assign(img.style, {
+                    width: '38px',
+                    height: '38px',
+                    objectFit: 'contain',
+                    transform: `rotate(${item.rotate || 0}deg)`,
+                    filter: selected
+                        ? 'drop-shadow(0 0 6px rgba(91,157,255,0.55)) drop-shadow(0 2px 4px rgba(0,0,0,0.6))'
+                        : 'drop-shadow(0 2px 4px rgba(0,0,0,0.6))',
+                });
+                wrap.appendChild(img);
+            } else {
+                wrap.textContent = String(i + 1);
+            }
+            this.wheelInner.appendChild(wrap);
+
+            // Hotkey label near the outer edge
+            const labelR = outerR - 14;
+            const lx = cx + Math.cos(angle) * labelR;
+            const ly = cy + Math.sin(angle) * labelR;
+            const hotkey = document.createElement('div');
+            hotkey.textContent = String(i + 1);
+            Object.assign(hotkey.style, {
+                position: 'absolute',
+                left: `${lx}px`,
+                top: `${ly}px`,
+                transform: 'translate(-50%, -50%)',
+                fontFamily: HUD.fontMono,
+                fontSize: '9px',
+                fontWeight: '600',
+                color: selected ? HUD.accent : HUD.textDim,
+                pointerEvents: 'none',
+            });
+            this.wheelInner.appendChild(hotkey);
+        }
+
+        // Center label
+        const center = document.createElement('div');
+        const highlighted = this.wheelHighlightIndex >= 0 ? this.slots[this.wheelHighlightIndex] : null;
+        center.textContent = highlighted ? highlighted.name : '';
+        Object.assign(center.style, {
+            position: 'absolute',
+            left: '50%',
+            top: '50%',
+            transform: 'translate(-50%, -50%)',
+            fontFamily: HUD.font,
+            fontSize: '13px',
+            fontWeight: '600',
+            color: HUD.text,
+            textAlign: 'center',
+            pointerEvents: 'none',
+            textShadow: '0 1px 3px rgba(0,0,0,0.7)',
+            maxWidth: '90px',
+        });
+        this.wheelInner.appendChild(center);
+    }
+
+    updateWheelHighlight(mouseX, mouseY) {
+        const cx = window.innerWidth / 2;
+        const cy = window.innerHeight / 2;
+        const dx = mouseX - cx;
+        const dy = mouseY - cy;
+        const dist = Math.hypot(dx, dy);
+        const deadZone = 28;
+        let newIndex = -1;
+        if (dist >= deadZone) {
+            const sliceAngle = (2 * Math.PI) / this.numSlots;
+            // Slot 0 centered at the top (-PI/2). Shift atan2 result so 0 falls
+            // at the start of slot 0's arc, then bucket by sliceAngle.
+            let angle = Math.atan2(dy, dx) + Math.PI / 2 + sliceAngle / 2;
+            angle = ((angle % (2 * Math.PI)) + 2 * Math.PI) % (2 * Math.PI);
+            newIndex = Math.floor(angle / sliceAngle) % this.numSlots;
+        }
+        if (newIndex !== this.wheelHighlightIndex) {
+            this.wheelHighlightIndex = newIndex;
+            this.renderWheel();
+        }
     }
 
     styleSlot(slotEl, selected) {

--- a/src/services/toolBarManager.js
+++ b/src/services/toolBarManager.js
@@ -25,21 +25,19 @@ export default class ToolbarManager {
 
         this.game.selectedIndex = 0;
         this.slots = new Array(numSlots).fill(null);
+        // The visible bottom-center toolbar has been replaced by the radial
+        // selector — keep an off-screen container so render() / drag-drop
+        // targets still exist without taking screen real estate.
         this.container = document.getElementById(containerId);
         if (!this.container) {
             this.container = document.createElement('div');
             this.container.id = containerId;
-            this.container.className = 'hud-panel';
             Object.assign(this.container.style, {
                 position: 'absolute',
-                left: '50%',
-                bottom: '24px',
-                transform: 'translateX(-50%)',
-                display: 'flex',
-                gap: '8px',
-                padding: '10px',
-                zIndex: '1000',
-                fontFamily: HUD.font,
+                left: '-9999px',
+                top: '-9999px',
+                display: 'none',
+                pointerEvents: 'none',
             });
             document.body.appendChild(this.container);
         }

--- a/src/services/uiManager.js
+++ b/src/services/uiManager.js
@@ -150,6 +150,7 @@ export default class UiManager {
                 this.saveButton.remove();
                 this.game.lightCanvas.remove();
                 this.statusPanel?.remove();
+                this.game.minimapManager?.destroy();
                 this.game.scene.stop("GameScene");
                 this.game.scene.start("MenuScene");
             }, 100);
@@ -159,8 +160,8 @@ export default class UiManager {
 
     addSaveButton() {
         return this.createButton('saveButton', {
-            top: '18px',
-            right: '18px',
+            top: '62px',
+            left: '18px',
         }, this.iconSvg('save') + '<span>Save</span>', 'accent', async () => {
             this.game.saveButton.disabled = true;
             this.game.saveButton.innerHTML = this.iconSvg('spinner') + '<span>Saving…</span>';
@@ -199,12 +200,12 @@ export default class UiManager {
         Object.assign(panel.style, {
             position: 'absolute',
             left: '18px',
-            bottom: '18px',
-            padding: '14px 16px',
-            width: '260px',
+            bottom: '218px',
+            padding: '12px 14px',
+            width: '210px',
             display: 'flex',
             flexDirection: 'column',
-            gap: '10px',
+            gap: '8px',
             zIndex: '1000',
         });
         document.body.appendChild(panel);

--- a/src/services/uiManager.js
+++ b/src/services/uiManager.js
@@ -151,6 +151,7 @@ export default class UiManager {
                 this.game.lightCanvas.remove();
                 this.statusPanel?.remove();
                 this.game.minimapManager?.destroy();
+                this.game.mapViewManager?.destroy();
                 this.game.scene.stop("GameScene");
                 this.game.scene.start("MenuScene");
             }, 100);
@@ -194,27 +195,8 @@ export default class UiManager {
     // -------------------- Status Panel --------------------
 
     addStatusPanel() {
-        const panel = document.createElement('div');
-        panel.id = 'statusPanel';
-        panel.className = 'hud-panel';
-        Object.assign(panel.style, {
-            position: 'absolute',
-            left: '18px',
-            bottom: '218px',
-            padding: '12px 14px',
-            width: '210px',
-            display: 'flex',
-            flexDirection: 'column',
-            gap: '8px',
-            zIndex: '1000',
-        });
-        document.body.appendChild(panel);
-        this.statusPanel = panel;
-
-        this.healthRow = this.addStatRow(panel, 'health', HUD.health, this.iconSvg('heart'));
-        this.energyRow = this.addStatRow(panel, 'energy', HUD.energy, this.iconSvg('bolt'));
-        this.breathRow = this.addStatRow(panel, 'breath', HUD.breath, this.iconSvg('droplet'));
-        this.breathRow.row.style.display = 'none';
+        // Stats are visualized as arcs around the minimap; this method is
+        // intentionally a no-op so the rest of the HUD wiring stays intact.
     }
 
     addStatRow(parent, key, color, iconSvg) {
@@ -265,17 +247,6 @@ export default class UiManager {
 
     updateUI() {
         const p = this.game.player;
-        const healthMax = p.maxHealth || 100;
-        const energyMax = p.maxEnergy || 100;
-        const breathMax = p.maxBreath || 100;
-
-        this.setRow(this.healthRow, p.health, healthMax);
-        this.setRow(this.energyRow, p.energy, energyMax);
-        this.setRow(this.breathRow, p.breath, breathMax);
-
-        const breathPct = (p.breath / breathMax) * 100;
-        this.breathRow.row.style.display = breathPct < 95 ? 'grid' : 'none';
-
         if (p.energy <= 0) this.game.playerManager.die('sleep');
         if (p.health <= 0) this.game.playerManager.die();
     }


### PR DESCRIPTION
## Summary
This PR introduces three major navigation and exploration systems to the game: a fog of war system that tracks explored tiles, a circular minimap display in the corner, and a full-screen interactive world map with custom markers.

## Key Changes

### Fog of War System (`fogOfWar.js`)
- Implemented bit-packed exploration tracking using `Uint8Array` for memory efficiency
- Each tile stores one bit indicating whether it has been explored
- Includes `revealCircle()` method to reveal tiles within a radius of the player
- Supports serialization/deserialization to base64 for save persistence
- Tracks version number to invalidate cached map renders when fog state changes

### Minimap Manager (`minimapManager.js`)
- Created circular minimap display positioned in bottom-left corner (184px diameter)
- Renders a 64×64 tile view centered on the player with 2px per tile scaling
- Displays player position with a white/accent-colored marker
- Integrated radial stat rings around the minimap showing health, energy, and breath bars with icons
- Updates at 80ms intervals to balance performance
- Shows current depth below ground level

### World Map View (`mapViewManager.js`)
- Full-screen interactive map accessible via 'M' key
- Features include:
  - Pan by dragging, zoom with mouse wheel (1-8x scale)
  - Custom markers with 7-color palette, cycled via 'C' key
  - Left-click to add markers, right-click to remove
  - Real-time coordinate display showing tile position and depth
  - Respects fog of war visibility
  - Caches rendered map tiles and invalidates on fog changes
  - Displays player position with multi-ring indicator
- Freezes player movement while map is open

### Toolbar Refactor (`toolBarManager.js`)
- Replaced bottom-center toolbar with radial selector wheel
- Activated by holding Shift key
- Displays 8 item slots in a circular arrangement with icons
- Highlights selected slot on mouse hover
- Shows item names and hotkey numbers (1-8)
- Smooth animations for opening/closing and selection

### Game Scene Integration (`GameScene.js`)
- Instantiates `FogOfWar`, `MinimapManager`, and `MapViewManager`
- Reveals tiles in a circle around player each frame (12-tile radius)
- Persists fog of war state and map markers to save data
- Loads fog and markers from saved game on startup
- Passes fog state to both minimap and world map for visibility filtering

### UI Manager Updates (`uiManager.js`)
- Repositioned save button from top-right to top-left (62px from top)
- Added cleanup calls to destroy minimap and map view on scene exit
- Removed status panel (replaced by minimap stat rings)

### Save/Load System
- Extended save format to include serialized fog of war and map markers
- Both Electron and cloud save paths updated to persist new data
- Menu scene passes fog and markers to game scene on load

## Notable Implementation Details
- Fog of war uses bit-packing to store 1 bit per tile, reducing memory from 1 byte to 1 bit per tile
- Minimap uses canvas rendering for performance with SVG overlays for stat rings
- World map caches tile rendering and only rebuilds when fog state changes (version tracking)
- Radial selector uses SVG paths for smooth, scalable geometry
- All UI elements use consistent HUD styling with backdrop blur and glassmorphism effects

https://claude.ai/code/session_01GX5R2my1T1whAf2fnu4r7Z