### PR TITLE
Optimize rendering and spatial queries with texture atlasing and spatial indexing

### DIFF
--- a/src/classes/breakable.js
+++ b/src/classes/breakable.js
@@ -35,21 +35,21 @@ export class Breakable extends Tile {
     }
 
     refreshCurveOverlay() {
-        const mask = this.game.tileAtlas.cornerCurveMaskFor(this.worldX, this.worldY);
+        const atlas = this.game.tileAtlas;
+        const mask = atlas.cornerCurveMaskFor(this.worldX, this.worldY);
         if (mask === this.lastCurveMask) return;
         this.lastCurveMask = mask;
         if (mask === 0) {
             if (this.curveOverlay) this.curveOverlay.setVisible(false);
             return;
         }
-        const atlas = this.game.tileAtlas;
-        const key = atlas.ensureCornerCurveTexture(mask);
+        const frame = atlas.ensureCornerCurveTexture(mask);
         if (!this.curveOverlay) {
-            this.curveOverlay = this.game.add.image(this.worldX, this.worldY, key);
+            this.curveOverlay = this.game.add.image(this.worldX, this.worldY, atlas.curveTextureKey, frame);
             this.curveOverlay.setOrigin(0.5, 0.5);
             this.curveOverlay.setDepth(0.5);
-        } else if (this.curveOverlay.texture.key !== key) {
-            this.curveOverlay.setTexture(key);
+        } else if (this.curveOverlay.frame.name !== frame) {
+            this.curveOverlay.setTexture(atlas.curveTextureKey, frame);
         }
         this.curveOverlay.setVisible(true);
     }
@@ -146,9 +146,9 @@ export class Breakable extends Tile {
         const variant = Math.floor(this.posHash(0) * atlas.variantCount);
         const useGrass = top && this.isNearSurface();
         const kind = useGrass ? 'grass' : 'dirt';
-        const key = atlas.ensureTexture(kind, mask, variant);
-        if (this.tileImage.texture.key !== key) {
-            this.tileImage.setTexture(key);
+        const frame = atlas.ensureTexture(kind, mask, variant);
+        if (this.tileImage.frame.name !== frame) {
+            this.tileImage.setTexture(atlas.tileTextureKey, frame);
         }
     }
 
@@ -249,8 +249,8 @@ export class Breakable extends Tile {
         // textureHeight-tall texture) aligns with the world tile bounds.
         // Center origin + Y offset = -overhang/2 means the texture's vertical
         // center sits overhang/2 above worldY.
-        const initialKey = atlas.keyFor('dirt', 0, 0);
-        this.tileImage = this.game.add.image(this.worldX, this.worldY - overhang / 2, initialKey);
+        const initialFrame = atlas.keyFor('dirt', 0, 0);
+        this.tileImage = this.game.add.image(this.worldX, this.worldY - overhang / 2, atlas.tileTextureKey, initialFrame);
         this.tileImage.setOrigin(0.5, 0.5);
         this.tileImage.setDepth(0);
 

--- a/src/classes/breakable.js
+++ b/src/classes/breakable.js
@@ -35,16 +35,22 @@ export class Breakable extends Tile {
     }
 
     refreshCurveOverlay() {
-        if (!this.curveOverlay) return;
         const mask = this.game.tileAtlas.cornerCurveMaskFor(this.worldX, this.worldY);
         if (mask === this.lastCurveMask) return;
         this.lastCurveMask = mask;
         if (mask === 0) {
-            this.curveOverlay.setVisible(false);
+            if (this.curveOverlay) this.curveOverlay.setVisible(false);
             return;
         }
-        const key = this.game.tileAtlas.ensureCornerCurveTexture(mask);
-        if (this.curveOverlay.texture.key !== key) this.curveOverlay.setTexture(key);
+        const atlas = this.game.tileAtlas;
+        const key = atlas.ensureCornerCurveTexture(mask);
+        if (!this.curveOverlay) {
+            this.curveOverlay = this.game.add.image(this.worldX, this.worldY, key);
+            this.curveOverlay.setOrigin(0.5, 0.5);
+            this.curveOverlay.setDepth(0.5);
+        } else if (this.curveOverlay.texture.key !== key) {
+            this.curveOverlay.setTexture(key);
+        }
         this.curveOverlay.setVisible(true);
     }
 
@@ -111,6 +117,18 @@ export class Breakable extends Tile {
         const inRange = this.worldY >= aboveGroundY && this.worldY <= aboveGroundY + ts * 3;
         if (!inRange) return false;
         return this.isOpenAt(this.worldX, this.worldY - ts);
+    }
+
+    _ensureCrackSprite() {
+        if (this.crackSprite) return this.crackSprite;
+        const ts = this.game.tileSize;
+        const s = this.game.add.image(this.worldX, this.worldY, 'crack');
+        s.setDisplaySize(ts - 1, ts - 1);
+        const health = this.tileDetails.health;
+        s.setAlpha(health == null ? 0.1 : 1 - health + 0.1);
+        s.setDepth(4);
+        this.crackSprite = s;
+        return s;
     }
 
     redrawTile() {
@@ -263,19 +281,15 @@ export class Breakable extends Tile {
             this.tileImage.setVisible(false);
         }
 
-        this.crackSprite = this.game.add.image(this.worldX, this.worldY, 'crack');
-        this.crackSprite.setDisplaySize(ts - 1, ts - 1);
-        this.crackSprite.setAlpha(1 - this.tileDetails.health + 0.1);
-        this.crackSprite.setDepth(4);
+        // crackSprite is lazy: only damaged tiles need it on creation
+        // (saves where health < 1). Fresh tiles get a crack sprite on the
+        // first hit via _ensureCrackSprite.
+        if (this.tileDetails.health != null && this.tileDetails.health < 1) {
+            this._ensureCrackSprite();
+        }
 
-        // Inside-corner curve overlay — small Image rendered above the body
-        // depth, with curve pixels in its corner overhang regions that
-        // extend INTO adjacent open diagonal cells. Uses the dark outline
-        // colour so it blends with the surrounding tile borders.
-        this.curveOverlay = this.game.add.image(this.worldX, this.worldY, atlas.cornerCurveKey(0));
-        this.curveOverlay.setOrigin(0.5, 0.5);
-        this.curveOverlay.setDepth(0.5);
-        this.curveOverlay.setVisible(false);
+        // curveOverlay also lazy — most cells never sit at an inside cave
+        // corner so creation up front was wasted. See refreshCurveOverlay.
         this.lastCurveMask = -1;
 
         this.fadeElements = [this.tileImage];
@@ -302,13 +316,14 @@ export class Breakable extends Tile {
     removeElements() {
         this.active = false;
         this.removeFromGroup();
-        this.crackSprite.destroy();
+        if (this.crackSprite) this.crackSprite.destroy();
         this.sprite.destroy();
         if (this.overlaySprite) this.overlaySprite.destroy();
         if (this.tileImage) this.tileImage.destroy();
         if (this.curveOverlay) this.curveOverlay.destroy();
         if (this.detailGraphics) this.detailGraphics.destroy();
         if (this.edgeRefreshDelay) this.edgeRefreshDelay.remove();
+        this._destroyBorderGraphics();
     }
 
     destroy(prefs) {
@@ -345,7 +360,7 @@ export class Breakable extends Tile {
 
                 if (health <= 0) {
                     this.game.physics.world.disable(this.sprite);
-                    this.crackSprite.setAlpha(0);
+                    if (this.crackSprite) this.crackSprite.setAlpha(0);
                     this.sprite.setStrokeStyle(0, 0);
                     this.game.dustEmitter.explode(50);
                     baseCell = this.tileDetails.trapped || {...this.game.tileTypes.empty};
@@ -353,8 +368,9 @@ export class Breakable extends Tile {
                     this.game.mapService.setTile(this.worldX, this.worldY, baseCell, this.sprite);
                 } else {
                     this.game.dustEmitter.explode(5);
+                    const crack = this._ensureCrackSprite();
                     this.game.tweens.add({
-                        targets: this.crackSprite,
+                        targets: crack,
                         alpha: 1 - health,
                         duration: 50,
                         ease: 'Cubic.easeOut',

--- a/src/classes/buttress.js
+++ b/src/classes/buttress.js
@@ -20,16 +20,22 @@ export class Buttress extends Tile {
     }
 
     refreshCurveOverlay() {
-        if (!this.curveOverlay) return;
         const mask = this.game.tileAtlas.cornerCurveMaskFor(this.worldX, this.worldY);
         if (mask === this.lastCurveMask) return;
         this.lastCurveMask = mask;
         if (mask === 0) {
-            this.curveOverlay.setVisible(false);
+            if (this.curveOverlay) this.curveOverlay.setVisible(false);
             return;
         }
-        const key = this.game.tileAtlas.ensureCornerCurveTexture(mask);
-        if (this.curveOverlay.texture.key !== key) this.curveOverlay.setTexture(key);
+        const atlas = this.game.tileAtlas;
+        const key = atlas.ensureCornerCurveTexture(mask);
+        if (!this.curveOverlay) {
+            this.curveOverlay = this.game.add.image(this.worldX, this.worldY, key);
+            this.curveOverlay.setOrigin(0.5, 0.5);
+            this.curveOverlay.setDepth(0.5);
+        } else if (this.curveOverlay.texture.key !== key) {
+            this.curveOverlay.setTexture(key);
+        }
         this.curveOverlay.setVisible(true);
     }
 
@@ -39,11 +45,8 @@ export class Buttress extends Tile {
         this.buttressSprite.setDisplaySize(this.game.tileSize, this.game.tileSize);
         baseSprite.setAlpha(0);
 
-        // Inside-corner curve overlay (same machinery as Breakable).
-        this.curveOverlay = this.game.add.image(this.worldX, this.worldY, this.game.tileAtlas.cornerCurveKey(0));
-        this.curveOverlay.setOrigin(0.5, 0.5);
-        this.curveOverlay.setDepth(0.5);
-        this.curveOverlay.setVisible(false);
+        // curveOverlay is lazy — most cells aren't at an inside cave corner
+        // so they never need one. See refreshCurveOverlay.
         this.lastCurveMask = -1;
 
         this.fadeElements = [this.buttressSprite];
@@ -64,6 +67,7 @@ export class Buttress extends Tile {
         if (this.curveOverlay) this.curveOverlay.destroy();
         if (this.curveRefreshDelay) this.curveRefreshDelay.remove();
         this.sprite.destroy();
+        this._destroyBorderGraphics();
     }
 
     destroy(prefs) {

--- a/src/classes/buttress.js
+++ b/src/classes/buttress.js
@@ -20,21 +20,21 @@ export class Buttress extends Tile {
     }
 
     refreshCurveOverlay() {
-        const mask = this.game.tileAtlas.cornerCurveMaskFor(this.worldX, this.worldY);
+        const atlas = this.game.tileAtlas;
+        const mask = atlas.cornerCurveMaskFor(this.worldX, this.worldY);
         if (mask === this.lastCurveMask) return;
         this.lastCurveMask = mask;
         if (mask === 0) {
             if (this.curveOverlay) this.curveOverlay.setVisible(false);
             return;
         }
-        const atlas = this.game.tileAtlas;
-        const key = atlas.ensureCornerCurveTexture(mask);
+        const frame = atlas.ensureCornerCurveTexture(mask);
         if (!this.curveOverlay) {
-            this.curveOverlay = this.game.add.image(this.worldX, this.worldY, key);
+            this.curveOverlay = this.game.add.image(this.worldX, this.worldY, atlas.curveTextureKey, frame);
             this.curveOverlay.setOrigin(0.5, 0.5);
             this.curveOverlay.setDepth(0.5);
-        } else if (this.curveOverlay.texture.key !== key) {
-            this.curveOverlay.setTexture(key);
+        } else if (this.curveOverlay.frame.name !== frame) {
+            this.curveOverlay.setTexture(atlas.curveTextureKey, frame);
         }
         this.curveOverlay.setVisible(true);
     }

--- a/src/classes/empty.js
+++ b/src/classes/empty.js
@@ -36,5 +36,6 @@ export class Empty extends Tile {
     destroy() {
         this.removeFromGroup();
         this.sprite.destroy();
+        this._destroyBorderGraphics();
     }
 }

--- a/src/classes/liftControl.js
+++ b/src/classes/liftControl.js
@@ -89,6 +89,7 @@ export class LiftControl extends Tile {
             this.sprite.destroy();
             this.light.destroy();
             this.switchSprite.destroy();
+            this._destroyBorderGraphics();
         }, prefs)
     }
 

--- a/src/classes/light.js
+++ b/src/classes/light.js
@@ -58,6 +58,7 @@ export class Light extends Tile {
             this.sprite.destroy();
             this.lampSprite.destroy();
             this.light.destroy();
+            this._destroyBorderGraphics();
         }, prefs)
     }
 

--- a/src/classes/liquid.js
+++ b/src/classes/liquid.js
@@ -26,6 +26,7 @@ export class Liquid extends Tile {
         this.active = false;
         this.removeFromGroup();
         this.sprite.destroy();
+        this._destroyBorderGraphics();
     }
 
     checkState() {

--- a/src/classes/rail.js
+++ b/src/classes/rail.js
@@ -41,6 +41,7 @@ export class Rail extends Tile {
         this.removeFromGroup();
         this.railSprite.destroy();
         this.sprite.destroy();
+        this._destroyBorderGraphics();
     }
 
     destroy(prefs) {

--- a/src/classes/tile.js
+++ b/src/classes/tile.js
@@ -35,6 +35,16 @@ export class Tile {
         // per cell across the whole loaded world.
         this.setupInteractions();
         this.addToGroup();
+        // Register this tile's sprite in the spatial index. For most
+        // tiles placeObject already did this at construction time, but
+        // for caved Breakables init() is deferred via delayedCall, so
+        // placeObject saw newTile.sprite === undefined and skipped.
+        // Re-registering here is idempotent for the eager path and
+        // is the only registration the delayed path ever gets.
+        const ms = this.game.mapService;
+        if (ms && this.chunkKey != null && this.cellX != null && this.cellY != null) {
+            ms._registerSpriteAt(this.chunkKey, this.cellY, this.cellX, this.sprite);
+        }
         // if (this.light) {
         //     this.light.fadeIn();
         // }

--- a/src/classes/tile.js
+++ b/src/classes/tile.js
@@ -29,15 +29,10 @@ export class Tile {
         this.sprite.cellX = this.cellX;
         this.sprite.cellY = this.cellY;
         this.sprite.chunkKey = this.chunkKey;
-        this.borderGraphics = this.game.add.graphics();
-        this.borderGraphics.lineStyle(1, 0xfff1c4, 1);
-        this.borderGraphics.strokeRect(
-            this.sprite.x - this.sprite.displayWidth / 2,
-            this.sprite.y - this.sprite.displayHeight / 2,
-            this.sprite.displayWidth,
-            this.sprite.displayHeight);
-        this.borderGraphics.setDepth(10);
-        this.borderGraphics.setAlpha(0);
+        // borderGraphics is lazy — see _ensureBorderGraphics. The hover
+        // highlight only ever shows on the few tiles the player points at,
+        // and creating one per tile up front was burning ~one GameObject
+        // per cell across the whole loaded world.
         this.setupInteractions();
         this.addToGroup();
         // if (this.light) {
@@ -64,6 +59,32 @@ export class Tile {
                 this.game.dustEmitter.explode(50);
             }
             this.game.tweens.add(anims);
+        }
+    }
+
+    _ensureBorderGraphics() {
+        if (this.borderGraphics) return this.borderGraphics;
+        const g = this.game.add.graphics();
+        g.lineStyle(1, 0xfff1c4, 1);
+        g.strokeRect(
+            this.sprite.x - this.sprite.displayWidth / 2,
+            this.sprite.y - this.sprite.displayHeight / 2,
+            this.sprite.displayWidth,
+            this.sprite.displayHeight);
+        g.setDepth(10);
+        g.setAlpha(0);
+        this.borderGraphics = g;
+        return g;
+    }
+
+    _destroyBorderGraphics() {
+        if (this.borderPulseTween) {
+            this.borderPulseTween.stop();
+            this.borderPulseTween = null;
+        }
+        if (this.borderGraphics) {
+            this.borderGraphics.destroy();
+            this.borderGraphics = null;
         }
     }
 
@@ -143,7 +164,7 @@ export class Tile {
             this.borderPulseTween.stop();
             this.borderPulseTween = null;
         }
-        this.borderGraphics.setAlpha(0);
+        if (this.borderGraphics) this.borderGraphics.setAlpha(0);
     }
 
     checkAdjacentBlocks(metadata) {
@@ -174,10 +195,11 @@ export class Tile {
         ))) || (metadata?.reclaimFrom?.id === this.tileDetails.id)) {
             const adj = this.checkAdjacentBlocks(metadata);
             if (adj) {
-                this.borderGraphics.setAlpha(1);
+                const g = this._ensureBorderGraphics();
+                g.setAlpha(1);
                 if (this.borderPulseTween) this.borderPulseTween.stop();
                 this.borderPulseTween = this.game.tweens.add({
-                    targets: this.borderGraphics,
+                    targets: g,
                     alpha: 0.55,
                     duration: 700,
                     ease: 'Sine.easeInOut',

--- a/src/classes/tree.js
+++ b/src/classes/tree.js
@@ -118,6 +118,7 @@ export class Tree extends Tile {
         this.removeFromGroup();
         if (this.treeSprite) this.treeSprite.destroy();
         this.sprite.destroy();
+        this._destroyBorderGraphics();
     }
 
     destroy(prefs) {

--- a/src/main.js
+++ b/src/main.js
@@ -16,6 +16,11 @@ const config = {
     backgroundColor: "#000000",
     pixelArt: true, // Ensures pixel art rendering
     antialias: false, // Disables default smoothing
+    // Snap sprite screen positions to integer pixels. Without this,
+    // sprites can sit at fractional positions during smooth camera
+    // moves (e.g. lift tweens), leaving 1-pixel transparent seams or
+    // bleeding the neighbouring frame of the packed tile atlas.
+    roundPixels: true,
     fps: {
         target: 30,  // ✅ Force 60 FPS
         forceSetTimeOut: false, // ✅ Ensure requestAnimationFrame is used

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -142,6 +142,10 @@ export default class GameScene extends Phaser.Scene {
         this.treeGroup = this.add.group();
         this.treeTextures = new TreeTextureFactory(this);
         this.liftControlGroup = this.physics.add.staticGroup();
+        // interactableGroup is just a stable alias for liftControlGroup —
+        // physics.overlap accepts the Group directly, so no per-frame
+        // array snapshot is needed.
+        this.interactableGroup = this.liftControlGroup;
         this.liquidGroup = this.physics.add.staticGroup();
         this.lightingManager = new LightingManager(this);
         this.lightingManager.registerGroup(this.soilGroup);
@@ -289,32 +293,43 @@ export default class GameScene extends Phaser.Scene {
             if (this.newGame) {
                 await this.saveGame(this.user, this.grid);
             }
+            const checkGroups = [
+                this.emptyGroup,
+                this.lightGroup,
+                this.liquidGroup,
+                this.railGroup,
+                this.soilGroup,
+                this.buttressGroup,
+            ];
             this.checkBlocksInterval = this.time.addEvent({
                 delay: 50,
                 callback: () => {
-                    // Option 1: If groups change rarely, you could cache this combined array externally.
-                    // For now, we're computing it on every call.
-
-                    const emptyChildren = this.emptyGroup.getChildren();
-                    const lightChildren = this.lightGroup.getChildren();
-                    const liquidChildren = this.liquidGroup.getChildren();
-                    const railChildren = this.railGroup.getChildren();
-                    const soilChildren = this.soilGroup.getChildren();
-                    const buttressChildren = this.buttressGroup.getChildren();
-                    // Combine arrays using spread syntax (more readable and possibly more optimized)
-                    const softSoil = [...emptyChildren, ...lightChildren, ...liquidChildren, ...railChildren, ...soilChildren, ...buttressChildren];
-                    const total = softSoil.length;
-
-                    // Process a batch of blocks using a for loop.
-                    const max = Math.min(currentIndex + batchSize, total);
-                    for (let i = currentIndex; i < max; i++) {
-                        const block = softSoil[i];
-                        if (block.tileRef?.checkState) {
-                            block.tileRef.checkState();
+                    // Walk batchSize tiles across the groups in order without
+                    // flattening into a new array each tick — the previous
+                    // spread allocated and GC'd ~3000 array slots per 50ms.
+                    let remaining = batchSize;
+                    let cursor = currentIndex;
+                    let total = 0;
+                    for (let gi = 0; gi < checkGroups.length; gi++) {
+                        const arr = checkGroups[gi].getChildren();
+                        const len = arr.length;
+                        total += len;
+                        if (remaining <= 0) continue;
+                        if (cursor >= len) {
+                            cursor -= len;
+                            continue;
                         }
+                        const end = Math.min(cursor + remaining, len);
+                        for (let i = cursor; i < end; i++) {
+                            const block = arr[i];
+                            if (block.tileRef?.checkState) {
+                                block.tileRef.checkState();
+                            }
+                        }
+                        remaining -= (end - cursor);
+                        cursor = 0;
                     }
                     currentIndex = (currentIndex + batchSize) >= total ? 0 : currentIndex + batchSize;
-
                 },
                 callbackScope: this,
                 loop: true
@@ -450,7 +465,6 @@ export default class GameScene extends Phaser.Scene {
             }
             this.lightingManager.updateLighting(delta);
             this.backgroundManager?.update();
-            this.interactableGroup = [...this.liftControlGroup.getChildren()];
             this.uiManager.updateUI();
             this.revealFogAroundPlayer(time);
             this.minimapManager?.update(time);

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -304,17 +304,23 @@ export default class GameScene extends Phaser.Scene {
             this.checkBlocksInterval = this.time.addEvent({
                 delay: 50,
                 callback: () => {
-                    // Walk batchSize tiles across the groups in order without
-                    // flattening into a new array each tick — the previous
-                    // spread allocated and GC'd ~3000 array slots per 50ms.
+                    // Snapshot each group's children before iterating: a
+                    // checkState can call setTile which removes a tile
+                    // from its group mid-batch and shifts the live array,
+                    // leaving undefined slots in the trailing indices.
+                    // The snapshot keeps array positions stable; the
+                    // block? + tileRef?. guards handle entries that
+                    // were destroyed during this same tick.
+                    const arrs = checkGroups.map(g => g.getChildren().slice());
+                    let total = 0;
+                    for (let gi = 0; gi < arrs.length; gi++) total += arrs[gi].length;
+
                     let remaining = batchSize;
                     let cursor = currentIndex;
-                    let total = 0;
-                    for (let gi = 0; gi < checkGroups.length; gi++) {
-                        const arr = checkGroups[gi].getChildren();
+                    for (let gi = 0; gi < arrs.length; gi++) {
+                        if (remaining <= 0) break;
+                        const arr = arrs[gi];
                         const len = arr.length;
-                        total += len;
-                        if (remaining <= 0) continue;
                         if (cursor >= len) {
                             cursor -= len;
                             continue;
@@ -322,9 +328,8 @@ export default class GameScene extends Phaser.Scene {
                         const end = Math.min(cursor + remaining, len);
                         for (let i = cursor; i < end; i++) {
                             const block = arr[i];
-                            if (block.tileRef?.checkState) {
-                                block.tileRef.checkState();
-                            }
+                            const ref = block?.tileRef;
+                            if (ref?.checkState) ref.checkState();
                         }
                         remaining -= (end - cursor);
                         cursor = 0;

--- a/src/services/cameraManager.js
+++ b/src/services/cameraManager.js
@@ -8,7 +8,11 @@ export default class CameraManager {
         const zoomX = width / baseWidth;
         const zoomY = height / baseHeight;
 
-        const zoom = Math.min(zoomX, zoomY) + 3.5;
+        // Snap to integer zoom — fractional zooms map integer-positioned
+        // tiles onto fractional screen pixels, which produces 1-pixel
+        // seams between adjacent tiles whenever the camera is mid-scroll
+        // (most visibly during the lift's smooth Y tween).
+        const zoom = Math.max(1, Math.round(Math.min(zoomX, zoomY) + 3.5));
 
         this.game.cameras.main.setZoom(zoom);
 

--- a/src/services/lighting.js
+++ b/src/services/lighting.js
@@ -173,16 +173,34 @@ export default class LightingManager {
 
     updateLighting(deltaTime) {
         const ctx = this.game.lightCtx;
-        ctx.clearRect(0, 0, this.game.lightCanvas.width, this.game.lightCanvas.height);
+        const canvas = this.game.lightCanvas;
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
 
         ctx.fillStyle = "rgba(0,0,0,1)";
-        ctx.fillRect(0, 0, this.game.lightCanvas.width, this.game.lightCanvas.height);
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
 
-        this.lights.forEach(light => !light.off && this.castLight(light));
+        // Cull lights that fall outside the camera view. The bloom halo
+        // extends to ~1.9× radius, so use that as the bounding box.
+        const cam = this.game.cameras.main;
+        const view = cam.worldView;
+        const viewLeft = view.x;
+        const viewRight = view.x + view.width;
+        const viewTop = view.y;
+        const viewBottom = view.y + view.height;
+
+        const lights = this.lights;
+        for (let i = 0; i < lights.length; i++) {
+            const light = lights[i];
+            if (light.off) continue;
+            const r = light.radius * 1.9;
+            if (light.x + r < viewLeft) continue;
+            if (light.x - r > viewRight) continue;
+            if (light.y + r < viewTop) continue;
+            if (light.y - r > viewBottom) continue;
+            this.castLight(light);
+        }
 
         this.updateSky();
-
-        // this.updateViewMask();
 
         ctx.globalCompositeOperation = "source-over";
     }
@@ -325,9 +343,10 @@ export default class LightingManager {
         _gradient.addColorStop(1, "rgba(0, 0, 0, 0)");
 
         // Paint the sky background by interpolating through the diurnal
-        // palette: bright blue at noon, navy at midnight, with warm
-        // orange swept through at dusk and dawn.
-        if (this.game.skyBox) {
+        // palette. The cycle is minutes long, so the per-frame color
+        // delta is invisible — sample at ~8 Hz to skip the work.
+        if (this.game.skyBox && (now - (this._lastSkyTintMs || 0) > 120)) {
+            this._lastSkyTintMs = now;
             const [r, g, b] = paletteColor(timeFraction);
             const tintColor = (r << 16) | (g << 8) | b;
             this.game.skyBox.setFillStyle(tintColor, 1);

--- a/src/services/map.js
+++ b/src/services/map.js
@@ -683,37 +683,39 @@ export default class MapService {
     }
 
     loadChunks(playerX, playerY, renderDistance = this.game.renderDistance) {
-        requestAnimationFrame(() => {
-            const chunkSizeInPixels = this.game.chunkSize * this.game.tileSize;
-            const baseChunkX = Math.floor(playerX / chunkSizeInPixels) * this.game.chunkSize;
-            const baseChunkY = Math.floor(playerY / chunkSizeInPixels) * this.game.chunkSize;
-            let newChunks = new Map();
+        // Run synchronously instead of deferring to the next rAF. The
+        // deferral let the camera scroll one frame ahead of the visible
+        // chunks, which on a fast lift travel produced a brief blank
+        // strip of tiles that hadn't loaded yet.
+        const chunkSizeInPixels = this.game.chunkSize * this.game.tileSize;
+        const baseChunkX = Math.floor(playerX / chunkSizeInPixels) * this.game.chunkSize;
+        const baseChunkY = Math.floor(playerY / chunkSizeInPixels) * this.game.chunkSize;
+        let newChunks = new Map();
 
-            for (let dx = -renderDistance; dx <= renderDistance; dx++) {
-                for (let dy = -renderDistance; dy <= renderDistance; dy++) {
-                    const cx = baseChunkX + dx * this.game.chunkSize;
-                    const cy = baseChunkY + dy * this.game.chunkSize;
-                    const chunkKey = `${cx}_${cy}`;
-                    if (this.game.grid[chunkKey]) {
-                        if (!this.game.loadedChunks.has(chunkKey)) {
-                            this.renderChunk(cx, cy);
-                        }
-                        newChunks.set(chunkKey, this.game.grid[chunkKey]);
+        for (let dx = -renderDistance; dx <= renderDistance; dx++) {
+            for (let dy = -renderDistance; dy <= renderDistance; dy++) {
+                const cx = baseChunkX + dx * this.game.chunkSize;
+                const cy = baseChunkY + dy * this.game.chunkSize;
+                const chunkKey = `${cx}_${cy}`;
+                if (this.game.grid[chunkKey]) {
+                    if (!this.game.loadedChunks.has(chunkKey)) {
+                        this.renderChunk(cx, cy);
                     }
+                    newChunks.set(chunkKey, this.game.grid[chunkKey]);
                 }
             }
+        }
 
-            // Unload chunks that are no longer within the render distance
-            this.game.loadedChunks.forEach((grid, key) => {
-                if (!newChunks.has(key)) {
-                    this.unloadChunk(key);
-                    this.game.loadedChunks.delete(key);
-                }
-            });
-
-            this.game.loadedChunks = newChunks;
-            this.game.children.bringToTop(this.game.shadowGraphics);
+        // Unload chunks that are no longer within the render distance
+        this.game.loadedChunks.forEach((grid, key) => {
+            if (!newChunks.has(key)) {
+                this.unloadChunk(key);
+                this.game.loadedChunks.delete(key);
+            }
         });
+
+        this.game.loadedChunks = newChunks;
+        this.game.children.bringToTop(this.game.shadowGraphics);
     }
 
     setTile(worldX, worldY, tileType, cellItem, prefs) {

--- a/src/services/map.js
+++ b/src/services/map.js
@@ -645,24 +645,34 @@ export default class MapService {
     }
 
     getEntitiesAround(x, y, radius) {
-        let entities = [];
-
-        this.game.entityChildren.forEach(group => {
-            if (group?.children) {
-                group.children.each(entity => {
-                    if (this.isWithinRadius(entity.x, entity.y, x, y, radius)) {
-                        entities.push(entity);
-                    }
-                });
-            } else if (Array.isArray(group)) {
-                group.forEach(entity => {
-                    if (this.isWithinRadius(entity.x, entity.y, x, y, radius)) {
-                        entities.push(entity);
-                    }
-                });
+        // Walk the spatial sprite index in a tile bounding box around the
+        // point and keep entries inside the circle. Replaces a full scan
+        // of every entity group's children.
+        const ts = this.game.tileSize;
+        const cs = this.game.chunkSize;
+        const r2 = radius * radius;
+        const minTx = Math.floor((x - radius) / ts);
+        const maxTx = Math.floor((x + radius) / ts);
+        const minTy = Math.floor((y - radius) / ts);
+        const maxTy = Math.floor((y + radius) / ts);
+        const entities = [];
+        for (let ty = minTy; ty <= maxTy; ty++) {
+            const chunkY = Math.floor(ty / cs) * cs;
+            const ly = ((ty % cs) + cs) % cs;
+            for (let tx = minTx; tx <= maxTx; tx++) {
+                const chunkX = Math.floor(tx / cs) * cs;
+                const chunk = this.spriteIndex[`${chunkX}_${chunkY}`];
+                if (!chunk) continue;
+                const row = chunk[ly];
+                if (!row) continue;
+                const lx = ((tx % cs) + cs) % cs;
+                const sprite = row[lx];
+                if (!sprite || !sprite.active) continue;
+                const dx = sprite.x - x;
+                const dy = sprite.y - y;
+                if (dx * dx + dy * dy <= r2) entities.push(sprite);
             }
-        });
-
+        }
         return entities;
     }
 

--- a/src/services/map.js
+++ b/src/services/map.js
@@ -69,6 +69,14 @@ export default class MapService {
         this.game.mapWidth = 322;
         this.game.loadedChunks = new Map();
         this.game.grid = this.game.grid || {};
+        // Spatial index: spriteIndex[chunkKey][localY][localX] → Phaser sprite.
+        // Populated in placeObject, cleared in unloadChunk. Lets
+        // getAdjacentBlocks/refreshNeighborEdges do O(1) neighbour lookups
+        // instead of scanning every entity group's children.
+        this.spriteIndex = {};
+        // Bumped any time a grid cell changes so consumers (minimap, future
+        // delta-sync, etc.) can skip work when the world is static.
+        this.game.gridVersion = 0;
         this.game.openSpaces = [];
         this.game.tileAtlas = new TileTextureAtlas(this.game);
         this.game.dustEmitter = this.game.add.particles(0, 0, 'dust', {
@@ -609,53 +617,31 @@ export default class MapService {
         );
     }
 
+    spriteAtWorld(worldX, worldY) {
+        const ts = this.game.tileSize;
+        const cs = this.game.chunkSize;
+        const tx = Math.floor(worldX / ts);
+        const ty = Math.floor(worldY / ts);
+        const chunkX = Math.floor(tx / cs) * cs;
+        const chunkY = Math.floor(ty / cs) * cs;
+        const chunk = this.spriteIndex[`${chunkX}_${chunkY}`];
+        if (!chunk) return null;
+        const lx = ((tx % cs) + cs) % cs;
+        const ly = ((ty % cs) + cs) % cs;
+        const row = chunk[ly];
+        if (!row) return null;
+        const sprite = row[lx];
+        return sprite && sprite.active ? sprite : null;
+    }
+
     getAdjacentBlocks(x, y) {
-        const tileSize = this.game.tileSize;
-        // Prepare an object to hold the adjacent blocks.
-        const blocks = {
-            left: null,
-            above: null,
-            right: null,
-            below: null,
+        const ts = this.game.tileSize;
+        return {
+            left:  this.spriteAtWorld(x - ts, y),
+            right: this.spriteAtWorld(x + ts, y),
+            above: this.spriteAtWorld(x, y - ts),
+            below: this.spriteAtWorld(x, y + ts),
         };
-
-        // Define the target positions for each direction.
-        const targets = {
-            left: {x: x - tileSize, y: y},
-            above: {x: x, y: y - tileSize},
-            right: {x: x + tileSize, y: y},
-            below: {x: x, y: y + tileSize},
-        };
-
-        // Loop through each group in entityChildren.
-        this.game.entityChildren.forEach(group => {
-            // If the group has a 'children' property (like a Phaser Group)
-            if (group?.children) {
-                group.children.each(entity => {
-                    for (const direction in targets) {
-                        const target = targets[direction];
-                        // Check if the entity is within half a tile of the target.
-                        if (Math.abs(entity.x - target.x) < tileSize / 2 &&
-                            Math.abs(entity.y - target.y) < tileSize / 2) {
-                            blocks[direction] = entity;
-                        }
-                    }
-                });
-            } else if (Array.isArray(group)) {
-                // If the group is simply an array of entities.
-                group.forEach(entity => {
-                    for (const direction in targets) {
-                        const target = targets[direction];
-                        if (Math.abs(entity.x - target.x) < tileSize / 2 &&
-                            Math.abs(entity.y - target.y) < tileSize / 2) {
-                            blocks[direction] = entity;
-                        }
-                    }
-                });
-            }
-        });
-
-        return blocks;
     }
 
     getEntitiesAround(x, y, radius) {
@@ -731,7 +717,11 @@ export default class MapService {
         if (!this.game.grid[chunkKey] || !this.game.grid[chunkKey][cellY] || !this.game.grid[chunkKey][cellX]) return; // Ensure chunk exists
 
         this.game.grid[chunkKey][cellY][cellX] = {...tileType};
-        if (cellItem?.tileRef) cellItem.tileRef.destroy(prefs);
+        this.game.gridVersion++;
+        if (cellItem?.tileRef) {
+            this._unregisterSpriteAt(chunkKey, cellY, cellX);
+            cellItem.tileRef.destroy(prefs);
+        }
         if (this.game.loadedChunks.has(chunkKey)) {
             const result = this.placeObject(tileType, worldX, worldY, {chunkKey, cellY, cellX}, prefs);
             this.refreshNeighborEdges(worldX, worldY);
@@ -739,19 +729,36 @@ export default class MapService {
         }
     }
 
+    _registerSpriteAt(chunkKey, cellY, cellX, sprite) {
+        if (!sprite) return;
+        let chunk = this.spriteIndex[chunkKey];
+        if (!chunk) {
+            chunk = new Array(this.game.chunkSize);
+            for (let i = 0; i < this.game.chunkSize; i++) chunk[i] = new Array(this.game.chunkSize).fill(null);
+            this.spriteIndex[chunkKey] = chunk;
+        }
+        const row = chunk[cellY];
+        if (row) row[cellX] = sprite;
+    }
+
+    _unregisterSpriteAt(chunkKey, cellY, cellX) {
+        const chunk = this.spriteIndex[chunkKey];
+        if (!chunk) return;
+        const row = chunk[cellY];
+        if (row) row[cellX] = null;
+    }
+
     refreshNeighborEdges(worldX, worldY) {
-        // Refresh all 8 surrounding solid tiles so silhouette edges and
-        // inner-corner curves update on dig/place.
+        // Refresh the 8 surrounding solid tiles so silhouette edges and
+        // inner-corner curves update on dig/place. O(8) via the spatial
+        // index instead of scanning every soil + buttress sprite.
         const ts = this.game.tileSize;
-        const groups = [this.game.soilGroup, this.game.buttressGroup];
-        for (const group of groups) {
-            if (!group?.children) continue;
-            group.children.each(entity => {
-                const dx = entity.x - worldX;
-                const dy = entity.y - worldY;
-                if ((dx === 0 && dy === 0) || Math.abs(dx) > ts || Math.abs(dy) > ts) return;
-                const ref = entity.tileRef;
-                if (!ref) return;
+        for (let dy = -1; dy <= 1; dy++) {
+            for (let dx = -1; dx <= 1; dx++) {
+                if (dx === 0 && dy === 0) continue;
+                const sprite = this.spriteAtWorld(worldX + dx * ts, worldY + dy * ts);
+                const ref = sprite?.tileRef;
+                if (!ref) continue;
                 if (ref.redrawTile) {
                     ref.lastEdgeMask = -1;
                     ref.redrawTile();
@@ -760,7 +767,7 @@ export default class MapService {
                     ref.lastCurveMask = -1;
                     ref.refreshCurveOverlay();
                 }
-            });
+            }
         }
     }
 
@@ -803,6 +810,9 @@ export default class MapService {
         }
         if (tileType.id === this.game.tileTypes.tree.id) {
             newTile = this.treePool.acquire(params);
+        }
+        if (newTile?.sprite && cellDetails) {
+            this._registerSpriteAt(cellDetails.chunkKey, cellDetails.cellY, cellDetails.cellX, newTile.sprite);
         }
         return newTile;
     }
@@ -862,6 +872,7 @@ export default class MapService {
             }
         });
 
+        delete this.spriteIndex[chunkKey];
         this.game.loadedChunks.delete(chunkKey);
     }
 

--- a/src/services/minimapManager.js
+++ b/src/services/minimapManager.js
@@ -253,20 +253,43 @@ export default class MinimapManager {
         if (time - this._lastUpdate < this.updateInterval) return;
         this._lastUpdate = time;
 
-        const ctx = this.ctx;
         const tileSize = this.game.tileSize || 10;
-        const chunkSize = this.game.chunkSize || 6;
         const playerTileX = Math.floor(this.game.player.x / tileSize);
         const playerTileY = Math.floor(this.game.player.y / tileSize);
+        const gridVersion = this.game.gridVersion || 0;
+        const fog = this.game.fogOfWar;
+        const fogVersion = fog ? fog.version : 0;
+
+        // Skip the full 64×64 canvas repaint entirely when nothing visible
+        // has changed since the last paint. Player standing still + no
+        // dig/place + no fog reveal == no work.
+        if (this._lastPlayerTileX === playerTileX &&
+            this._lastPlayerTileY === playerTileY &&
+            this._lastGridVersion === gridVersion &&
+            this._lastFogVersion === fogVersion &&
+            this._painted) {
+            return;
+        }
+        this._lastPlayerTileX = playerTileX;
+        this._lastPlayerTileY = playerTileY;
+        this._lastGridVersion = gridVersion;
+        this._lastFogVersion = fogVersion;
+        this._painted = true;
+
+        const ctx = this.ctx;
+        const chunkSize = this.game.chunkSize || 6;
         const half = this.tilesPerSide / 2;
         const startX = playerTileX - half;
         const startY = playerTileY - half;
         const aboveGround = this.game.aboveGround || 20;
-        const fog = this.game.fogOfWar;
 
         ctx.fillStyle = VOID_COLOR;
         ctx.fillRect(0, 0, this.size, this.size);
 
+        // Cache the last chunk seen across cells in the same chunk to avoid
+        // re-doing the string concat + dict lookup for every tile.
+        let lastChunkX = NaN, lastChunkY = NaN, lastChunk = null;
+        let lastFill = null;
         for (let row = 0; row < this.tilesPerSide; row++) {
             const tileY = startY + row;
             if (tileY < 0 || tileY >= this.game.mapHeight) continue;
@@ -275,25 +298,34 @@ export default class MinimapManager {
                 const tileX = startX + col;
                 if (tileX < 0 || tileX >= this.game.mapWidth) continue;
                 if (fog && !fog.has(tileX, tileY)) continue;
-                const chunkX = Math.floor(tileX / chunkSize) * chunkSize;
-                const chunkY = Math.floor(tileY / chunkSize) * chunkSize;
-                const chunk = this.game.grid[`${chunkX}_${chunkY}`];
-                if (!chunk) continue;
-                const localX = tileX % chunkSize;
-                const localY = tileY % chunkSize;
-                const tile = chunk[localY] && chunk[localY][localX];
+                const chunkX = tileX - ((tileX % chunkSize) + chunkSize) % chunkSize;
+                const chunkY = tileY - ((tileY % chunkSize) + chunkSize) % chunkSize;
+                if (chunkX !== lastChunkX || chunkY !== lastChunkY) {
+                    lastChunkX = chunkX;
+                    lastChunkY = chunkY;
+                    lastChunk = this.game.grid[`${chunkX}_${chunkY}`] || null;
+                }
+                if (!lastChunk) continue;
+                const localX = tileX - chunkX;
+                const localY = tileY - chunkY;
+                const tileRow = lastChunk[localY];
+                if (!tileRow) continue;
+                const tile = tileRow[localX];
                 if (!tile) continue;
 
                 const id = tile.id;
                 const drawX = col * this.pxPerTile;
+                let fill;
                 if (id == null || id === 0) {
-                    if (tileY < aboveGround) {
-                        ctx.fillStyle = SKY_COLOR;
-                        ctx.fillRect(drawX, drawY, this.pxPerTile, this.pxPerTile);
-                    }
-                    continue;
+                    if (tileY >= aboveGround) continue;
+                    fill = SKY_COLOR;
+                } else {
+                    fill = TILE_COLORS[id] || '#444';
                 }
-                ctx.fillStyle = TILE_COLORS[id] || '#444';
+                if (fill !== lastFill) {
+                    ctx.fillStyle = fill;
+                    lastFill = fill;
+                }
                 ctx.fillRect(drawX, drawY, this.pxPerTile, this.pxPerTile);
             }
         }

--- a/src/services/tileTextureAtlas.js
+++ b/src/services/tileTextureAtlas.js
@@ -68,19 +68,30 @@ export default class TileTextureAtlas {
         this.tileTextureKey = 'tile_atlas';
         this.curveTextureKey = 'tile_curve_atlas';
 
-        // Atlas layout: each (mask, variant) gets a tileSize × textureHeight
-        // cell at a deterministic position. MASKS_PER_ROW masks per row,
+        // 1px transparent gutter on every side of every frame keeps the
+        // GPU from sampling into a neighbouring frame at sub-pixel
+        // sprite positions (otherwise visible as thin coloured seams
+        // along tile edges during smooth camera moves).
+        this.gutter = 1;
+        const cellW = this.tileSize + this.gutter * 2;
+        const cellH = this.textureHeight + this.gutter * 2;
+
+        // Atlas layout: each (mask, variant) gets one padded cell at a
+        // deterministic position. MASKS_PER_ROW masks per row,
         // VARIANT_COUNT variants packed horizontally within each mask cell.
         // Grass frames live below all dirt frames so kind→y is constant.
         this.cellsPerMaskRow = MASKS_PER_ROW;
-        this.atlasWidth = this.cellsPerMaskRow * this.variantCount * this.tileSize;
+        this.cellWidth = cellW;
+        this.cellHeight = cellH;
+        this.atlasWidth = this.cellsPerMaskRow * this.variantCount * cellW;
         this.kindRows = Math.ceil(MAX_MASKS / this.cellsPerMaskRow);
-        this.grassYOffset = this.kindRows * this.textureHeight;
+        this.grassYOffset = this.kindRows * cellH;
         this.atlasHeight = this.grassYOffset * 2;
 
         this.curveSize = this.tileSize + 4;
-        this.curveAtlasWidth = 16 * this.curveSize;
-        this.curveAtlasHeight = this.curveSize;
+        this.curveCellSize = this.curveSize + this.gutter * 2;
+        this.curveAtlasWidth = 16 * this.curveCellSize;
+        this.curveAtlasHeight = this.curveCellSize;
 
         this._tileFramesAdded = new Set();
         this._curveFramesAdded = new Set();
@@ -149,13 +160,16 @@ export default class TileTextureAtlas {
     _tileFramePosition(kind, mask, variant) {
         const col = mask % this.cellsPerMaskRow;
         const row = Math.floor(mask / this.cellsPerMaskRow);
-        const x = col * this.variantCount * this.tileSize + variant * this.tileSize;
-        const y = row * this.textureHeight + (kind === 'grass' ? this.grassYOffset : 0);
-        return { x, y };
+        // Cell origin (top-left of the padded cell), then offset by the
+        // gutter so the frame rect sits inside the cell with transparent
+        // pixels around it.
+        const cellX = col * this.variantCount * this.cellWidth + variant * this.cellWidth;
+        const cellY = row * this.cellHeight + (kind === 'grass' ? this.grassYOffset : 0);
+        return { x: cellX + this.gutter, y: cellY + this.gutter };
     }
 
     _curveFramePosition(mask) {
-        return { x: mask * this.curveSize, y: 0 };
+        return { x: mask * this.curveCellSize + this.gutter, y: this.gutter };
     }
 
     ensureTileFrame(kind, mask, variant) {

--- a/src/services/tileTextureAtlas.js
+++ b/src/services/tileTextureAtlas.js
@@ -1,7 +1,9 @@
-// Pre-renders dirt and grass tile variants as Phaser canvas textures
-// at scene init. Each tile becomes a cheap Image sprite that just
-// references one of these atlas textures, swapping keys when its
-// neighbour state changes.
+// Pre-renders dirt and grass tile variants into a single packed canvas
+// texture (with named frames per mask/variant), plus a second canvas for
+// the inner-corner curve overlays. Tiles all reference the same atlas
+// texture and only swap frames as their neighbour state changes — this
+// lets Phaser batch their draw calls instead of issuing one GL bind
+// per unique tile texture.
 //
 // Visual approach mirrors Terraria-style auto-tiles:
 // - sharp pixel-art square base
@@ -12,6 +14,9 @@
 // - 3 variants per edge mask for visual variety
 
 const VARIANT_COUNT = 8;
+// Edge mask is 4 outside-corner bits + 4 inside-corner bits = 8 bits.
+const MAX_MASKS = 256;
+const MASKS_PER_ROW = 16;
 
 function makeRng(seed) {
     let s = seed | 0;
@@ -60,35 +65,207 @@ export default class TileTextureAtlas {
         this.grassB = 0x88b85c;
         this.grassDark = 0x4f7330;
 
-        this.generate();
+        this.tileTextureKey = 'tile_atlas';
+        this.curveTextureKey = 'tile_curve_atlas';
+
+        // Atlas layout: each (mask, variant) gets a tileSize × textureHeight
+        // cell at a deterministic position. MASKS_PER_ROW masks per row,
+        // VARIANT_COUNT variants packed horizontally within each mask cell.
+        // Grass frames live below all dirt frames so kind→y is constant.
+        this.cellsPerMaskRow = MASKS_PER_ROW;
+        this.atlasWidth = this.cellsPerMaskRow * this.variantCount * this.tileSize;
+        this.kindRows = Math.ceil(MAX_MASKS / this.cellsPerMaskRow);
+        this.grassYOffset = this.kindRows * this.textureHeight;
+        this.atlasHeight = this.grassYOffset * 2;
+
+        this.curveSize = this.tileSize + 4;
+        this.curveAtlasWidth = 16 * this.curveSize;
+        this.curveAtlasHeight = this.curveSize;
+
+        this._tileFramesAdded = new Set();
+        this._curveFramesAdded = new Set();
+        this._tileDirty = false;
+        this._curveDirty = false;
+
+        this._initAtlases();
+        this._generateEager();
     }
 
-    generate() {
-        // Pre-generate the simple 4-bit (no-inner-corner) cases. Inner-corner
-        // variants (mask bits 16/32/64/128) are generated lazily on first use
-        // since most aren't needed in any given playthrough.
+    _initAtlases() {
+        if (this.game.textures.exists(this.tileTextureKey)) {
+            this.game.textures.remove(this.tileTextureKey);
+        }
+        this.tileTex = this.game.textures.createCanvas(this.tileTextureKey, this.atlasWidth, this.atlasHeight);
+        this.tileCtx = this.tileTex.context;
+        this.tileCtx.imageSmoothingEnabled = false;
+
+        if (this.game.textures.exists(this.curveTextureKey)) {
+            this.game.textures.remove(this.curveTextureKey);
+        }
+        this.curveTex = this.game.textures.createCanvas(this.curveTextureKey, this.curveAtlasWidth, this.curveAtlasHeight);
+        this.curveCtx = this.curveTex.context;
+        this.curveCtx.imageSmoothingEnabled = false;
+    }
+
+    _generateEager() {
+        // 4-bit silhouette masks (0..15) cover every neighbour combination
+        // without inner-corner state, which is most of the tiles in any
+        // playthrough. Higher 8-bit masks (16+) are lazy.
         for (let mask = 0; mask < 16; mask++) {
             for (let variant = 0; variant < this.variantCount; variant++) {
-                this.makeDirtTexture(mask, variant);
+                this._makeDirtFrame(mask, variant);
                 if (mask & 1) {
-                    this.makeGrassTexture(mask, variant);
+                    this._makeGrassFrame(mask, variant);
                 }
             }
         }
+        for (let mask = 0; mask < 16; mask++) {
+            this._makeCurveFrame(mask);
+        }
+        this._flushTile();
+        this._flushCurve();
     }
 
+    _flushTile() {
+        if (!this._tileDirty) return;
+        this.tileTex.refresh();
+        this._tileDirty = false;
+    }
+
+    _flushCurve() {
+        if (!this._curveDirty) return;
+        this.curveTex.refresh();
+        this._curveDirty = false;
+    }
+
+    tileFrameName(kind, mask, variant) {
+        return `${kind}_${mask}_${variant}`;
+    }
+
+    curveFrameName(mask) {
+        return `curve_${mask}`;
+    }
+
+    _tileFramePosition(kind, mask, variant) {
+        const col = mask % this.cellsPerMaskRow;
+        const row = Math.floor(mask / this.cellsPerMaskRow);
+        const x = col * this.variantCount * this.tileSize + variant * this.tileSize;
+        const y = row * this.textureHeight + (kind === 'grass' ? this.grassYOffset : 0);
+        return { x, y };
+    }
+
+    _curveFramePosition(mask) {
+        return { x: mask * this.curveSize, y: 0 };
+    }
+
+    ensureTileFrame(kind, mask, variant) {
+        const name = this.tileFrameName(kind, mask, variant);
+        if (this._tileFramesAdded.has(name)) return name;
+        if (kind === 'grass') this._makeGrassFrame(mask, variant);
+        else this._makeDirtFrame(mask, variant);
+        this._flushTile();
+        return name;
+    }
+
+    ensureCurveFrame(mask) {
+        const name = this.curveFrameName(mask);
+        if (this._curveFramesAdded.has(name)) return name;
+        this._makeCurveFrame(mask);
+        this._flushCurve();
+        return name;
+    }
+
+    // Legacy-named wrappers kept for the existing call sites.
     keyFor(kind, mask, variant) {
-        return `tile_${kind}_${mask}_${variant}`;
+        return this.tileFrameName(kind, mask, variant);
     }
 
     ensureTexture(kind, mask, variant) {
-        const key = this.keyFor(kind, mask, variant);
-        if (!this.game.textures.exists(key)) {
-            if (kind === 'grass') this.makeGrassTexture(mask, variant);
-            else this.makeDirtTexture(mask, variant);
-        }
-        return key;
+        return this.ensureTileFrame(kind, mask, variant);
     }
+
+    cornerCurveKey(mask) {
+        return this.curveFrameName(mask);
+    }
+
+    ensureCornerCurveTexture(mask) {
+        return this.ensureCurveFrame(mask);
+    }
+
+    _makeDirtFrame(mask, variant) {
+        const name = this.tileFrameName('dirt', mask, variant);
+        if (this._tileFramesAdded.has(name)) return;
+        const { x, y } = this._tileFramePosition('dirt', mask, variant);
+        const ctx = this.tileCtx;
+        ctx.save();
+        ctx.translate(x, y);
+        ctx.clearRect(0, 0, this.tileSize, this.textureHeight);
+        this.drawBody(ctx, mask, variant, this.dirtBaseColor);
+        ctx.restore();
+        this.tileTex.add(name, 0, x, y, this.tileSize, this.textureHeight);
+        this._tileFramesAdded.add(name);
+        this._tileDirty = true;
+    }
+
+    _makeGrassFrame(mask, variant) {
+        const name = this.tileFrameName('grass', mask, variant);
+        if (this._tileFramesAdded.has(name)) return;
+        const { x, y } = this._tileFramePosition('grass', mask, variant);
+        const ctx = this.tileCtx;
+        ctx.save();
+        ctx.translate(x, y);
+        ctx.clearRect(0, 0, this.tileSize, this.textureHeight);
+        const filled = this.drawBody(ctx, mask, variant, this.dirtBaseColor);
+        this.drawGrass(ctx, mask, variant, filled);
+        ctx.restore();
+        this.tileTex.add(name, 0, x, y, this.tileSize, this.textureHeight);
+        this._tileFramesAdded.add(name);
+        this._tileDirty = true;
+    }
+
+    _makeCurveFrame(mask) {
+        const name = this.curveFrameName(mask);
+        if (this._curveFramesAdded.has(name)) return;
+        const { x, y } = this._curveFramePosition(mask);
+        const size = this.curveSize;
+        const ctx = this.curveCtx;
+        ctx.save();
+        ctx.translate(x, y);
+        ctx.clearRect(0, 0, size, size);
+
+        const outline = toCss(darken(this.dirtBaseColor, 55));
+        ctx.fillStyle = outline;
+
+        // 3-pixel L per corner. "Near" pixel sits diagonally adjacent to
+        // the tile body; the other two extend along the cave walls formed
+        // by the two solid neighbours.
+        if (mask & 1) {                         // top-left
+            ctx.fillRect(1, 1, 1, 1);
+            ctx.fillRect(0, 1, 1, 1);
+            ctx.fillRect(1, 0, 1, 1);
+        }
+        if (mask & 2) {                         // top-right
+            ctx.fillRect(size - 2, 1, 1, 1);
+            ctx.fillRect(size - 1, 1, 1, 1);
+            ctx.fillRect(size - 2, 0, 1, 1);
+        }
+        if (mask & 4) {                         // bottom-left
+            ctx.fillRect(1, size - 2, 1, 1);
+            ctx.fillRect(0, size - 2, 1, 1);
+            ctx.fillRect(1, size - 1, 1, 1);
+        }
+        if (mask & 8) {                         // bottom-right
+            ctx.fillRect(size - 2, size - 2, 1, 1);
+            ctx.fillRect(size - 1, size - 2, 1, 1);
+            ctx.fillRect(size - 2, size - 1, 1, 1);
+        }
+        ctx.restore();
+        this.curveTex.add(name, 0, x, y, size, size);
+        this._curveFramesAdded.add(name);
+        this._curveDirty = true;
+    }
+
+    // ----- Pixel-build helpers (unchanged) -----
 
     // Build a per-pixel filled mask for the body, applying corner cuts
     // where two adjacent sides face air, plus optional edge erosion for
@@ -166,11 +343,6 @@ export default class TileTextureAtlas {
     }
 
     drawBody(ctx, mask, variant, baseColor) {
-        const top = !!(mask & 1);
-        const right = !!(mask & 2);
-        const bottom = !!(mask & 4);
-        const left = !!(mask & 8);
-
         const ts = this.tileSize;
         const yOff = this.grassOverhang;
         const rng = makeRng(mask * 17 + variant * 257 + 1);
@@ -200,6 +372,10 @@ export default class TileTextureAtlas {
         // every 4-tile junction. Use a softer darken than lo.
         const seamShade = darken(baseColor, 16);
         const seamBits = Math.floor(rng() * 16);
+        const top = !!(mask & 1);
+        const right = !!(mask & 2);
+        const bottom = !!(mask & 4);
+        const left = !!(mask & 8);
         const seam = (cornerX, cornerY, conds, bit) => {
             if (!conds || !(seamBits & bit)) return;
             if (filled[cornerY][cornerX]) {
@@ -280,93 +456,12 @@ export default class TileTextureAtlas {
         }
     }
 
-    makeDirtTexture(mask, variant) {
-        const key = this.keyFor('dirt', mask, variant);
-        if (this.game.textures.exists(key)) return;
-        const tex = this.game.textures.createCanvas(key, this.tileSize, this.textureHeight);
-        const ctx = tex.context;
-        ctx.imageSmoothingEnabled = false;
-        ctx.clearRect(0, 0, this.tileSize, this.textureHeight);
-        this.drawBody(ctx, mask, variant, this.dirtBaseColor);
-        tex.refresh();
-    }
-
-    makeGrassTexture(mask, variant) {
-        const key = this.keyFor('grass', mask, variant);
-        if (this.game.textures.exists(key)) return;
-        const tex = this.game.textures.createCanvas(key, this.tileSize, this.textureHeight);
-        const ctx = tex.context;
-        ctx.imageSmoothingEnabled = false;
-        ctx.clearRect(0, 0, this.tileSize, this.textureHeight);
-        const filled = this.drawBody(ctx, mask, variant, this.dirtBaseColor);
-        this.drawGrass(ctx, mask, variant, filled);
-        tex.refresh();
-    }
-
-    // ----- Corner curve overlays for solid tiles -----
-    // Each solid tile can add a small overlay Image centred on its world
-    // position. The overlay's texture is the same size as the tile body
-    // plus a 2px overhang on each side (so e.g. 14x14 for a 10px tile).
-    // Curve pixels are drawn ONLY in the corner overhang regions — never
-    // in the body region — so the overlay sits cleanly outside the
-    // tile's bounds, extending into the adjacent diagonal cell.
-    //
-    // Pixels use the dark outline colour so they blend with the
-    // surrounding tile silhouette borders regardless of tile type.
-
     cornerCurveOverhang() {
         return 2;
     }
 
     cornerCurveSize() {
-        return this.tileSize + this.cornerCurveOverhang() * 2;
-    }
-
-    cornerCurveKey(mask) {
-        return `tile_corner_curve_${mask}`;
-    }
-
-    ensureCornerCurveTexture(mask) {
-        const key = this.cornerCurveKey(mask);
-        if (!this.game.textures.exists(key)) this.makeCornerCurveTexture(mask, key);
-        return key;
-    }
-
-    makeCornerCurveTexture(mask, key) {
-        const size = this.cornerCurveSize();
-        const tex = this.game.textures.createCanvas(key, size, size);
-        const ctx = tex.context;
-        ctx.imageSmoothingEnabled = false;
-        ctx.clearRect(0, 0, size, size);
-
-        const outline = toCss(darken(this.dirtBaseColor, 55));
-        ctx.fillStyle = outline;
-
-        // 3-pixel L per corner. The "near" pixel sits diagonally adjacent
-        // to the tile body; the other two extend along the cave walls
-        // formed by the two solid neighbours.
-        if (mask & 1) {                         // top-left
-            ctx.fillRect(1, 1, 1, 1);
-            ctx.fillRect(0, 1, 1, 1);
-            ctx.fillRect(1, 0, 1, 1);
-        }
-        if (mask & 2) {                         // top-right
-            ctx.fillRect(size - 2, 1, 1, 1);
-            ctx.fillRect(size - 1, 1, 1, 1);
-            ctx.fillRect(size - 2, 0, 1, 1);
-        }
-        if (mask & 4) {                         // bottom-left
-            ctx.fillRect(1, size - 2, 1, 1);
-            ctx.fillRect(0, size - 2, 1, 1);
-            ctx.fillRect(1, size - 1, 1, 1);
-        }
-        if (mask & 8) {                         // bottom-right
-            ctx.fillRect(size - 2, size - 2, 1, 1);
-            ctx.fillRect(size - 1, size - 2, 1, 1);
-            ctx.fillRect(size - 2, size - 1, 1, 1);
-        }
-
-        tex.refresh();
+        return this.curveSize;
     }
 
     // True when the cell at (worldX, worldY) is a solid wall-forming tile.


### PR DESCRIPTION
## Summary
This PR significantly improves rendering performance and spatial query efficiency by consolidating tile textures into packed atlases and introducing a spatial index for O(1) entity lookups instead of full-group scans.

## Key Changes

### Texture Atlas Consolidation (tileTextureAtlas.js)
- **Packed texture atlases**: Replaced individual per-tile textures with two packed canvas atlases:
  - `tile_atlas`: Contains all dirt and grass tile variants (256 masks × 8 variants) in a single texture with deterministic frame positions
  - `tile_curve_atlas`: Contains all 16 corner curve overlays in a single texture
- **Frame-based rendering**: Tiles now reference the same atlas texture and swap frames as neighbor state changes, enabling Phaser to batch draw calls instead of issuing one GL bind per unique tile texture
- **Lazy generation**: High-bit masks (16+) are generated on-demand; eager generation covers the common 4-bit cases (0-15)
- **Gutter padding**: Added 1px transparent gutters around frames to prevent GPU sampling artifacts during sub-pixel sprite positioning

### Spatial Indexing (map.js)
- **Sprite index**: Added `spriteIndex` data structure mapping chunk keys → 2D arrays of sprites for O(1) neighbor lookups
- **Grid versioning**: Introduced `gridVersion` counter to track world state changes for minimap and other consumers
- **Optimized queries**:
  - `spriteAtWorld()`: O(1) lookup replaces scanning all entity groups
  - `getAdjacentBlocks()`: Now uses spatial index instead of iterating all entities
  - `getEntitiesAround()`: Uses spatial index with bounding box + distance check instead of full scan
  - `refreshNeighborEdges()`: O(8) fixed lookups instead of scanning soil/buttress groups
- **Synchronous chunk loading**: Removed `requestAnimationFrame` deferral to prevent camera scrolling ahead of loaded chunks

### Lazy Graphics Initialization (tile.js)
- **Deferred border graphics**: `borderGraphics` now created on-demand via `_ensureBorderGraphics()` instead of per-tile at init
- **Cleanup methods**: Added `_destroyBorderGraphics()` to properly clean up tweens and graphics on tile destruction
- **Spatial index registration**: Tiles now register their sprites in the spatial index during `init()` to handle both eager and delayed initialization paths

### Minimap Optimization (minimapManager.js)
- **Change detection**: Skip full canvas repaint when player position, grid version, and fog version haven't changed
- **Chunk caching**: Cache the last chunk accessed to avoid repeated string concat + dict lookups within the same chunk
- **Improved chunk math**: Simplified chunk coordinate calculation using modulo arithmetic

### Lighting Optimization (lighting.js)
- **Frustum culling**: Only cast light for sources within camera view (with 1.9× radius bloom halo margin)
- **Loop refactoring**: Changed from `forEach` to indexed loop for better control and early continue

### Curve Overlay Lazy Creation (breakable.js, buttress.js)
- **On-demand creation**: `curveOverlay` sprites now created only when needed (mask ≠ 0) instead of pre-allocated
- **Frame-based updates**: Use frame names instead of texture keys for comparison and updates
- **Shared atlas**: All curve overlays reference the same `curveTextureKey` with different frames

### Batch Processing Stability (GameScene.js)
- **Snapshot arrays**: `checkState()` batch processing now snapshots group children before iteration to handle mid-batch tile destruction
- **Stable group alias**: Added `interactableGroup` as alias for `liftControlGroup` for clarity

### Memory Cleanup
- All tile subclasses now call `_destroyBorderGraphics()` in their destroy methods to prevent graphics leaks

## Implementation Details
- Texture atlas layout is deterministic: `(mask % MASKS_PER_ROW, mask / MASKS_PER_ROW)` for position, with variants packed horizontally
- Spatial index uses chunk keys as primary key, then 2D arrays indexed by local tile coordinates

https://claude.ai/code/session_01SLwmAdcCKhLU2DXAa6ekfj