### PR TITLE
Implement crafting system and unified Pip-Boy UI theme

### DIFF
--- a/src/classes/breakable.js
+++ b/src/classes/breakable.js
@@ -365,6 +365,13 @@ export class Breakable extends Tile {
                     this.game.dustEmitter.explode(50);
                     baseCell = this.tileDetails.trapped || {...this.game.tileTypes.empty};
                     this.clicking = false;
+                    // Coal veins also drop a unit straight to the player's
+                    // inventory so crafting at the lift doesn't require a
+                    // minecart pickup. The minecart catch path still works
+                    // for the visible debris that scatters from the break.
+                    if (this.tileDetails.type === 1) {
+                        this.game.inventoryManager?.addCoal?.(1);
+                    }
                     this.game.mapService.setTile(this.worldX, this.worldY, baseCell, this.sprite);
                 } else {
                     this.game.dustEmitter.explode(5);

--- a/src/classes/minecart.js
+++ b/src/classes/minecart.js
@@ -76,6 +76,45 @@ export class MineCart {
         }
     }
 
+    hasCargo() {
+        return Object.values(this.inventory).some(v => v > 0);
+    }
+
+    // True if the cart is sitting one cell away from a lift control on any
+    // side. Cart x/y are tweened between tile-aligned goals, so we snap to
+    // the nearest grid cell before asking the map service for neighbours.
+    liftControlAdjacent() {
+        const ts = this.game.tileSize;
+        const liftId = this.game.tileTypes?.liftControl?.id;
+        if (liftId == null) return false;
+        const snapX = Math.round(this.sprite.x / ts) * ts;
+        const snapY = Math.round(this.sprite.y / ts) * ts;
+        const adj = this.game.mapService.getAdjacentBlocks(snapX, snapY);
+        return Object.values(adj).some(b => b?.tileRef?.tileDetails?.id === liftId);
+    }
+
+    /**
+     * Hand the cart's contents off to the player's stockpile. Currently the
+     * cart only ever catches coal (the one material breakable debris is
+     * created from), but the dispatch table covers wood too so trees
+     * dropping debris in the future Just Works without touching this code.
+     * Anything unmapped is silently left behind so we don't drop arbitrary
+     * inventory items into wood/coal stacks.
+     */
+    dumpToStockpile() {
+        const im = this.game.inventoryManager;
+        if (!im) return;
+        const handlers = {
+            coal: (n) => im.addCoal(n),
+            wood: (n) => im.addWood(n),
+        };
+        Object.entries(this.inventory).forEach(([key, count]) => {
+            if (count > 0 && handlers[key]) handlers[key](count);
+        });
+        this.inventory = {};
+        this.UI?.clearInventoryDisplay?.();
+    }
+
     setRotation(rotation) {
         this.rotation = rotation;
 

--- a/src/classes/minecartUI.js
+++ b/src/classes/minecartUI.js
@@ -1,5 +1,44 @@
 import {getColorForPercentage} from "../services/colourManager";
 
+// Pip-Boy phosphor palette — matches the lift terminal, inventory window,
+// and tool wheel so the cart UI reads as the same in-world device.
+const PIP_GREEN = 0x33ff33;
+const PIP_DIM = 0x1a8a1a;
+const PIP_BG = 0x001a00;
+const PIP_GREEN_CSS = '#33ff33';
+const PIP_DIM_CSS = '#1a8a1a';
+const PIP_FONT = '"VT323", "Share Tech Mono", monospace';
+
+const TITLE_STYLE = {
+    fontSize: '12px',
+    color: PIP_GREEN_CSS,
+    fontFamily: PIP_FONT,
+    shadow: { color: PIP_GREEN_CSS, fill: false, offsetX: 0, offsetY: 0, blur: 4 },
+};
+
+const LABEL_STYLE = {
+    fontSize: '10px',
+    color: PIP_DIM_CSS,
+    fontFamily: PIP_FONT,
+    shadow: { color: PIP_GREEN_CSS, fill: false, offsetX: 0, offsetY: 0, blur: 2 },
+};
+
+const VALUE_STYLE = {
+    fontSize: '11px',
+    color: PIP_GREEN_CSS,
+    fontFamily: PIP_FONT,
+    shadow: { color: PIP_GREEN_CSS, fill: false, offsetX: 0, offsetY: 0, blur: 3 },
+};
+
+const COUNT_STYLE = {
+    fontSize: '11px',
+    color: PIP_GREEN_CSS,
+    fontFamily: PIP_FONT,
+    stroke: '#000000',
+    strokeThickness: 2,
+    shadow: { color: PIP_GREEN_CSS, fill: false, offsetX: 0, offsetY: 0, blur: 3 },
+};
+
 export default class MineCartUI {
     constructor(cart, x, y) {
         const game = cart.game;
@@ -7,104 +46,93 @@ export default class MineCartUI {
         this.game = game;
         this.inventory = {};
 
-        // 1) Create a container at position (x, y)
         this.container = game.add.container(x, y);
 
-        // 2) Background rectangle with cyberpunk styling
-        this.bg = game.add.rectangle(0, 0, 260, 135, 0x000000, 0.9);
-        this.bg.setOrigin(0, 0); // top-left origin
-        this.bg.setStrokeStyle(2, 0x00ffff);
+        // Outer phosphor frame — solid green border, dark green-tinted
+        // background so the panel sits like a CRT readout above the cart.
+        this.bg = game.add.rectangle(0, 0, 260, 135, PIP_BG, 0.92);
+        this.bg.setOrigin(0, 0);
+        this.bg.setStrokeStyle(2, PIP_GREEN);
         this.container.add(this.bg);
-        
-        // Add inner glow effect
-        this.innerGlow = game.add.rectangle(2, 2, 256, 131, 0x00ffff, 0.1);
+
+        // Subtle inset glow so the whole panel reads as lit phosphor.
+        this.innerGlow = game.add.rectangle(2, 2, 256, 131, PIP_GREEN, 0.05);
         this.innerGlow.setOrigin(0, 0);
         this.container.add(this.innerGlow);
-        
-        this.placeholders = {}
 
+        // Top divider + title strip so the panel looks like a terminal
+        // readout instead of a floating tooltip.
+        this.titleBar = game.add.rectangle(0, 0, 260, 16, PIP_GREEN, 0.12);
+        this.titleBar.setOrigin(0, 0);
+        this.titleBar.setStrokeStyle(1, PIP_DIM);
+        this.container.add(this.titleBar);
+        this.title = game.add.text(8, 2, '> CART // STATUS', TITLE_STYLE);
+        this.container.add(this.title);
+
+        // Three placeholder slots for material icons. Bordered green so
+        // even an empty cart looks like a populated readout.
+        this.placeholders = {};
         for (let i = 0; i < 3; i++) {
-            let xPos = 35 + i * (40 + 8); // Better spacing
-            this.placeholders[i] = game.add.rectangle(xPos, 35, 40, 40, 0x000000, 0.8);
-            this.placeholders[i].setStrokeStyle(1, 0x00ffff);
+            let xPos = 15 + i * (40 + 8);
+            this.placeholders[i] = game.add.rectangle(xPos, 25, 40, 40, PIP_BG, 0.6);
+            this.placeholders[i].setOrigin(0, 0);
+            this.placeholders[i].setStrokeStyle(1, PIP_DIM);
             this.container.add(this.placeholders[i]);
         }
 
-        // Progress bar background with cyberpunk styling
-        this.progressBg = game.add.rectangle(15, 95, 130, 12, 0x000000);
+        // Progress bar — phosphor frame, neon fill keyed to cart load.
+        this.progressLabel = game.add.text(15, 78, 'LOAD', LABEL_STYLE);
+        this.container.add(this.progressLabel);
+        this.progressBg = game.add.rectangle(15, 92, 130, 10, PIP_BG, 0.85);
         this.progressBg.setOrigin(0, 0);
-        this.progressBg.setStrokeStyle(1, 0x00ffff);
+        this.progressBg.setStrokeStyle(1, PIP_DIM);
         this.container.add(this.progressBg);
-        
-        // Progress bar fill with neon effect
-        this.progressFill = game.add.rectangle(15, 95, 130 * this.cart.percentageFull, 12, getColorForPercentage(this.cart.percentageFull));
+        this.progressFill = game.add.rectangle(15, 92, 130 * this.cart.percentageFull, 10, getColorForPercentage(this.cart.percentageFull));
         this.progressFill.setOrigin(0, 0);
         this.container.add(this.progressFill);
-
-        // Progress text with cyberpunk styling
-        this.progressText = game.add.text(15, 112, `${this.cart.currentWeight}kg / ${this.cart.maxWeight}kg`, {
-            fontSize: '11px',
-            color: '#00ffff',
-            fontFamily: 'monospace',
-            fontStyle: 'bold'
-        });
+        this.progressText = game.add.text(15, 108, `${this.cart.currentWeight}KG / ${this.cart.maxWeight}KG`, VALUE_STYLE);
         this.container.add(this.progressText);
 
-        // Direction arrows with cyberpunk styling
-        this.arrowRight = this.game.add.triangle(
-            210, 55,
-            0, 0, 10, 7, 0, 14,
-            0x00ffff,
-            1
-        );
-        this.arrowRight.setStrokeStyle(1, 0x000000);
+        // Direction selector — phosphor triangles on the right side.
+        this.directionLabel = this.game.add.text(165, 78, 'DIRECTION', LABEL_STYLE);
+        this.container.add(this.directionLabel);
 
-        this.arrowRight.setInteractive(
-            new Phaser.Geom.Triangle(0, 0, 10, 7, 0, 14),
-            Phaser.Geom.Triangle.Contains
-        );
-
-        this.arrowRight.on('pointerdown', (e) => {
-            this.arrowLeft.setAlpha(0.3);
-            this.arrowRight.setAlpha(1);
-            cart.changeDirections({right: true})
-        });
-
-        this.container.add(this.arrowRight);
+        const arrowGeomR = new Phaser.Geom.Triangle(0, 0, 10, 7, 0, 14);
+        const arrowGeomL = new Phaser.Geom.Triangle(0, 7, 10, 0, 10, 14);
 
         this.arrowLeft = this.game.add.triangle(
-            180, 55,
+            180, 95,
             0, 7, 10, 0, 10, 14,
-            0x00ffff,
+            PIP_GREEN,
             1
         );
-        this.arrowLeft.setStrokeStyle(1, 0x000000);
-
-        this.arrowLeft.setInteractive(
-            new Phaser.Geom.Triangle(0, 7, 10, 0, 10, 14),
-            Phaser.Geom.Triangle.Contains
-        );
-
-        this.arrowLeft.on('pointerdown', (e) => {
+        this.arrowLeft.setStrokeStyle(1, PIP_GREEN);
+        this.arrowLeft.setInteractive(arrowGeomL, Phaser.Geom.Triangle.Contains);
+        this.arrowLeft.on('pointerdown', () => {
             this.arrowRight.setAlpha(0.3);
             this.arrowLeft.setAlpha(1);
-            cart.changeDirections({left: true})
+            cart.changeDirections({left: true});
         });
-
         this.container.add(this.arrowLeft);
 
-        // Direction text with cyberpunk styling
-        this.directionText = this.game.add.text(165, 80, 'DIRECTION', {
-            fontSize: '10px',
-            color: '#00ffff',
-            fontFamily: 'monospace',
-            fontStyle: 'bold'
+        this.arrowRight = this.game.add.triangle(
+            215, 95,
+            0, 0, 10, 7, 0, 14,
+            PIP_GREEN,
+            1
+        );
+        this.arrowRight.setStrokeStyle(1, PIP_GREEN);
+        this.arrowRight.setInteractive(arrowGeomR, Phaser.Geom.Triangle.Contains);
+        this.arrowRight.on('pointerdown', () => {
+            this.arrowLeft.setAlpha(0.3);
+            this.arrowRight.setAlpha(1);
+            cart.changeDirections({right: true});
         });
-        this.container.add(this.directionText);
+        this.container.add(this.arrowRight);
 
-        // Separator line with cyberpunk styling
-        this.line = this.game.add.line(0, 0, 150, 65, 150, 150, 0x00ffff, 1);
-        this.line.strokeWidth = 2;
+        // Vertical phosphor divider between cargo + direction columns.
+        this.line = this.game.add.line(0, 0, 155, 70, 155, 128, PIP_DIM, 1);
+        this.line.strokeWidth = 1;
         this.container.add(this.line);
 
         if (cart.directions['left']) {
@@ -120,45 +148,41 @@ export default class MineCartUI {
     update() {
         this.setPosition(this.cart.sprite.x - this.cart.sprite.displayWidth / 2, this.cart.sprite.y + this.cart.sprite.displayHeight / 2 + 2);
 
-        let index = 1;
         Object.entries(this.cart.inventory).forEach(([key, value], index) => {
-            let xPos = 15 + index * (40 + 8);
-            if (!this.inventory[key]) {
-                this.inventory[`${key}_image`] = this.game.add.image(15, 15, key);
+            const xPos = 15 + index * (40 + 8);
+            if (!this.inventory[`${key}_image`]) {
+                this.inventory[`${key}_image`] = this.game.add.image(xPos, 25, key);
                 this.inventory[`${key}_image`].setDisplaySize(40, 40);
                 this.inventory[`${key}_image`].setOrigin(0, 0);
-                this.inventory[`${key}_image`].setPosition(15, 15);
-                
-                // Item count with cyberpunk styling
-                this.inventory[`${key}_count`] = this.game.add.text(22, 22, value, {
-                    fontSize: '11px',
-                    color: '#ffffff',
-                    fontFamily: 'monospace',
-                    fontStyle: 'bold',
-                    stroke: '#000000',
-                    strokeThickness: 2
-                });
-                
-                // Item name with cyberpunk styling
-                this.inventory[key] = this.game.add.text(xPos, 60, key.toUpperCase(), {
-                    fontSize: '10px',
-                    color: '#00ffff',
-                    fontFamily: 'monospace',
-                    fontStyle: 'bold'
-                });
-                this.container.add(this.inventory[key]);
+                // Hue-shift the material icon to phosphor green so it
+                // matches the rest of the CRT — Phaser's tint multiplies
+                // the texture by this colour, so we use PIP_GREEN.
+                this.inventory[`${key}_image`].setTint(PIP_GREEN);
+
+                this.inventory[`${key}_count`] = this.game.add.text(xPos + 4, 27, value, COUNT_STYLE);
+
+                this.inventory[`${key}_name`] = this.game.add.text(xPos, 64, key.toUpperCase(), LABEL_STYLE);
                 this.container.add(this.inventory[`${key}_image`]);
                 this.container.add(this.inventory[`${key}_count`]);
+                this.container.add(this.inventory[`${key}_name`]);
             } else {
                 this.inventory[`${key}_count`].setText(value);
+                this.inventory[`${key}_image`].setPosition(xPos, 25);
+                this.inventory[`${key}_count`].setPosition(xPos + 4, 27);
+                this.inventory[`${key}_name`].setPosition(xPos, 64);
             }
-            index++;
         });
-        
-        // Update progress bar with neon glow
+
         this.progressFill.width = 130 * this.cart.percentageFull;
         this.progressFill.setFillStyle(getColorForPercentage(this.cart.percentageFull));
-        this.progressText.setText(`${this.cart.currentWeight}kg / ${this.cart.maxWeight}kg`);
+        this.progressText.setText(`${this.cart.currentWeight}KG / ${this.cart.maxWeight}KG`);
+    }
+
+    // Drop every per-material image / count / name so the UI doesn't show
+    // stale entries after dumpToStockpile() empties cart.inventory.
+    clearInventoryDisplay() {
+        Object.values(this.inventory).forEach(obj => obj?.destroy?.());
+        this.inventory = {};
     }
 
     setPosition(x, y) {
@@ -166,7 +190,6 @@ export default class MineCartUI {
         this.container.y = y;
     }
 
-    // Show / hide the entire panel
     show() {
         this.container.setVisible(true);
     }

--- a/src/services/InventoryManager.js
+++ b/src/services/InventoryManager.js
@@ -1,7 +1,13 @@
-import { HUD } from './uiManager.js';
 import InventoryItem from '../classes/InventoryItem.js';
 
 const STYLE_ID = 'inventory-panel-styles';
+
+// Pip-Boy phosphor palette — matches the lift terminal so the whole
+// player-facing UI reads as the same in-world device.
+const PIP_GREEN = '#33ff33';
+const PIP_DIM = '#1a8a1a';
+const PIP_FAINT = '#0d4a0d';
+const PIP_BG = 'rgba(0, 16, 0, 0.97)';
 
 // Equipment slots are passive for now — they accept any item via drag &
 // drop so the rig of equipment can be assembled, but there's no armor /
@@ -16,68 +22,115 @@ const EQUIPMENT_SLOTS = [
 
 function injectStyles() {
     if (document.getElementById(STYLE_ID)) return;
+    // VT323 / Share Tech Mono are loaded by the lift terminal too. The
+    // request is idempotent so a second <link> is fine if the terminal
+    // hasn't been opened yet.
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://fonts.googleapis.com/css2?family=VT323&family=Share+Tech+Mono&display=swap';
+    document.head.appendChild(link);
+
     const style = document.createElement('style');
     style.id = STYLE_ID;
     style.textContent = `
         .inventory-panel {
-            font-family: ${HUD.font};
-            color: ${HUD.text};
+            font-family: 'VT323', 'Share Tech Mono', monospace;
+            color: ${PIP_GREEN};
+            background: ${PIP_BG};
+            border: 2px solid ${PIP_GREEN};
+            box-shadow: 0 0 30px rgba(51, 255, 51, 0.4),
+                        inset 0 0 60px rgba(51, 255, 51, 0.05);
+            text-shadow: 0 0 4px rgba(51, 255, 51, 0.6);
             display: flex;
             flex-direction: column;
-            gap: 0;
             width: min(720px, calc(100vw - 32px));
             max-height: calc(100vh - 32px);
+            user-select: none;
+            border-radius: 0;
+            backdrop-filter: none;
+            -webkit-backdrop-filter: none;
+        }
+        .inventory-panel::after {
+            content: '';
+            position: absolute;
+            inset: 0;
+            background: repeating-linear-gradient(
+                to bottom,
+                rgba(0,0,0,0) 0,
+                rgba(0,0,0,0) 2px,
+                rgba(0,0,0,0.18) 2px,
+                rgba(0,0,0,0.18) 3px
+            );
+            pointer-events: none;
         }
         .inventory-panel .ip-header {
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            padding: 12px 16px;
-            border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+            display: grid;
+            grid-template-columns: 1fr auto 1fr;
+            align-items: baseline;
+            gap: 12px;
+            padding: 12px 18px 8px;
+            border-bottom: 1px dashed ${PIP_DIM};
         }
         .inventory-panel .ip-title {
-            display: flex; align-items: center; gap: 10px;
+            grid-column: 2;
+            text-align: center;
+            font-size: 22px;
+            letter-spacing: 0.18em;
+            color: ${PIP_GREEN};
         }
-        .inventory-panel .ip-title .dot {
-            width: 6px; height: 6px; border-radius: 50%;
-            background: ${HUD.accent};
-            box-shadow: 0 0 10px ${HUD.accent};
+        .inventory-panel .ip-link {
+            font-size: 12px;
+            letter-spacing: 0.22em;
+            color: ${PIP_DIM};
         }
-        .inventory-panel .ip-title span {
-            font-size: 13px;
-            font-weight: 600;
-            letter-spacing: 0.08em;
-            text-transform: uppercase;
-            color: ${HUD.text};
+        .inventory-panel .ip-link .dot {
+            display: inline-block;
+            width: 6px;
+            height: 6px;
+            border-radius: 50%;
+            background: ${PIP_GREEN};
+            box-shadow: 0 0 6px ${PIP_GREEN};
+            margin-right: 6px;
+            animation: ip-blink 1.2s ease-in-out infinite;
+        }
+        .inventory-panel .ip-link-right {
+            justify-self: end;
+        }
+        @keyframes ip-blink {
+            0%, 60%, 100% { opacity: 1; }
+            70%, 90% { opacity: 0.25; }
         }
         .inventory-panel .ip-hint {
-            font-size: 11px;
-            color: ${HUD.textMuted};
+            grid-column: 1;
+            justify-self: start;
+            font-size: 12px;
+            letter-spacing: 0.18em;
+            color: ${PIP_DIM};
         }
         .inventory-panel .ip-hint kbd {
-            font-family: ${HUD.fontMono};
-            font-size: 10px;
-            font-weight: 600;
-            color: ${HUD.text};
-            background: rgba(255, 255, 255, 0.08);
-            border: 1px solid rgba(255, 255, 255, 0.12);
-            border-radius: 4px;
-            padding: 2px 6px;
+            font-family: inherit;
+            font-size: 12px;
+            color: ${PIP_GREEN};
+            background: transparent;
+            border: 1px solid ${PIP_DIM};
+            border-radius: 0;
+            padding: 0 5px;
             margin: 0 2px;
+            text-shadow: inherit;
         }
         .inventory-panel .ip-body {
             display: grid;
-            grid-template-columns: 220px 1fr;
+            grid-template-columns: 240px 1fr;
             gap: 16px;
-            padding: 16px;
+            padding: 14px 18px 16px;
         }
         .inventory-panel .ip-section-label {
-            font-size: 10px;
-            font-weight: 600;
-            letter-spacing: 0.16em;
-            text-transform: uppercase;
-            color: ${HUD.textMuted};
-            margin: 0 0 8px;
+            font-size: 13px;
+            letter-spacing: 0.18em;
+            color: ${PIP_GREEN};
+            margin: 0 0 6px;
+            padding-bottom: 2px;
+            border-bottom: 1px dashed ${PIP_DIM};
         }
         .inventory-panel .ip-character {
             display: flex;
@@ -87,24 +140,21 @@ function injectStyles() {
         .inventory-panel .ip-char-frame {
             position: relative;
             display: grid;
-            grid-template-columns: 1fr 60px;
+            grid-template-columns: 1fr 72px;
             gap: 8px;
-            padding: 10px;
-            background: linear-gradient(180deg, rgba(0,0,0,0.55) 0%, rgba(0,0,0,0.25) 100%);
-            border: 1px solid rgba(255, 255, 255, 0.08);
-            border-radius: 10px;
-            box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+            padding: 8px;
+            background: rgba(0, 24, 0, 0.45);
+            border: 1px solid ${PIP_DIM};
         }
         .inventory-panel .ip-char-portrait {
             display: flex;
             align-items: center;
             justify-content: center;
-            min-height: 180px;
+            min-height: 190px;
             background:
-                radial-gradient(120% 90% at 50% 30%, rgba(91, 157, 255, 0.18) 0%, rgba(91, 157, 255, 0) 60%),
-                linear-gradient(180deg, rgba(255, 255, 255, 0.04) 0%, rgba(0, 0, 0, 0.25) 100%);
-            border: 1px solid rgba(255, 255, 255, 0.06);
-            border-radius: 8px;
+                radial-gradient(120% 90% at 50% 30%, rgba(51, 255, 51, 0.10) 0%, rgba(0, 0, 0, 0) 65%),
+                linear-gradient(180deg, rgba(0, 24, 0, 0.4) 0%, rgba(0, 0, 0, 0.5) 100%);
+            border: 1px solid ${PIP_DIM};
             position: relative;
             overflow: hidden;
         }
@@ -115,17 +165,20 @@ function injectStyles() {
             background: repeating-linear-gradient(
                 to bottom,
                 rgba(0,0,0,0) 0,
-                rgba(0,0,0,0) 3px,
-                rgba(0,0,0,0.18) 3px,
-                rgba(0,0,0,0.18) 4px
+                rgba(0,0,0,0) 2px,
+                rgba(0,0,0,0.30) 2px,
+                rgba(0,0,0,0.30) 3px
             );
             pointer-events: none;
         }
         .inventory-panel .ip-char-portrait img {
             image-rendering: pixelated;
-            height: 78%;
-            max-height: 160px;
-            filter: drop-shadow(0 6px 14px rgba(0, 0, 0, 0.6));
+            height: 82%;
+            max-height: 170px;
+            filter:
+                drop-shadow(0 0 6px rgba(51, 255, 51, 0.55))
+                drop-shadow(0 0 2px rgba(51, 255, 51, 0.8))
+                brightness(0.6) sepia(1) hue-rotate(60deg) saturate(6);
         }
         .inventory-panel .ip-equipment {
             display: flex;
@@ -134,7 +187,7 @@ function injectStyles() {
         }
         .inventory-panel .ip-grid {
             display: grid;
-            gap: 6px;
+            gap: 4px;
         }
         .inventory-panel .ip-grid.inv {
             grid-template-columns: repeat(6, 56px);
@@ -146,87 +199,83 @@ function injectStyles() {
             width: 56px;
             height: 56px;
             box-sizing: border-box;
-            background: linear-gradient(135deg, rgba(255, 255, 255, 0.04) 0%, rgba(255, 255, 255, 0.01) 100%);
-            border: 1px solid rgba(255, 255, 255, 0.08);
-            border-radius: 8px;
+            background: rgba(0, 24, 0, 0.35);
+            border: 1px solid ${PIP_DIM};
+            border-radius: 0;
             padding: 6px;
             position: relative;
             cursor: pointer;
             display: flex;
             align-items: center;
             justify-content: center;
-            transition: transform 160ms ease, border-color 160ms ease, background 160ms ease, box-shadow 160ms ease;
-            box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+            transition: background 80ms, border-color 80ms;
         }
         .inventory-panel .ip-slot:hover {
-            transform: translateY(-1px);
-            border-color: rgba(91, 157, 255, 0.55);
-            background: linear-gradient(135deg, rgba(91, 157, 255, 0.12) 0%, rgba(91, 157, 255, 0.04) 100%);
-            box-shadow: 0 0 0 2px rgba(91, 157, 255, 0.15), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+            background: rgba(51, 255, 51, 0.12);
+            border-color: ${PIP_GREEN};
         }
         .inventory-panel .ip-slot.equipment {
             width: 100%;
-            height: 48px;
-            border-radius: 6px;
+            height: 56px;
         }
         .inventory-panel .ip-slot.equipment .placeholder {
-            font-size: 9px;
-            font-weight: 600;
-            color: ${HUD.textDim};
+            font-size: 12px;
+            color: ${PIP_DIM};
             letter-spacing: 0.16em;
             text-transform: uppercase;
             text-align: center;
             line-height: 1.1;
         }
         .inventory-panel .ip-slot.hotbar.selected {
-            border-color: ${HUD.accent};
-            background: linear-gradient(135deg, rgba(91, 157, 255, 0.20) 0%, rgba(91, 157, 255, 0.08) 100%);
-            box-shadow: 0 0 0 2px rgba(91, 157, 255, 0.22), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+            border-color: ${PIP_GREEN};
+            background: rgba(51, 255, 51, 0.18);
+            box-shadow: inset 0 0 8px rgba(51, 255, 51, 0.35),
+                        0 0 6px rgba(51, 255, 51, 0.4);
         }
         .inventory-panel .ip-slot img {
             width: 78%;
             height: 78%;
             object-fit: contain;
-            filter: drop-shadow(0 2px 6px rgba(0, 0, 0, 0.6));
+            filter:
+                drop-shadow(0 0 3px rgba(51, 255, 51, 0.55))
+                brightness(0.7) sepia(1) hue-rotate(60deg) saturate(5);
             pointer-events: auto;
         }
         .inventory-panel .ip-slot .stack {
-            color: #fff;
+            color: ${PIP_GREEN};
             position: absolute;
-            bottom: 3px;
+            bottom: 2px;
             right: 4px;
-            font-weight: 700;
-            font-size: 10px;
-            font-family: ${HUD.fontMono};
-            background: rgba(0, 0, 0, 0.65);
-            border: 1px solid rgba(255, 255, 255, 0.15);
-            border-radius: 5px;
-            padding: 1px 4px;
-            min-width: 16px;
+            font-family: inherit;
+            font-size: 13px;
+            background: rgba(0, 16, 0, 0.85);
+            border: 1px solid ${PIP_DIM};
+            padding: 0 3px;
+            min-width: 14px;
             text-align: center;
-            backdrop-filter: blur(6px);
             pointer-events: none;
             font-variant-numeric: tabular-nums;
+            text-shadow: 0 0 3px rgba(51, 255, 51, 0.6);
+            line-height: 1.1;
         }
         .inventory-panel .ip-slot .hotkey {
             position: absolute;
-            top: 3px;
-            left: 5px;
-            font-family: ${HUD.fontMono};
-            font-size: 9px;
-            font-weight: 600;
-            color: ${HUD.textDim};
+            top: 1px;
+            left: 4px;
+            font-family: inherit;
+            font-size: 12px;
+            color: ${PIP_DIM};
             letter-spacing: 0.05em;
             pointer-events: none;
+            text-shadow: 0 0 2px rgba(51, 255, 51, 0.4);
         }
         .inventory-panel .ip-slot.hotbar.selected .hotkey {
-            color: ${HUD.accent};
+            color: ${PIP_GREEN};
         }
         .inventory-panel .ip-slot .empty {
-            width: 16px;
-            height: 16px;
-            border-radius: 4px;
-            border: 1px dashed rgba(255, 255, 255, 0.10);
+            width: 12px;
+            height: 12px;
+            border: 1px dashed ${PIP_FAINT};
             pointer-events: none;
         }
         .inventory-panel .ip-slot.equipment .empty { display: none; }
@@ -234,11 +283,6 @@ function injectStyles() {
             display: flex;
             flex-direction: column;
             gap: 14px;
-        }
-        .inventory-panel .ip-divider {
-            border: 0;
-            border-top: 1px dashed rgba(255, 255, 255, 0.08);
-            margin: 4px 0 2px;
         }
     `;
     document.head.appendChild(style);
@@ -263,7 +307,7 @@ export default class InventoryManager {
         injectStyles();
         this.container = document.createElement('div');
         this.container.id = containerId;
-        this.container.className = 'hud-panel inventory-panel';
+        this.container.className = 'inventory-panel';
         Object.assign(this.container.style, {
             position: 'fixed',
             top: '50%',
@@ -277,15 +321,13 @@ export default class InventoryManager {
 
         this.container.innerHTML = `
             <div class="ip-header">
-                <div class="ip-title">
-                    <span class="dot"></span>
-                    <span>Inventory</span>
-                </div>
-                <div class="ip-hint">Press <kbd>I</kbd> to close</div>
+                <div class="ip-hint">[ <kbd>I</kbd> CLOSE ]</div>
+                <div class="ip-title">ROOBOO PIP-INV</div>
+                <div class="ip-link ip-link-right"><span class="dot"></span>SYS-LINK</div>
             </div>
             <div class="ip-body">
                 <div class="ip-character">
-                    <div class="ip-section-label">Character</div>
+                    <div class="ip-section-label">CHARACTER</div>
                     <div class="ip-char-frame">
                         <div class="ip-char-portrait">
                             <img src="images/player.png" alt="Character" draggable="false">
@@ -295,11 +337,11 @@ export default class InventoryManager {
                 </div>
                 <div class="ip-inv-side">
                     <div>
-                        <div class="ip-section-label">Backpack</div>
+                        <div class="ip-section-label">BACKPACK</div>
                         <div class="ip-grid inv" data-slot-group="inventory"></div>
                     </div>
                     <div>
-                        <div class="ip-section-label">Hotbar</div>
+                        <div class="ip-section-label">HOTBAR</div>
                         <div class="ip-grid hotbar" data-slot-group="hotbar"></div>
                     </div>
                 </div>

--- a/src/services/InventoryManager.js
+++ b/src/services/InventoryManager.js
@@ -1,6 +1,249 @@
 import { HUD } from './uiManager.js';
 import InventoryItem from '../classes/InventoryItem.js';
 
+const STYLE_ID = 'inventory-panel-styles';
+
+// Equipment slots are passive for now — they accept any item via drag &
+// drop so the rig of equipment can be assembled, but there's no armor /
+// stat system reading from them yet. The set + order here determines the
+// vertical layout in the character pane.
+const EQUIPMENT_SLOTS = [
+    { id: 'head', label: 'Helmet' },
+    { id: 'chest', label: 'Chest' },
+    { id: 'legs', label: 'Legs' },
+    { id: 'feet', label: 'Boots' },
+];
+
+function injectStyles() {
+    if (document.getElementById(STYLE_ID)) return;
+    const style = document.createElement('style');
+    style.id = STYLE_ID;
+    style.textContent = `
+        .inventory-panel {
+            font-family: ${HUD.font};
+            color: ${HUD.text};
+            display: flex;
+            flex-direction: column;
+            gap: 0;
+            width: min(720px, calc(100vw - 32px));
+            max-height: calc(100vh - 32px);
+        }
+        .inventory-panel .ip-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 12px 16px;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+        }
+        .inventory-panel .ip-title {
+            display: flex; align-items: center; gap: 10px;
+        }
+        .inventory-panel .ip-title .dot {
+            width: 6px; height: 6px; border-radius: 50%;
+            background: ${HUD.accent};
+            box-shadow: 0 0 10px ${HUD.accent};
+        }
+        .inventory-panel .ip-title span {
+            font-size: 13px;
+            font-weight: 600;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            color: ${HUD.text};
+        }
+        .inventory-panel .ip-hint {
+            font-size: 11px;
+            color: ${HUD.textMuted};
+        }
+        .inventory-panel .ip-hint kbd {
+            font-family: ${HUD.fontMono};
+            font-size: 10px;
+            font-weight: 600;
+            color: ${HUD.text};
+            background: rgba(255, 255, 255, 0.08);
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+        }
+        .inventory-panel .ip-body {
+            display: grid;
+            grid-template-columns: 220px 1fr;
+            gap: 16px;
+            padding: 16px;
+        }
+        .inventory-panel .ip-section-label {
+            font-size: 10px;
+            font-weight: 600;
+            letter-spacing: 0.16em;
+            text-transform: uppercase;
+            color: ${HUD.textMuted};
+            margin: 0 0 8px;
+        }
+        .inventory-panel .ip-character {
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+        }
+        .inventory-panel .ip-char-frame {
+            position: relative;
+            display: grid;
+            grid-template-columns: 1fr 60px;
+            gap: 8px;
+            padding: 10px;
+            background: linear-gradient(180deg, rgba(0,0,0,0.55) 0%, rgba(0,0,0,0.25) 100%);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            border-radius: 10px;
+            box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+        }
+        .inventory-panel .ip-char-portrait {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 180px;
+            background:
+                radial-gradient(120% 90% at 50% 30%, rgba(91, 157, 255, 0.18) 0%, rgba(91, 157, 255, 0) 60%),
+                linear-gradient(180deg, rgba(255, 255, 255, 0.04) 0%, rgba(0, 0, 0, 0.25) 100%);
+            border: 1px solid rgba(255, 255, 255, 0.06);
+            border-radius: 8px;
+            position: relative;
+            overflow: hidden;
+        }
+        .inventory-panel .ip-char-portrait::after {
+            content: '';
+            position: absolute;
+            inset: 0;
+            background: repeating-linear-gradient(
+                to bottom,
+                rgba(0,0,0,0) 0,
+                rgba(0,0,0,0) 3px,
+                rgba(0,0,0,0.18) 3px,
+                rgba(0,0,0,0.18) 4px
+            );
+            pointer-events: none;
+        }
+        .inventory-panel .ip-char-portrait img {
+            image-rendering: pixelated;
+            height: 78%;
+            max-height: 160px;
+            filter: drop-shadow(0 6px 14px rgba(0, 0, 0, 0.6));
+        }
+        .inventory-panel .ip-equipment {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+        }
+        .inventory-panel .ip-grid {
+            display: grid;
+            gap: 6px;
+        }
+        .inventory-panel .ip-grid.inv {
+            grid-template-columns: repeat(6, 56px);
+        }
+        .inventory-panel .ip-grid.hotbar {
+            grid-template-columns: repeat(7, 56px);
+        }
+        .inventory-panel .ip-slot {
+            width: 56px;
+            height: 56px;
+            box-sizing: border-box;
+            background: linear-gradient(135deg, rgba(255, 255, 255, 0.04) 0%, rgba(255, 255, 255, 0.01) 100%);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            border-radius: 8px;
+            padding: 6px;
+            position: relative;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            transition: transform 160ms ease, border-color 160ms ease, background 160ms ease, box-shadow 160ms ease;
+            box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+        }
+        .inventory-panel .ip-slot:hover {
+            transform: translateY(-1px);
+            border-color: rgba(91, 157, 255, 0.55);
+            background: linear-gradient(135deg, rgba(91, 157, 255, 0.12) 0%, rgba(91, 157, 255, 0.04) 100%);
+            box-shadow: 0 0 0 2px rgba(91, 157, 255, 0.15), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+        }
+        .inventory-panel .ip-slot.equipment {
+            width: 100%;
+            height: 48px;
+            border-radius: 6px;
+        }
+        .inventory-panel .ip-slot.equipment .placeholder {
+            font-size: 9px;
+            font-weight: 600;
+            color: ${HUD.textDim};
+            letter-spacing: 0.16em;
+            text-transform: uppercase;
+            text-align: center;
+            line-height: 1.1;
+        }
+        .inventory-panel .ip-slot.hotbar.selected {
+            border-color: ${HUD.accent};
+            background: linear-gradient(135deg, rgba(91, 157, 255, 0.20) 0%, rgba(91, 157, 255, 0.08) 100%);
+            box-shadow: 0 0 0 2px rgba(91, 157, 255, 0.22), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+        }
+        .inventory-panel .ip-slot img {
+            width: 78%;
+            height: 78%;
+            object-fit: contain;
+            filter: drop-shadow(0 2px 6px rgba(0, 0, 0, 0.6));
+            pointer-events: auto;
+        }
+        .inventory-panel .ip-slot .stack {
+            color: #fff;
+            position: absolute;
+            bottom: 3px;
+            right: 4px;
+            font-weight: 700;
+            font-size: 10px;
+            font-family: ${HUD.fontMono};
+            background: rgba(0, 0, 0, 0.65);
+            border: 1px solid rgba(255, 255, 255, 0.15);
+            border-radius: 5px;
+            padding: 1px 4px;
+            min-width: 16px;
+            text-align: center;
+            backdrop-filter: blur(6px);
+            pointer-events: none;
+            font-variant-numeric: tabular-nums;
+        }
+        .inventory-panel .ip-slot .hotkey {
+            position: absolute;
+            top: 3px;
+            left: 5px;
+            font-family: ${HUD.fontMono};
+            font-size: 9px;
+            font-weight: 600;
+            color: ${HUD.textDim};
+            letter-spacing: 0.05em;
+            pointer-events: none;
+        }
+        .inventory-panel .ip-slot.hotbar.selected .hotkey {
+            color: ${HUD.accent};
+        }
+        .inventory-panel .ip-slot .empty {
+            width: 16px;
+            height: 16px;
+            border-radius: 4px;
+            border: 1px dashed rgba(255, 255, 255, 0.10);
+            pointer-events: none;
+        }
+        .inventory-panel .ip-slot.equipment .empty { display: none; }
+        .inventory-panel .ip-inv-side {
+            display: flex;
+            flex-direction: column;
+            gap: 14px;
+        }
+        .inventory-panel .ip-divider {
+            border: 0;
+            border-top: 1px dashed rgba(255, 255, 255, 0.08);
+            margin: 4px 0 2px;
+        }
+    `;
+    document.head.appendChild(style);
+}
+
 export default class InventoryManager {
     /**
      * @param {Phaser.Scene} scene - Your game scene.
@@ -11,83 +254,67 @@ export default class InventoryManager {
         this.game = scene;
         this.numSlots = numSlots;
         this.slots = new Array(numSlots).fill(null);
+        // Equipment is keyed by slot id (head/chest/legs/feet). Drag &
+        // drop sets these; nothing in the game reads from them yet, but
+        // the slots persist across opens so the player can lay out gear
+        // and have it stay there.
+        this.equipment = Object.fromEntries(EQUIPMENT_SLOTS.map(s => [s.id, null]));
 
-        this.container = document.getElementById(containerId);
-        if (!this.container) {
-            this.container = document.createElement('div');
-            this.container.id = containerId;
-            this.container.className = 'hud-panel';
-            Object.assign(this.container.style, {
-                position: 'fixed',
-                top: '50%',
-                left: '50%',
-                transform: 'translate(-50%, -50%) scale(0.96)',
-                opacity: '0',
-                padding: '0',
-                zIndex: '2000',
-                fontFamily: HUD.font,
-                minWidth: '420px',
-                transition: 'opacity 180ms ease, transform 180ms ease',
-                pointerEvents: 'none',
-            });
+        injectStyles();
+        this.container = document.createElement('div');
+        this.container.id = containerId;
+        this.container.className = 'hud-panel inventory-panel';
+        Object.assign(this.container.style, {
+            position: 'fixed',
+            top: '50%',
+            left: '50%',
+            transform: 'translate(-50%, -50%) scale(0.96)',
+            opacity: '0',
+            zIndex: '2000',
+            transition: 'opacity 180ms ease, transform 180ms ease',
+            pointerEvents: 'none',
+        });
 
-            // Header
-            const header = document.createElement('div');
-            Object.assign(header.style, {
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                padding: '14px 18px',
-                borderBottom: '1px solid rgba(255, 255, 255, 0.06)',
-            });
+        this.container.innerHTML = `
+            <div class="ip-header">
+                <div class="ip-title">
+                    <span class="dot"></span>
+                    <span>Inventory</span>
+                </div>
+                <div class="ip-hint">Press <kbd>I</kbd> to close</div>
+            </div>
+            <div class="ip-body">
+                <div class="ip-character">
+                    <div class="ip-section-label">Character</div>
+                    <div class="ip-char-frame">
+                        <div class="ip-char-portrait">
+                            <img src="images/player.png" alt="Character" draggable="false">
+                        </div>
+                        <div class="ip-equipment" data-slot-group="equipment"></div>
+                    </div>
+                </div>
+                <div class="ip-inv-side">
+                    <div>
+                        <div class="ip-section-label">Backpack</div>
+                        <div class="ip-grid inv" data-slot-group="inventory"></div>
+                    </div>
+                    <div>
+                        <div class="ip-section-label">Hotbar</div>
+                        <div class="ip-grid hotbar" data-slot-group="hotbar"></div>
+                    </div>
+                </div>
+            </div>
+        `;
+        document.body.appendChild(this.container);
+        this.invGrid = this.container.querySelector('[data-slot-group="inventory"]');
+        this.hotbarGrid = this.container.querySelector('[data-slot-group="hotbar"]');
+        this.equipGrid = this.container.querySelector('[data-slot-group="equipment"]');
+        // Stop input from leaking through to the canvas underneath.
+        const swallow = (e) => e.stopPropagation();
+        this.container.addEventListener('mousedown', swallow);
+        this.container.addEventListener('mouseup', swallow);
+        this.container.addEventListener('wheel', swallow);
 
-            const titleWrap = document.createElement('div');
-            Object.assign(titleWrap.style, { display: 'flex', alignItems: 'center', gap: '10px' });
-            const dot = document.createElement('span');
-            Object.assign(dot.style, {
-                width: '6px', height: '6px', borderRadius: '50%',
-                background: HUD.accent,
-                boxShadow: `0 0 10px ${HUD.accent}`,
-            });
-            const title = document.createElement('span');
-            title.textContent = 'Inventory';
-            Object.assign(title.style, {
-                fontFamily: HUD.font,
-                fontSize: '13px',
-                fontWeight: '600',
-                color: HUD.text,
-                letterSpacing: '0.08em',
-                textTransform: 'uppercase',
-            });
-            titleWrap.appendChild(dot);
-            titleWrap.appendChild(title);
-
-            const hint = document.createElement('span');
-            hint.innerHTML = `Press <kbd style="font-family:${HUD.fontMono};font-size:10px;font-weight:600;color:${HUD.text};background:rgba(255,255,255,0.08);border:1px solid rgba(255,255,255,0.12);border-radius:4px;padding:2px 6px;margin:0 2px;">I</kbd> to close`;
-            Object.assign(hint.style, {
-                fontFamily: HUD.font,
-                fontSize: '11px',
-                color: HUD.textMuted,
-            });
-
-            header.appendChild(titleWrap);
-            header.appendChild(hint);
-            this.container.appendChild(header);
-
-            // Grid
-            this.grid = document.createElement('div');
-            Object.assign(this.grid.style, {
-                display: 'grid',
-                gridTemplateColumns: 'repeat(6, 64px)',
-                gap: '8px',
-                padding: '18px',
-            });
-            this.container.appendChild(this.grid);
-
-            document.body.appendChild(this.container);
-        } else {
-            this.grid = this.container;
-        }
         this._visible = false;
 
         document.addEventListener('keydown', this.handleKeyDown.bind(this));
@@ -105,6 +332,7 @@ export default class InventoryManager {
         this.container.style.opacity = this._visible ? '1' : '0';
         this.container.style.transform = `translate(-50%, -50%) scale(${this._visible ? 1 : 0.96})`;
         this.container.style.pointerEvents = this._visible ? 'auto' : 'none';
+        if (this._visible) this.render();
     }
 
     addItem(item) {
@@ -254,124 +482,162 @@ export default class InventoryManager {
     }
 
     render() {
-        this.grid.innerHTML = '';
+        this._renderInventoryGrid();
+        this._renderHotbar();
+        this._renderEquipment();
+    }
+
+    _renderInventoryGrid() {
+        if (!this.invGrid) return;
+        this.invGrid.innerHTML = '';
         for (let i = 0; i < this.numSlots; i++) {
-            const slotEl = document.createElement('div');
-            slotEl.classList.add('inventory-slot');
-            slotEl.dataset.index = i;
-            Object.assign(slotEl.style, {
-                width: '64px',
-                height: '64px',
-                background: 'linear-gradient(135deg, rgba(255, 255, 255, 0.04) 0%, rgba(255, 255, 255, 0.01) 100%)',
-                border: '1px solid rgba(255, 255, 255, 0.08)',
-                borderRadius: '8px',
-                boxSizing: 'border-box',
-                position: 'relative',
-                padding: '8px',
-                cursor: 'pointer',
-                transition: 'transform 160ms ease, border-color 160ms ease, background 160ms ease, box-shadow 160ms ease',
-                boxShadow: 'inset 0 1px 0 rgba(255, 255, 255, 0.04)',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-            });
-
-            slotEl.addEventListener('mouseenter', () => {
-                slotEl.style.transform = 'translateY(-1px)';
-                slotEl.style.borderColor = `rgba(91, 157, 255, 0.55)`;
-                slotEl.style.background = 'linear-gradient(135deg, rgba(91, 157, 255, 0.12) 0%, rgba(91, 157, 255, 0.04) 100%)';
-                slotEl.style.boxShadow = `0 0 0 2px rgba(91, 157, 255, 0.15), inset 0 1px 0 rgba(255, 255, 255, 0.06)`;
-            });
-            slotEl.addEventListener('mouseleave', () => {
-                slotEl.style.transform = 'translateY(0)';
-                slotEl.style.borderColor = 'rgba(255, 255, 255, 0.08)';
-                slotEl.style.background = 'linear-gradient(135deg, rgba(255, 255, 255, 0.04) 0%, rgba(255, 255, 255, 0.01) 100%)';
-                slotEl.style.boxShadow = 'inset 0 1px 0 rgba(255, 255, 255, 0.04)';
-            });
-
-            slotEl.addEventListener('dragover', e => e.preventDefault());
-            slotEl.addEventListener('drop', (e) => {
-                e.preventDefault();
-                const draggedItemId = e.dataTransfer.getData('text/plain');
-                const source = e.dataTransfer.getData('source');
-                const sourceIndex = parseInt(e.dataTransfer.getData('sourceIndex'), 10);
-                const targetIndex = parseInt(slotEl.dataset.index, 10);
-
-                if (source === 'inventory') {
-                    if (sourceIndex === targetIndex) return;
-                    this.swapItems(sourceIndex, targetIndex);
-                } else if (source === 'toolbar') {
-                    const toolbarManager = this.game.toolBarManager;
-                    const draggedItem = toolbarManager.getItemById(draggedItemId);
-                    if (!draggedItem) return;
-                    const targetItem = this.slots[targetIndex];
-                    this.slots[targetIndex] = draggedItem;
-                    toolbarManager.removeItemBySlot(sourceIndex);
-                    if (targetItem) {
-                        toolbarManager.addItemToSlot(sourceIndex, targetItem);
-                    }
-                    this.render();
-                    toolbarManager.render();
-                }
-            });
-
-            const item = this.slots[i];
-            if (item) {
-                const img = document.createElement('img');
-                img.src = item.imageUrl;
-                img.alt = item.name;
-                img.title = item.name;
-                Object.assign(img.style, {
-                    width: '78%',
-                    height: '78%',
-                    objectFit: 'contain',
-                    transform: `rotate(${item.rotate}deg)`,
-                    filter: 'drop-shadow(0 2px 6px rgba(0, 0, 0, 0.6))',
-                    pointerEvents: 'auto',
-                });
-                img.draggable = true;
-                img.addEventListener('dragstart', (e) => {
-                    e.dataTransfer.setData('text/plain', item.id);
-                    e.dataTransfer.setData('source', 'inventory');
-                    e.dataTransfer.setData('sourceIndex', i.toString());
-                });
-                slotEl.appendChild(img);
-
-                if (item.metadata?.number != null) {
-                    const number = document.createElement('div');
-                    Object.assign(number.style, {
-                        color: '#fff',
-                        position: 'absolute',
-                        bottom: '4px',
-                        right: '5px',
-                        fontWeight: '700',
-                        fontSize: '11px',
-                        fontFamily: HUD.fontMono,
-                        background: 'rgba(0, 0, 0, 0.65)',
-                        border: '1px solid rgba(255, 255, 255, 0.15)',
-                        borderRadius: '6px',
-                        padding: '1px 5px',
-                        minWidth: '18px',
-                        textAlign: 'center',
-                        backdropFilter: 'blur(6px)',
-                        pointerEvents: 'none',
-                        fontVariantNumeric: 'tabular-nums',
-                    });
-                    number.innerHTML = item.metadata.number;
-                    slotEl.appendChild(number);
-                }
-            } else {
-                const empty = document.createElement('div');
-                Object.assign(empty.style, {
-                    width: '18px',
-                    height: '18px',
-                    borderRadius: '4px',
-                    border: '1px dashed rgba(255, 255, 255, 0.10)',
-                    pointerEvents: 'none',
-                });
-                slotEl.appendChild(empty);
-            }
-            this.grid.appendChild(slotEl);
+            this.invGrid.appendChild(this._buildSlot({
+                source: 'inventory',
+                index: i,
+                item: this.slots[i],
+            }));
         }
     }
+
+    _renderHotbar() {
+        if (!this.hotbarGrid) return;
+        this.hotbarGrid.innerHTML = '';
+        const tb = this.game.toolBarManager;
+        if (!tb) return;
+        for (let i = 0; i < tb.numSlots; i++) {
+            const slotEl = this._buildSlot({
+                source: 'toolbar',
+                index: i,
+                item: tb.slots[i],
+                hotkey: i + 1,
+                selected: this.game.selectedIndex === i,
+            });
+            slotEl.classList.add('hotbar');
+            if (this.game.selectedIndex === i) slotEl.classList.add('selected');
+            slotEl.addEventListener('click', (e) => {
+                if (e.target.tagName === 'IMG') return; // let drag start
+                tb.setSelected(i);
+                this._renderHotbar();
+            });
+            this.hotbarGrid.appendChild(slotEl);
+        }
+    }
+
+    _renderEquipment() {
+        if (!this.equipGrid) return;
+        this.equipGrid.innerHTML = '';
+        EQUIPMENT_SLOTS.forEach(spec => {
+            const slotEl = this._buildSlot({
+                source: 'equipment',
+                index: spec.id,
+                item: this.equipment[spec.id],
+                placeholder: spec.label,
+            });
+            slotEl.classList.add('equipment');
+            this.equipGrid.appendChild(slotEl);
+        });
+    }
+
+    /**
+     * Move/swap an item between any of the four containers (inventory,
+     * toolbar, equipment, or another inventory slot). The drop handler on
+     * each slot dispatches here so the matrix of source x target is in
+     * one place. Returns silently if either side is out of range.
+     */
+    _move(source, sourceIndex, target, targetIndex) {
+        if (source === target && sourceIndex === targetIndex) return;
+        const src = this._readSlot(source, sourceIndex);
+        if (!src) return;
+        const dst = this._readSlot(target, targetIndex);
+        this._writeSlot(target, targetIndex, src);
+        this._writeSlot(source, sourceIndex, dst);
+        this.render();
+        const tb = this.game.toolBarManager;
+        if (tb) {
+            tb.render();
+            if (this.game.selectedIndex != null) tb.setSelected(this.game.selectedIndex);
+        }
+    }
+
+    _readSlot(group, index) {
+        if (group === 'inventory') return this.slots[index] || null;
+        if (group === 'toolbar') return this.game.toolBarManager?.slots?.[index] || null;
+        if (group === 'equipment') return this.equipment[index] || null;
+        return null;
+    }
+
+    _writeSlot(group, index, item) {
+        if (group === 'inventory') {
+            this.slots[index] = item;
+        } else if (group === 'toolbar') {
+            const tb = this.game.toolBarManager;
+            if (!tb) return;
+            tb.slots[index] = item;
+        } else if (group === 'equipment') {
+            this.equipment[index] = item;
+        }
+    }
+
+    _buildSlot({ source, index, item, hotkey, placeholder }) {
+        const slotEl = document.createElement('div');
+        slotEl.classList.add('ip-slot');
+        slotEl.dataset.source = source;
+        slotEl.dataset.index = String(index);
+
+        slotEl.addEventListener('dragover', e => e.preventDefault());
+        slotEl.addEventListener('drop', (e) => {
+            e.preventDefault();
+            const src = e.dataTransfer.getData('source');
+            const rawIdx = e.dataTransfer.getData('sourceIndex');
+            // Source index is a string slot id for equipment, a number for
+            // inventory / toolbar. Coerce based on the source group so the
+            // _move() lookups land in the right container.
+            const coerce = (group, raw) => group === 'equipment' ? raw : parseInt(raw, 10);
+            const tgtIndex = source === 'equipment' ? index : parseInt(slotEl.dataset.index, 10);
+            this._move(src, coerce(src, rawIdx), source, tgtIndex);
+        });
+
+        if (item) {
+            const img = document.createElement('img');
+            img.src = item.imageUrl;
+            img.alt = item.name;
+            img.title = item.name;
+            img.style.transform = `rotate(${item.rotate || 0}deg)`;
+            img.draggable = true;
+            img.addEventListener('dragstart', (e) => {
+                e.dataTransfer.setData('text/plain', item.id);
+                e.dataTransfer.setData('source', source);
+                e.dataTransfer.setData('sourceIndex', String(index));
+            });
+            slotEl.appendChild(img);
+
+            if (item.metadata?.number != null) {
+                const stack = document.createElement('div');
+                stack.className = 'stack';
+                stack.textContent = item.metadata.number;
+                slotEl.appendChild(stack);
+            }
+        } else {
+            if (placeholder) {
+                const ph = document.createElement('div');
+                ph.className = 'placeholder';
+                ph.textContent = placeholder;
+                slotEl.appendChild(ph);
+            } else {
+                const empty = document.createElement('div');
+                empty.className = 'empty';
+                slotEl.appendChild(empty);
+            }
+        }
+
+        if (hotkey != null) {
+            const hk = document.createElement('div');
+            hk.className = 'hotkey';
+            hk.textContent = String(hotkey);
+            slotEl.appendChild(hk);
+        }
+
+        return slotEl;
+    }
+
 }

--- a/src/services/InventoryManager.js
+++ b/src/services/InventoryManager.js
@@ -150,7 +150,7 @@ function injectStyles() {
             display: flex;
             align-items: center;
             justify-content: center;
-            min-height: 190px;
+            height: 210px;
             background:
                 radial-gradient(120% 90% at 50% 30%, rgba(51, 255, 51, 0.10) 0%, rgba(0, 0, 0, 0) 65%),
                 linear-gradient(180deg, rgba(0, 24, 0, 0.4) 0%, rgba(0, 0, 0, 0.5) 100%);
@@ -171,14 +171,50 @@ function injectStyles() {
             );
             pointer-events: none;
         }
-        .inventory-panel .ip-char-portrait img {
+        /* The player is drawn in-game as a head sprite stacked on top of
+           a body sprite, and each source file is a spritesheet — crop a
+           single frame from each via background-position/-size so the
+           portrait isn't a row of duplicate feet. Both source frames are
+           55px wide; scale 2x for a readable pixel-art portrait. */
+        .inventory-panel .ip-char-figure {
+            position: relative;
+            width: 110px;
+            height: 180px;
             image-rendering: pixelated;
-            height: 82%;
-            max-height: 170px;
             filter:
                 drop-shadow(0 0 6px rgba(51, 255, 51, 0.55))
                 drop-shadow(0 0 2px rgba(51, 255, 51, 0.8))
                 brightness(0.6) sepia(1) hue-rotate(60deg) saturate(6);
+        }
+        .inventory-panel .ip-char-figure .head,
+        .inventory-panel .ip-char-figure .body {
+            position: absolute;
+            left: 50%;
+            image-rendering: pixelated;
+            background-repeat: no-repeat;
+            transform: translateX(-50%);
+        }
+        /* Head spritesheet: 110x98 source (2x2 grid of 55x49 frames).
+           Render frame 0 by sizing the bg to the source's 2x scale and
+           leaving the offset at 0,0. Element height matches one frame. */
+        .inventory-panel .ip-char-figure .head {
+            top: 0;
+            width: 110px;
+            height: 98px;
+            background-image: url(images/player_head.png);
+            background-size: 220px 196px;
+            background-position: 0 0;
+        }
+        /* Body spritesheet: 55x70 source (single frame). Scale 2x to
+           match the head and anchor to the bottom of the figure so the
+           feet land at the floor of the portrait. */
+        .inventory-panel .ip-char-figure .body {
+            bottom: 0;
+            width: 110px;
+            height: 140px;
+            background-image: url(images/player_stationary.png);
+            background-size: 110px 140px;
+            background-position: 0 0;
         }
         .inventory-panel .ip-equipment {
             display: flex;
@@ -330,7 +366,10 @@ export default class InventoryManager {
                     <div class="ip-section-label">CHARACTER</div>
                     <div class="ip-char-frame">
                         <div class="ip-char-portrait">
-                            <img src="images/player.png" alt="Character" draggable="false">
+                            <div class="ip-char-figure" aria-label="Character">
+                                <div class="head"></div>
+                                <div class="body"></div>
+                            </div>
                         </div>
                         <div class="ip-equipment" data-slot-group="equipment"></div>
                     </div>

--- a/src/services/InventoryManager.js
+++ b/src/services/InventoryManager.js
@@ -120,11 +120,26 @@ export default class InventoryManager {
     // Adds to the existing wood stack if present in either the inventory or
     // the toolbar, otherwise creates a new stack in the inventory.
     addWood(amount = 1) {
+        this._addOrStack('wood', amount, () =>
+            new InventoryItem('wood', null, 'Wood', 'material', 'images/wood.png', {number: amount})
+        );
+    }
+
+    // Coal mined from coal-veined soil. Mirrors addWood so the same stack
+    // semantics apply (single stack across inventory + toolbar). Used as a
+    // crafting ingredient by the lift terminal.
+    addCoal(amount = 1) {
+        this._addOrStack('coal', amount, () =>
+            new InventoryItem('coal', null, 'Coal', 'material', 'images/coal.png', {number: amount})
+        );
+    }
+
+    _addOrStack(id, amount, factory) {
         const bump = (existing) => {
             const current = existing.metadata?.number || 0;
             existing.updateMetaData({...(existing.metadata || {}), number: current + amount});
         };
-        const inSlot = this.slots.find(s => s && s.id === 'wood');
+        const inSlot = this.slots.find(s => s && s.id === id);
         if (inSlot) {
             bump(inSlot);
             this.render();
@@ -133,7 +148,7 @@ export default class InventoryManager {
         }
         const tb = this.game.toolBarManager;
         if (tb) {
-            const inToolbar = tb.slots.find(s => s && s.id === 'wood');
+            const inToolbar = tb.slots.find(s => s && s.id === id);
             if (inToolbar) {
                 bump(inToolbar);
                 tb.render();
@@ -141,8 +156,82 @@ export default class InventoryManager {
                 return;
             }
         }
-        const wood = new InventoryItem('wood', null, 'Wood', 'material', 'images/wood.png', {number: amount});
-        this.addItem(wood);
+        this.addItem(factory());
+    }
+
+    // Walk inventory + toolbar and total up every stack whose id matches.
+    // Items without a metadata.number count as a single unit so non-stacked
+    // tools still register as "1 owned".
+    getResourceCount(id) {
+        let total = 0;
+        const tally = (item) => {
+            if (!item || item.id !== id) return;
+            const n = item.metadata?.number;
+            total += (n == null ? 1 : n);
+        };
+        this.slots.forEach(tally);
+        this.game.toolBarManager?.slots?.forEach(tally);
+        return total;
+    }
+
+    // Drain `amount` units from stacks of `id` across inventory + toolbar.
+    // Stacks are emptied left-to-right (inventory first, then toolbar) and
+    // a stack hitting 0 is cleared so the slot frees up. Returns true on
+    // success — the caller should pre-check with getResourceCount so we
+    // never partially consume on a failed craft.
+    consumeResource(id, amount) {
+        if (amount <= 0) return true;
+        let remaining = amount;
+        const drainStack = (item, onEmpty) => {
+            if (!item || item.id !== id || remaining <= 0) return;
+            const have = item.metadata?.number != null ? item.metadata.number : 1;
+            const take = Math.min(have, remaining);
+            const left = have - take;
+            remaining -= take;
+            if (left <= 0) onEmpty();
+            else item.updateMetaData({...(item.metadata || {}), number: left});
+        };
+
+        for (let i = 0; i < this.slots.length && remaining > 0; i++) {
+            drainStack(this.slots[i], () => { this.slots[i] = null; });
+        }
+        const tb = this.game.toolBarManager;
+        if (tb) {
+            for (let i = 0; i < tb.slots.length && remaining > 0; i++) {
+                drainStack(tb.slots[i], () => tb.removeItemBySlot(i));
+            }
+        }
+
+        this.render();
+        tb?.render();
+        if (tb && this.game.selectedIndex != null) tb.setSelected(this.game.selectedIndex);
+        return remaining === 0;
+    }
+
+    // Bump an existing tool stack's metadata.number by `amount`. Returns
+    // true if a matching item was found (and incremented), false otherwise.
+    // Crafting recipes that target tools the player isn't carrying skip
+    // production silently — see liftTerminal.craft().
+    addToToolStack(id, amount) {
+        const bump = (item) => {
+            const current = item.metadata?.number || 0;
+            item.updateMetaData({...(item.metadata || {}), number: current + amount});
+        };
+        const inSlot = this.slots.find(s => s && s.id === id);
+        if (inSlot) {
+            bump(inSlot);
+            this.render();
+            return true;
+        }
+        const tb = this.game.toolBarManager;
+        const inToolbar = tb?.slots.find(s => s && s.id === id);
+        if (inToolbar) {
+            bump(inToolbar);
+            tb.render();
+            tb.setSelected(this.game.selectedIndex);
+            return true;
+        }
+        return false;
     }
 
     addItemToSlot(index, item) {

--- a/src/services/controls.js
+++ b/src/services/controls.js
@@ -205,10 +205,18 @@ export default class ControlsManager {
         })
 
         this.game.physics.overlap(this.game.player, this.game.mineCartGroup, (obj1, obj2) => {
-            obj2.cartRef.playerOver = true;
-            this.game.interactionText = obj2.cartRef.moving ? 'stop' : 'start';
-            this.game.showInteractionPrompt = () => {
-                obj2.cartRef.toggleMoving();
+            const cart = obj2.cartRef;
+            cart.playerOver = true;
+            this.game.interactionText = cart.moving ? 'stop' : 'start';
+            this.game.showInteractionPrompt = () => cart.toggleMoving();
+            // When the cart is parked next to a lift control, expose a
+            // secondary action that ships its contents to the stockpile.
+            // Replaces the lift control's own "teleport" prompt because
+            // the player overlap with the cart runs after the lift
+            // overlap, but only when there's actually something to dump.
+            if (cart.hasCargo() && cart.liftControlAdjacent()) {
+                this.game.secondaryInteractionText = 'Dump to Stockpile';
+                this.game.showSecondaryInteractionPrompt = () => cart.dumpToStockpile();
             }
         });
 

--- a/src/services/liftTerminal.js
+++ b/src/services/liftTerminal.js
@@ -17,10 +17,20 @@
 // - `maxExtension` should also be persisted with the save game when the
 //   save system is updated to include rig state.
 
+import { RECIPES } from './recipes.js';
+
 const TERMINAL_GREEN = '#33ff33';
 const TERMINAL_DIM = '#1a8a1a';
+const TERMINAL_RED = '#ff5050';
 const TERMINAL_BG = 'rgba(0, 16, 0, 0.97)';
 const STYLE_ID = 'lift-terminal-styles';
+
+// Friendly labels for the raw materials referenced in recipes. Kept here
+// (rather than in recipes.js) so the data file stays pure.
+const RESOURCE_LABELS = {
+    wood: 'WOOD',
+    coal: 'COAL',
+};
 
 function injectStyles() {
     if (document.getElementById(STYLE_ID)) return;
@@ -131,6 +141,70 @@ function injectStyles() {
             font-size: 14px;
             padding: 4px 0;
         }
+        .lift-terminal-tabs {
+            display: flex;
+            gap: 6px;
+            margin: 6px 0 10px;
+        }
+        .lift-terminal-tab {
+            flex: 1;
+            background: transparent;
+            border: 1px solid ${TERMINAL_DIM};
+            color: ${TERMINAL_DIM};
+            font-family: inherit;
+            font-size: 14px;
+            padding: 4px 8px;
+            cursor: pointer;
+            letter-spacing: 0.12em;
+            text-align: center;
+            text-shadow: inherit;
+        }
+        .lift-terminal-tab:hover {
+            background: rgba(51, 255, 51, 0.08);
+        }
+        .lift-terminal-tab.active {
+            border-color: ${TERMINAL_GREEN};
+            color: ${TERMINAL_GREEN};
+            background: rgba(51, 255, 51, 0.12);
+        }
+        .lift-terminal-recipe {
+            border: 1px solid ${TERMINAL_DIM};
+            padding: 6px 8px;
+            margin: 6px 0;
+        }
+        .lift-terminal-recipe-head {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            font-size: 16px;
+        }
+        .lift-terminal-recipe-head img {
+            width: 18px;
+            height: 18px;
+            object-fit: contain;
+            filter: drop-shadow(0 0 3px rgba(51, 255, 51, 0.45));
+        }
+        .lift-terminal-recipe-desc {
+            font-size: 12px;
+            color: ${TERMINAL_DIM};
+            margin: 2px 0 4px;
+            letter-spacing: 0.04em;
+        }
+        .lift-terminal-recipe-costs {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 4px 12px;
+            font-size: 13px;
+            margin-bottom: 4px;
+        }
+        .lift-terminal-recipe-costs .short {
+            color: ${TERMINAL_RED};
+        }
+        .lift-terminal-recipe .lift-terminal-btn {
+            margin: 4px 0 0;
+            font-size: 14px;
+            padding: 4px 8px;
+        }
     `;
     document.head.appendChild(style);
 }
@@ -145,9 +219,10 @@ export default class LiftTerminal {
         // TODO(crafting): replace placeholder with real metal-rope inventory.
         // The player will craft rope segments from smelted ore and consume
         // them here. For now, treat as fully stocked.
-        this.metal = 9999;
+        this.metal = 50;
         this.extendCost = 50;
         this.extendIncrement = 100;
+        this.activeTab = 'main';
         // How far below the surface the rig's rope can reach (world units).
         // TODO(persistence): persist with save game once rig state is saved.
         this.maxExtension = 0;
@@ -167,23 +242,41 @@ export default class LiftTerminal {
         root.innerHTML = `
             <div class="lift-terminal-title">ROOBOO MINING RIG / TERMINAL</div>
             <div class="lift-terminal-sub">SYS-LINK ESTABLISHED</div>
-            <div class="lift-terminal-section">
-                <h3>RIG STATUS</h3>
-                <div class="lift-terminal-row"><span>CURRENT DEPTH</span><span data-field="depth">--</span></div>
-                <div class="lift-terminal-row"><span>ROPE LENGTH</span><span data-field="rope">--</span></div>
-                <div class="lift-terminal-row"><span>STATUS</span><span data-field="status">--</span></div>
+            <div class="lift-terminal-tabs">
+                <button class="lift-terminal-tab active" data-tab="main">[ RIG ]</button>
+                <button class="lift-terminal-tab" data-tab="crafting">[ CRAFTING ]</button>
             </div>
-            <div class="lift-terminal-section">
-                <h3>RESOURCES</h3>
-                <div class="lift-terminal-row"><span>METAL ROPE STOCK</span><span data-field="metal">--</span></div>
-                <button class="lift-terminal-btn" data-action="extend">
-                    EXTEND ROPE +<span data-field="extendIncrement">--</span>m
-                    <span class="right">COST <span data-field="extendCost">--</span></span>
-                </button>
+            <div data-pane="main">
+                <div class="lift-terminal-section">
+                    <h3>RIG STATUS</h3>
+                    <div class="lift-terminal-row"><span>CURRENT DEPTH</span><span data-field="depth">--</span></div>
+                    <div class="lift-terminal-row"><span>ROPE LENGTH</span><span data-field="rope">--</span></div>
+                    <div class="lift-terminal-row"><span>STATUS</span><span data-field="status">--</span></div>
+                </div>
+                <div class="lift-terminal-section">
+                    <h3>RESOURCES</h3>
+                    <div class="lift-terminal-row"><span>METAL ROPE STOCK</span><span data-field="metal">--</span></div>
+                    <button class="lift-terminal-btn" data-action="extend">
+                        EXTEND ROPE +<span data-field="extendIncrement">--</span>m
+                        <span class="right">COST <span data-field="extendCost">--</span></span>
+                    </button>
+                </div>
+                <div class="lift-terminal-section">
+                    <h3>LEVELS</h3>
+                    <div data-field="levels"></div>
+                </div>
             </div>
-            <div class="lift-terminal-section">
-                <h3>LEVELS</h3>
-                <div data-field="levels"></div>
+            <div data-pane="crafting" style="display:none;">
+                <div class="lift-terminal-section">
+                    <h3>STOCKPILE</h3>
+                    <div class="lift-terminal-row"><span>WOOD</span><span data-field="stockWood">--</span></div>
+                    <div class="lift-terminal-row"><span>COAL</span><span data-field="stockCoal">--</span></div>
+                    <div class="lift-terminal-row"><span>METAL ROPE</span><span data-field="stockMetal">--</span></div>
+                </div>
+                <div class="lift-terminal-section">
+                    <h3>BLUEPRINTS</h3>
+                    <div data-field="recipes"></div>
+                </div>
             </div>
             <div class="lift-terminal-actions">
                 <button class="lift-terminal-btn" data-action="close">[ DISCONNECT ]</button>
@@ -199,10 +292,22 @@ export default class LiftTerminal {
             extendIncrement: root.querySelector('[data-field="extendIncrement"]'),
             extendCost: root.querySelector('[data-field="extendCost"]'),
             levels: root.querySelector('[data-field="levels"]'),
+            stockWood: root.querySelector('[data-field="stockWood"]'),
+            stockCoal: root.querySelector('[data-field="stockCoal"]'),
+            stockMetal: root.querySelector('[data-field="stockMetal"]'),
+            recipes: root.querySelector('[data-field="recipes"]'),
         };
+        this.panes = {
+            main: root.querySelector('[data-pane="main"]'),
+            crafting: root.querySelector('[data-pane="crafting"]'),
+        };
+        this.tabButtons = root.querySelectorAll('[data-tab]');
 
         root.querySelector('[data-action="extend"]').addEventListener('click', () => this.extendRope());
         root.querySelector('[data-action="close"]').addEventListener('click', () => this.close());
+        this.tabButtons.forEach(btn => {
+            btn.addEventListener('click', () => this.setTab(btn.dataset.tab));
+        });
 
         // Stop terminal-internal input from leaking to the canvas so the
         // player doesn't swing tools / change toolbar slot while clicking
@@ -215,6 +320,18 @@ export default class LiftTerminal {
 
     toggle() {
         if (this.isOpen) this.close(); else this.open();
+    }
+
+    setTab(tab) {
+        if (!this.panes[tab]) return;
+        this.activeTab = tab;
+        Object.entries(this.panes).forEach(([name, el]) => {
+            el.style.display = name === tab ? 'block' : 'none';
+        });
+        this.tabButtons.forEach(btn => {
+            btn.classList.toggle('active', btn.dataset.tab === tab);
+        });
+        this.refresh();
     }
 
     open() {
@@ -235,7 +352,9 @@ export default class LiftTerminal {
     extendRope() {
         if (this.craneManager.moving) return;
         if (this.metal < this.extendCost) return;
-        // TODO(crafting): deduct from real metal-rope inventory once available.
+        // Metal rope is crafted at the table (wood + coal → metal). When
+        // the rope-segment-as-inventory-item rework lands this should drain
+        // from inventoryManager.consumeResource('metalRope', ...) instead.
         this.metal -= this.extendCost;
         this.maxExtension += this.extendIncrement;
         this.refresh();
@@ -277,6 +396,7 @@ export default class LiftTerminal {
             empty.className = 'lift-terminal-empty';
             empty.textContent = '> NO LIFT CONTROLS DETECTED IN SHAFT.';
             list.appendChild(empty);
+            this.renderCrafting();
             return;
         }
 
@@ -297,6 +417,119 @@ export default class LiftTerminal {
             });
             list.appendChild(btn);
         });
+
+        this.renderCrafting();
+    }
+
+    // Resource lookup that bridges the inventory (wood, coal) and the rig's
+    // own pools (metal). Recipe inputs reference these ids verbatim.
+    _resourceCount(id) {
+        if (id === 'metal') return this.metal;
+        return this.game.inventoryManager?.getResourceCount?.(id) || 0;
+    }
+
+    _consumeResource(id, amount) {
+        if (id === 'metal') {
+            if (this.metal < amount) return false;
+            this.metal -= amount;
+            return true;
+        }
+        return !!this.game.inventoryManager?.consumeResource?.(id, amount);
+    }
+
+    renderCrafting() {
+        if (!this.fields.recipes) return;
+        this.fields.stockWood.textContent = String(this._resourceCount('wood'));
+        this.fields.stockCoal.textContent = String(this._resourceCount('coal'));
+        this.fields.stockMetal.textContent = String(this.metal);
+
+        const list = this.fields.recipes;
+        list.innerHTML = '';
+
+        RECIPES.forEach(recipe => {
+            const card = document.createElement('div');
+            card.className = 'lift-terminal-recipe';
+
+            const head = document.createElement('div');
+            head.className = 'lift-terminal-recipe-head';
+            const img = document.createElement('img');
+            img.src = recipe.icon;
+            img.alt = '';
+            if (recipe.iconRotate) img.style.transform = `rotate(${recipe.iconRotate}deg)`;
+            const name = document.createElement('span');
+            name.textContent = recipe.name.toUpperCase();
+            head.appendChild(img);
+            head.appendChild(name);
+            card.appendChild(head);
+
+            if (recipe.description) {
+                const desc = document.createElement('div');
+                desc.className = 'lift-terminal-recipe-desc';
+                desc.textContent = recipe.description;
+                card.appendChild(desc);
+            }
+
+            const costs = document.createElement('div');
+            costs.className = 'lift-terminal-recipe-costs';
+            let canAfford = true;
+            recipe.inputs.forEach(input => {
+                const have = this._resourceCount(input.id);
+                const short = have < input.amount;
+                if (short) canAfford = false;
+                const tag = document.createElement('span');
+                tag.textContent = `${RESOURCE_LABELS[input.id] || input.id.toUpperCase()} ${have}/${input.amount}`;
+                if (short) tag.classList.add('short');
+                costs.appendChild(tag);
+            });
+            card.appendChild(costs);
+
+            const btn = document.createElement('button');
+            btn.className = 'lift-terminal-btn';
+            btn.disabled = !canAfford;
+            btn.innerHTML = canAfford
+                ? `[ CRAFT ]<span class="right">+${recipe.output.amount}</span>`
+                : `[ INSUFFICIENT ]<span class="right">+${recipe.output.amount}</span>`;
+            btn.addEventListener('click', () => {
+                if (!btn.disabled) this.craft(recipe);
+            });
+            card.appendChild(btn);
+
+            list.appendChild(card);
+        });
+    }
+
+    /**
+     * Run a recipe: re-check costs (in case state changed between render
+     * and click), then consume inputs and apply the output. Output kinds:
+     *   - 'metal': top up the rig's rope stockpile.
+     *   - 'tool':  bump an existing tool stack's metadata.number. If the
+     *              player isn't carrying that tool, the craft is refused
+     *              (resources stay untouched) so we don't silently eat
+     *              materials for an item the player can't receive.
+     */
+    craft(recipe) {
+        for (const input of recipe.inputs) {
+            if (this._resourceCount(input.id) < input.amount) return;
+        }
+        if (recipe.output.kind === 'tool') {
+            const im = this.game.inventoryManager;
+            const tb = this.game.toolBarManager;
+            const hasSlot = im?.slots?.some(s => s && s.id === recipe.output.toolId)
+                || tb?.slots?.some(s => s && s.id === recipe.output.toolId);
+            if (!hasSlot) return;
+        }
+
+        for (const input of recipe.inputs) {
+            this._consumeResource(input.id, input.amount);
+        }
+
+        if (recipe.output.kind === 'metal') {
+            this.metal += recipe.output.amount;
+        } else if (recipe.output.kind === 'tool') {
+            this.game.inventoryManager?.addToToolStack?.(recipe.output.toolId, recipe.output.amount);
+        }
+
+        this.refresh();
     }
 
     /**

--- a/src/services/liftTerminal.js
+++ b/src/services/liftTerminal.js
@@ -5,17 +5,15 @@
 // monospace text stays sharp regardless of the canvas zoom (same approach
 // the rest of the HUD uses, see src/services/uiManager.js).
 //
-// Crafting / upgrade hookups (TODO):
-// - "Metal rope" is the resource that extends the rig's reach. The flow we
-//   want long-term is: ore (existing mining system) -> smelt to ingots ->
-//   craft into metal rope segments -> consumed here when the player presses
-//   EXTEND ROPE.
-// - For now we hold a placeholder `metal` count on the terminal itself and
-//   deduct from it on extend. When the crafting/upgrade system lands, swap
-//   the placeholder reads/writes for real inventory ops at the marked
-//   spots below.
-// - `maxExtension` should also be persisted with the save game when the
-//   save system is updated to include rig state.
+// Layout: a fixed-size 3-column panel — rig status / stockpile on the
+// left, travel (levels + extend rope) in the middle, blueprints on the
+// right. The whole thing fits inside the viewport at typical resolutions
+// so there is no scrollbar; if a column overflows internally it scrolls
+// on its own without dragging the rest of the screen with it.
+//
+// Persistence TODO: rope reach (maxExtension) and the metal-rope pool
+// should be serialised with the save game when rig state is added to the
+// save schema.
 
 import { RECIPES } from './recipes.js';
 
@@ -25,8 +23,6 @@ const TERMINAL_RED = '#ff5050';
 const TERMINAL_BG = 'rgba(0, 16, 0, 0.97)';
 const STYLE_ID = 'lift-terminal-styles';
 
-// Friendly labels for the raw materials referenced in recipes. Kept here
-// (rather than in recipes.js) so the data file stays pure.
 const RESOURCE_LABELS = {
     wood: 'WOOD',
     coal: 'COAL',
@@ -43,23 +39,24 @@ function injectStyles() {
     style.id = STYLE_ID;
     style.textContent = `
         .lift-terminal {
-            position: absolute;
+            position: fixed;
             top: 50%;
             left: 50%;
             transform: translate(-50%, -50%);
-            width: 480px;
-            max-height: 80vh;
-            overflow-y: auto;
+            width: min(900px, calc(100vw - 32px));
+            max-height: calc(100vh - 32px);
             background: ${TERMINAL_BG};
             border: 2px solid ${TERMINAL_GREEN};
             box-shadow: 0 0 30px rgba(51, 255, 51, 0.4),
                         inset 0 0 60px rgba(51, 255, 51, 0.05);
             font-family: 'VT323', 'Share Tech Mono', monospace;
             color: ${TERMINAL_GREEN};
-            padding: 18px 22px 16px;
+            padding: 16px 20px 14px;
             z-index: 2000;
             text-shadow: 0 0 4px rgba(51, 255, 51, 0.6);
             user-select: none;
+            display: flex;
+            flex-direction: column;
         }
         .lift-terminal::after {
             content: '';
@@ -74,36 +71,92 @@ function injectStyles() {
             );
             pointer-events: none;
         }
+        .lift-terminal-header {
+            display: grid;
+            grid-template-columns: 1fr auto 1fr;
+            align-items: baseline;
+            gap: 12px;
+            border-bottom: 1px dashed ${TERMINAL_DIM};
+            padding-bottom: 8px;
+            margin-bottom: 10px;
+        }
         .lift-terminal-title {
+            grid-column: 2;
             font-size: 22px;
             letter-spacing: 0.14em;
             text-align: center;
-            margin: 0 0 2px;
+            margin: 0;
         }
-        .lift-terminal-sub {
-            font-size: 13px;
+        .lift-terminal-link {
+            font-size: 12px;
             color: ${TERMINAL_DIM};
-            text-align: center;
-            margin-bottom: 12px;
             letter-spacing: 0.2em;
+            justify-self: start;
+        }
+        .lift-terminal-link-right {
+            justify-self: end;
+        }
+        .lift-terminal-link .dot {
+            display: inline-block;
+            width: 6px;
+            height: 6px;
+            border-radius: 50%;
+            background: ${TERMINAL_GREEN};
+            box-shadow: 0 0 6px ${TERMINAL_GREEN};
+            margin-right: 6px;
+            animation: lift-terminal-blink 1.2s ease-in-out infinite;
+        }
+        @keyframes lift-terminal-blink {
+            0%, 60%, 100% { opacity: 1; }
+            70%, 90% { opacity: 0.25; }
+        }
+        .lift-terminal-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr 1.1fr;
+            gap: 14px;
+            flex: 1;
+            min-height: 0;
+        }
+        .lift-terminal-col {
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+            min-height: 0;
         }
         .lift-terminal-section {
-            margin: 10px 0;
+            display: flex;
+            flex-direction: column;
+            min-height: 0;
             font-size: 16px;
-            line-height: 1.5;
+            line-height: 1.4;
         }
         .lift-terminal-section h3 {
-            font-size: 15px;
+            font-size: 13px;
             font-weight: normal;
-            margin: 0 0 4px 0;
+            margin: 0 0 6px 0;
             border-bottom: 1px dashed ${TERMINAL_DIM};
             padding-bottom: 2px;
-            letter-spacing: 0.12em;
+            letter-spacing: 0.18em;
+            color: ${TERMINAL_GREEN};
         }
+        .lift-terminal-section-body {
+            min-height: 0;
+            overflow: auto;
+            scrollbar-width: thin;
+            scrollbar-color: ${TERMINAL_DIM} transparent;
+        }
+        .lift-terminal-section-body::-webkit-scrollbar { width: 6px; }
+        .lift-terminal-section-body::-webkit-scrollbar-thumb {
+            background: ${TERMINAL_DIM};
+        }
+        .lift-terminal-section.grow { flex: 1; min-height: 0; }
         .lift-terminal-row {
             display: flex;
             justify-content: space-between;
+            font-size: 15px;
+            padding: 1px 0;
         }
+        .lift-terminal-row .lbl { color: ${TERMINAL_DIM}; letter-spacing: 0.06em; }
         .lift-terminal-btn {
             display: block;
             width: 100%;
@@ -112,12 +165,12 @@ function injectStyles() {
             border: 1px solid ${TERMINAL_GREEN};
             color: ${TERMINAL_GREEN};
             font-family: inherit;
-            font-size: 16px;
+            font-size: 14px;
             text-align: left;
-            padding: 5px 10px;
-            margin: 4px 0;
+            padding: 4px 8px;
+            margin: 3px 0;
             cursor: pointer;
-            letter-spacing: 0.08em;
+            letter-spacing: 0.06em;
             transition: background 80ms;
             text-shadow: inherit;
         }
@@ -130,80 +183,96 @@ function injectStyles() {
             cursor: not-allowed;
         }
         .lift-terminal-btn .right { float: right; }
-        .lift-terminal-actions {
-            display: flex;
-            gap: 10px;
-            margin-top: 12px;
-        }
-        .lift-terminal-actions .lift-terminal-btn { margin: 0; flex: 1; }
         .lift-terminal-empty {
             color: ${TERMINAL_DIM};
-            font-size: 14px;
+            font-size: 13px;
             padding: 4px 0;
         }
-        .lift-terminal-tabs {
-            display: flex;
+        .lift-terminal-stockpile {
+            display: grid;
+            grid-template-columns: repeat(3, 1fr);
             gap: 6px;
-            margin: 6px 0 10px;
         }
-        .lift-terminal-tab {
-            flex: 1;
-            background: transparent;
+        .lift-terminal-stockpile .cell {
             border: 1px solid ${TERMINAL_DIM};
+            padding: 4px 6px;
+            display: flex;
+            flex-direction: column;
+            align-items: flex-start;
+        }
+        .lift-terminal-stockpile .lbl {
+            font-size: 11px;
             color: ${TERMINAL_DIM};
-            font-family: inherit;
-            font-size: 14px;
-            padding: 4px 8px;
-            cursor: pointer;
-            letter-spacing: 0.12em;
-            text-align: center;
-            text-shadow: inherit;
+            letter-spacing: 0.14em;
         }
-        .lift-terminal-tab:hover {
-            background: rgba(51, 255, 51, 0.08);
-        }
-        .lift-terminal-tab.active {
-            border-color: ${TERMINAL_GREEN};
+        .lift-terminal-stockpile .val {
+            font-size: 20px;
             color: ${TERMINAL_GREEN};
-            background: rgba(51, 255, 51, 0.12);
+            font-variant-numeric: tabular-nums;
+            line-height: 1.1;
+        }
+        .lift-terminal-recipes {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 6px;
+            padding-right: 4px;
         }
         .lift-terminal-recipe {
             border: 1px solid ${TERMINAL_DIM};
-            padding: 6px 8px;
-            margin: 6px 0;
+            padding: 5px 7px;
+            display: flex;
+            flex-direction: column;
+            min-height: 0;
         }
         .lift-terminal-recipe-head {
             display: flex;
             align-items: center;
-            gap: 8px;
-            font-size: 16px;
+            gap: 6px;
+            font-size: 14px;
+            letter-spacing: 0.04em;
         }
         .lift-terminal-recipe-head img {
-            width: 18px;
-            height: 18px;
+            width: 16px;
+            height: 16px;
             object-fit: contain;
             filter: drop-shadow(0 0 3px rgba(51, 255, 51, 0.45));
+            flex-shrink: 0;
         }
-        .lift-terminal-recipe-desc {
-            font-size: 12px;
-            color: ${TERMINAL_DIM};
-            margin: 2px 0 4px;
-            letter-spacing: 0.04em;
+        .lift-terminal-recipe-head .label {
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
         .lift-terminal-recipe-costs {
             display: flex;
             flex-wrap: wrap;
-            gap: 4px 12px;
-            font-size: 13px;
-            margin-bottom: 4px;
+            gap: 2px 8px;
+            font-size: 12px;
+            margin: 3px 0;
+            color: ${TERMINAL_DIM};
         }
         .lift-terminal-recipe-costs .short {
             color: ${TERMINAL_RED};
         }
         .lift-terminal-recipe .lift-terminal-btn {
-            margin: 4px 0 0;
-            font-size: 14px;
-            padding: 4px 8px;
+            margin: 2px 0 0;
+            font-size: 12px;
+            padding: 3px 6px;
+            letter-spacing: 0.06em;
+            text-align: center;
+        }
+        .lift-terminal-footer {
+            margin-top: 10px;
+            padding-top: 8px;
+            border-top: 1px dashed ${TERMINAL_DIM};
+        }
+        .lift-terminal-footer .lift-terminal-btn {
+            text-align: center;
+        }
+        .lift-terminal-levels {
+            display: flex;
+            flex-direction: column;
+            gap: 2px;
         }
     `;
     document.head.appendChild(style);
@@ -216,13 +285,12 @@ export default class LiftTerminal {
         this.game = craneManager.game;
         this.isOpen = false;
 
-        // TODO(crafting): replace placeholder with real metal-rope inventory.
-        // The player will craft rope segments from smelted ore and consume
-        // them here. For now, treat as fully stocked.
+        // Player starts with a single rope-segment's worth of slack — enough
+        // for one EXTEND ROPE before they have to head back up and craft
+        // more from wood + coal at the blueprint table.
         this.metal = 50;
         this.extendCost = 50;
         this.extendIncrement = 100;
-        this.activeTab = 'main';
         // How far below the surface the rig's rope can reach (world units).
         // TODO(persistence): persist with save game once rig state is saved.
         this.maxExtension = 0;
@@ -240,45 +308,51 @@ export default class LiftTerminal {
         root.className = 'lift-terminal';
         root.style.display = 'none';
         root.innerHTML = `
-            <div class="lift-terminal-title">ROOBOO MINING RIG / TERMINAL</div>
-            <div class="lift-terminal-sub">SYS-LINK ESTABLISHED</div>
-            <div class="lift-terminal-tabs">
-                <button class="lift-terminal-tab active" data-tab="main">[ RIG ]</button>
-                <button class="lift-terminal-tab" data-tab="crafting">[ CRAFTING ]</button>
+            <div class="lift-terminal-header">
+                <div class="lift-terminal-link"><span class="dot"></span>SYS-LINK</div>
+                <div class="lift-terminal-title">ROOBOO MINING RIG</div>
+                <div class="lift-terminal-link lift-terminal-link-right">TERMINAL v1.0</div>
             </div>
-            <div data-pane="main">
-                <div class="lift-terminal-section">
-                    <h3>RIG STATUS</h3>
-                    <div class="lift-terminal-row"><span>CURRENT DEPTH</span><span data-field="depth">--</span></div>
-                    <div class="lift-terminal-row"><span>ROPE LENGTH</span><span data-field="rope">--</span></div>
-                    <div class="lift-terminal-row"><span>STATUS</span><span data-field="status">--</span></div>
+            <div class="lift-terminal-grid">
+                <div class="lift-terminal-col">
+                    <div class="lift-terminal-section">
+                        <h3>RIG STATUS</h3>
+                        <div class="lift-terminal-row"><span class="lbl">DEPTH</span><span data-field="depth">--</span></div>
+                        <div class="lift-terminal-row"><span class="lbl">ROPE</span><span data-field="rope">--</span></div>
+                        <div class="lift-terminal-row"><span class="lbl">STATUS</span><span data-field="status">--</span></div>
+                    </div>
+                    <div class="lift-terminal-section">
+                        <h3>STOCKPILE</h3>
+                        <div class="lift-terminal-stockpile">
+                            <div class="cell"><span class="lbl">WOOD</span><span class="val" data-field="stockWood">0</span></div>
+                            <div class="cell"><span class="lbl">COAL</span><span class="val" data-field="stockCoal">0</span></div>
+                            <div class="cell"><span class="lbl">ROPE</span><span class="val" data-field="stockMetal">0</span></div>
+                        </div>
+                    </div>
+                    <div class="lift-terminal-section">
+                        <h3>EXTEND ROPE</h3>
+                        <button class="lift-terminal-btn" data-action="extend">
+                            +<span data-field="extendIncrement">--</span>m
+                            <span class="right">COST <span data-field="extendCost">--</span></span>
+                        </button>
+                    </div>
                 </div>
-                <div class="lift-terminal-section">
-                    <h3>RESOURCES</h3>
-                    <div class="lift-terminal-row"><span>METAL ROPE STOCK</span><span data-field="metal">--</span></div>
-                    <button class="lift-terminal-btn" data-action="extend">
-                        EXTEND ROPE +<span data-field="extendIncrement">--</span>m
-                        <span class="right">COST <span data-field="extendCost">--</span></span>
-                    </button>
+                <div class="lift-terminal-col">
+                    <div class="lift-terminal-section grow">
+                        <h3>LEVELS</h3>
+                        <div class="lift-terminal-section-body lift-terminal-levels" data-field="levels"></div>
+                    </div>
                 </div>
-                <div class="lift-terminal-section">
-                    <h3>LEVELS</h3>
-                    <div data-field="levels"></div>
+                <div class="lift-terminal-col">
+                    <div class="lift-terminal-section grow">
+                        <h3>BLUEPRINTS</h3>
+                        <div class="lift-terminal-section-body">
+                            <div class="lift-terminal-recipes" data-field="recipes"></div>
+                        </div>
+                    </div>
                 </div>
             </div>
-            <div data-pane="crafting" style="display:none;">
-                <div class="lift-terminal-section">
-                    <h3>STOCKPILE</h3>
-                    <div class="lift-terminal-row"><span>WOOD</span><span data-field="stockWood">--</span></div>
-                    <div class="lift-terminal-row"><span>COAL</span><span data-field="stockCoal">--</span></div>
-                    <div class="lift-terminal-row"><span>METAL ROPE</span><span data-field="stockMetal">--</span></div>
-                </div>
-                <div class="lift-terminal-section">
-                    <h3>BLUEPRINTS</h3>
-                    <div data-field="recipes"></div>
-                </div>
-            </div>
-            <div class="lift-terminal-actions">
+            <div class="lift-terminal-footer">
                 <button class="lift-terminal-btn" data-action="close">[ DISCONNECT ]</button>
             </div>
         `;
@@ -288,7 +362,6 @@ export default class LiftTerminal {
             depth: root.querySelector('[data-field="depth"]'),
             rope: root.querySelector('[data-field="rope"]'),
             status: root.querySelector('[data-field="status"]'),
-            metal: root.querySelector('[data-field="metal"]'),
             extendIncrement: root.querySelector('[data-field="extendIncrement"]'),
             extendCost: root.querySelector('[data-field="extendCost"]'),
             levels: root.querySelector('[data-field="levels"]'),
@@ -297,17 +370,9 @@ export default class LiftTerminal {
             stockMetal: root.querySelector('[data-field="stockMetal"]'),
             recipes: root.querySelector('[data-field="recipes"]'),
         };
-        this.panes = {
-            main: root.querySelector('[data-pane="main"]'),
-            crafting: root.querySelector('[data-pane="crafting"]'),
-        };
-        this.tabButtons = root.querySelectorAll('[data-tab]');
 
         root.querySelector('[data-action="extend"]').addEventListener('click', () => this.extendRope());
         root.querySelector('[data-action="close"]').addEventListener('click', () => this.close());
-        this.tabButtons.forEach(btn => {
-            btn.addEventListener('click', () => this.setTab(btn.dataset.tab));
-        });
 
         // Stop terminal-internal input from leaking to the canvas so the
         // player doesn't swing tools / change toolbar slot while clicking
@@ -322,23 +387,11 @@ export default class LiftTerminal {
         if (this.isOpen) this.close(); else this.open();
     }
 
-    setTab(tab) {
-        if (!this.panes[tab]) return;
-        this.activeTab = tab;
-        Object.entries(this.panes).forEach(([name, el]) => {
-            el.style.display = name === tab ? 'block' : 'none';
-        });
-        this.tabButtons.forEach(btn => {
-            btn.classList.toggle('active', btn.dataset.tab === tab);
-        });
-        this.refresh();
-    }
-
     open() {
         if (this.isOpen) return;
         this.isOpen = true;
         this.game.freezePlayer = true;
-        this.root.style.display = 'block';
+        this.root.style.display = 'flex';
         this.refresh();
     }
 
@@ -382,12 +435,16 @@ export default class LiftTerminal {
         this.fields.depth.textContent = `-${currentDepth} M`;
         this.fields.rope.textContent = `-${Math.round(this.maxExtension)} M`;
         this.fields.status.textContent = cm.moving ? 'IN MOTION' : 'IDLE';
-        this.fields.metal.textContent = String(this.metal);
         this.fields.extendIncrement.textContent = String(this.extendIncrement);
         this.fields.extendCost.textContent = String(this.extendCost);
 
-        const levels = this._scanLevelsFromGrid();
+        this.renderLevels(currentY, surfaceY);
+        this.renderCrafting();
+    }
 
+    renderLevels(currentY, surfaceY) {
+        const cm = this.craneManager;
+        const levels = this._scanLevelsFromGrid();
         const list = this.fields.levels;
         list.innerHTML = '';
 
@@ -396,7 +453,6 @@ export default class LiftTerminal {
             empty.className = 'lift-terminal-empty';
             empty.textContent = '> NO LIFT CONTROLS DETECTED IN SHAFT.';
             list.appendChild(empty);
-            this.renderCrafting();
             return;
         }
 
@@ -417,8 +473,6 @@ export default class LiftTerminal {
             });
             list.appendChild(btn);
         });
-
-        this.renderCrafting();
     }
 
     // Resource lookup that bridges the inventory (wood, coal) and the rig's
@@ -457,17 +511,11 @@ export default class LiftTerminal {
             img.alt = '';
             if (recipe.iconRotate) img.style.transform = `rotate(${recipe.iconRotate}deg)`;
             const name = document.createElement('span');
+            name.className = 'label';
             name.textContent = recipe.name.toUpperCase();
             head.appendChild(img);
             head.appendChild(name);
             card.appendChild(head);
-
-            if (recipe.description) {
-                const desc = document.createElement('div');
-                desc.className = 'lift-terminal-recipe-desc';
-                desc.textContent = recipe.description;
-                card.appendChild(desc);
-            }
 
             const costs = document.createElement('div');
             costs.className = 'lift-terminal-recipe-costs';
@@ -487,8 +535,9 @@ export default class LiftTerminal {
             btn.className = 'lift-terminal-btn';
             btn.disabled = !canAfford;
             btn.innerHTML = canAfford
-                ? `[ CRAFT ]<span class="right">+${recipe.output.amount}</span>`
-                : `[ INSUFFICIENT ]<span class="right">+${recipe.output.amount}</span>`;
+                ? `[ CRAFT ] +${recipe.output.amount}`
+                : `[ INSUFFICIENT ]`;
+            btn.title = recipe.description || '';
             btn.addEventListener('click', () => {
                 if (!btn.disabled) this.craft(recipe);
             });

--- a/src/services/recipes.js
+++ b/src/services/recipes.js
@@ -1,0 +1,93 @@
+// Crafting recipes used by the lift terminal's crafting table.
+//
+// Each recipe consumes raw materials (wood / coal from the player's
+// inventory and metal from the rig's stockpile) and produces either an
+// item stack (bumping an existing tool's metadata.number) or refills the
+// rig's metal-rope pool used by EXTEND ROPE.
+//
+// Recipes that target a tool the player doesn't have a stack of yet are
+// no-ops on the consumer side: we look the tool up by id across the
+// inventory and toolbar, and only bump if found. The default GameScene
+// loadout seeds the toolbar with the tools listed below so the lookups
+// resolve from the start.
+
+export const RECIPES = [
+    {
+        id: 'metalRope',
+        name: 'Metal Rope',
+        description: 'Refills the rig\'s rope stockpile (+50 m of reach when extended).',
+        icon: 'images/wood.png',
+        inputs: [
+            {id: 'wood', amount: 3},
+            {id: 'coal', amount: 2},
+        ],
+        output: {kind: 'metal', amount: 50},
+    },
+    {
+        id: 'buttress',
+        name: 'Buttress',
+        description: 'Wooden support beam.',
+        icon: 'images/buttress.png',
+        inputs: [
+            {id: 'wood', amount: 2},
+        ],
+        output: {kind: 'tool', toolId: 'buttress', amount: 1},
+    },
+    {
+        id: 'rail',
+        name: 'Rail',
+        description: 'Flat track segment for mine carts.',
+        icon: 'images/rail.png',
+        inputs: [
+            {id: 'wood', amount: 1},
+            {id: 'coal', amount: 1},
+        ],
+        output: {kind: 'tool', toolId: 'rail', amount: 1},
+    },
+    {
+        id: 'rail-left',
+        name: 'Rail (Left)',
+        description: 'Diagonal track segment, sloping up-left.',
+        icon: 'images/rail.png',
+        iconRotate: 45,
+        inputs: [
+            {id: 'wood', amount: 1},
+            {id: 'coal', amount: 1},
+        ],
+        output: {kind: 'tool', toolId: 'rail-left', amount: 1},
+    },
+    {
+        id: 'rail-right',
+        name: 'Rail (Right)',
+        description: 'Diagonal track segment, sloping up-right.',
+        icon: 'images/rail.png',
+        iconRotate: -45,
+        inputs: [
+            {id: 'wood', amount: 1},
+            {id: 'coal', amount: 1},
+        ],
+        output: {kind: 'tool', toolId: 'rail-right', amount: 1},
+    },
+    {
+        id: 'lamp',
+        name: 'Lamp',
+        description: 'Casts a wide, warm light when placed.',
+        icon: 'images/lamp.png',
+        inputs: [
+            {id: 'wood', amount: 2},
+            {id: 'coal', amount: 1},
+        ],
+        output: {kind: 'tool', toolId: 'lamp', amount: 1},
+    },
+    {
+        id: 'minecart',
+        name: 'Mine Cart',
+        description: 'Hauls debris along a rail line.',
+        icon: 'images/mine-cart.png',
+        inputs: [
+            {id: 'wood', amount: 5},
+            {id: 'coal', amount: 3},
+        ],
+        output: {kind: 'tool', toolId: 'minecart', amount: 1},
+    },
+];

--- a/src/services/toolBarManager.js
+++ b/src/services/toolBarManager.js
@@ -1,5 +1,51 @@
 import { HUD } from './uiManager.js';
 
+// Pip-Boy phosphor palette — matches the lift terminal and inventory
+// panel so the radial selector reads as the same in-world device.
+const PIP_GREEN = '#33ff33';
+const PIP_DIM = '#1a8a1a';
+const PIP_FONT = "'VT323', 'Share Tech Mono', monospace";
+const WHEEL_STYLE_ID = 'pipboy-wheel-styles';
+
+function injectWheelStyles() {
+    if (document.getElementById(WHEEL_STYLE_ID)) return;
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://fonts.googleapis.com/css2?family=VT323&family=Share+Tech+Mono&display=swap';
+    document.head.appendChild(link);
+
+    const style = document.createElement('style');
+    style.id = WHEEL_STYLE_ID;
+    style.textContent = `
+        .pipboy-wheel-inner::before,
+        .pipboy-wheel-inner::after {
+            content: '';
+            position: absolute;
+            border-radius: 50%;
+            pointer-events: none;
+        }
+        .pipboy-wheel-inner::before {
+            inset: -8px;
+            border: 1px solid ${PIP_DIM};
+            box-shadow: 0 0 18px rgba(51, 255, 51, 0.25),
+                        inset 0 0 18px rgba(51, 255, 51, 0.08);
+        }
+        .pipboy-wheel-inner::after {
+            inset: 0;
+            background: repeating-linear-gradient(
+                to bottom,
+                rgba(0,0,0,0) 0,
+                rgba(0,0,0,0) 2px,
+                rgba(0,0,0,0.22) 2px,
+                rgba(0,0,0,0.22) 3px
+            );
+            -webkit-mask: radial-gradient(circle at center, #000 60%, transparent 100%);
+            mask: radial-gradient(circle at center, #000 60%, transparent 100%);
+        }
+    `;
+    document.head.appendChild(style);
+}
+
 function describeArc(cx, cy, outerR, innerR, startAngle, endAngle) {
     const x1 = cx + outerR * Math.cos(startAngle);
     const y1 = cy + outerR * Math.sin(startAngle);
@@ -97,6 +143,7 @@ export default class ToolbarManager {
     }
 
     createWheelOverlay() {
+        injectWheelStyles();
         this.wheelOverlay = document.createElement('div');
         Object.assign(this.wheelOverlay.style, {
             position: 'fixed',
@@ -106,11 +153,12 @@ export default class ToolbarManager {
             justifyContent: 'center',
             pointerEvents: 'none',
             zIndex: '2000',
-            background: 'radial-gradient(circle at center, rgba(0,0,0,0.45) 0%, rgba(0,0,0,0) 60%)',
+            background: 'radial-gradient(circle at center, rgba(0, 24, 0, 0.55) 0%, rgba(0, 0, 0, 0) 60%)',
             opacity: '0',
             transition: 'opacity 140ms ease',
         });
         this.wheelInner = document.createElement('div');
+        this.wheelInner.className = 'pipboy-wheel-inner';
         Object.assign(this.wheelInner.style, {
             position: 'relative',
             width: '320px',
@@ -142,7 +190,7 @@ export default class ToolbarManager {
         svg.setAttribute('viewBox', `0 0 ${size} ${size}`);
         svg.style.position = 'absolute';
         svg.style.inset = '0';
-        svg.style.filter = 'drop-shadow(0 8px 24px rgba(0,0,0,0.55))';
+        svg.style.filter = 'drop-shadow(0 0 12px rgba(51, 255, 51, 0.35))';
 
         for (let i = 0; i < slotsCount; i++) {
             const a0 = startOffset + i * sliceAngle;
@@ -151,8 +199,8 @@ export default class ToolbarManager {
             const path = describeArc(cx, cy, outerR, innerR, a0, a1);
             const pathEl = document.createElementNS(svgNS, 'path');
             pathEl.setAttribute('d', path);
-            pathEl.setAttribute('fill', selected ? 'rgba(91,157,255,0.32)' : 'rgba(16,19,26,0.78)');
-            pathEl.setAttribute('stroke', selected ? '#5b9dff' : 'rgba(255,255,255,0.10)');
+            pathEl.setAttribute('fill', selected ? 'rgba(51, 255, 51, 0.22)' : 'rgba(0, 16, 0, 0.85)');
+            pathEl.setAttribute('stroke', selected ? PIP_GREEN : PIP_DIM);
             pathEl.setAttribute('stroke-width', selected ? '2' : '1');
             svg.appendChild(pathEl);
         }
@@ -176,13 +224,14 @@ export default class ToolbarManager {
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'center',
-                color: selected ? HUD.accent : HUD.textDim,
-                fontFamily: HUD.fontMono,
-                fontSize: '11px',
-                fontWeight: '600',
-                opacity: item ? '1' : (selected ? '0.9' : '0.4'),
+                color: selected ? PIP_GREEN : PIP_DIM,
+                fontFamily: PIP_FONT,
+                fontSize: '18px',
+                letterSpacing: '0.08em',
+                opacity: item ? '1' : (selected ? '0.95' : '0.5'),
                 transition: 'transform 120ms ease, color 120ms ease, opacity 120ms ease',
                 pointerEvents: 'none',
+                textShadow: '0 0 4px rgba(51, 255, 51, 0.6)',
             });
             if (item) {
                 const img = document.createElement('img');
@@ -193,8 +242,8 @@ export default class ToolbarManager {
                     objectFit: 'contain',
                     transform: `rotate(${item.rotate || 0}deg)`,
                     filter: selected
-                        ? 'drop-shadow(0 0 6px rgba(91,157,255,0.55)) drop-shadow(0 2px 4px rgba(0,0,0,0.6))'
-                        : 'drop-shadow(0 2px 4px rgba(0,0,0,0.6))',
+                        ? 'drop-shadow(0 0 6px rgba(51, 255, 51, 0.75)) brightness(0.8) sepia(1) hue-rotate(60deg) saturate(6)'
+                        : 'drop-shadow(0 0 3px rgba(51, 255, 51, 0.45)) brightness(0.6) sepia(1) hue-rotate(60deg) saturate(5)',
                 });
                 wrap.appendChild(img);
             } else {
@@ -213,11 +262,12 @@ export default class ToolbarManager {
                 left: `${lx}px`,
                 top: `${ly}px`,
                 transform: 'translate(-50%, -50%)',
-                fontFamily: HUD.fontMono,
-                fontSize: '9px',
-                fontWeight: '600',
-                color: selected ? HUD.accent : HUD.textDim,
+                fontFamily: PIP_FONT,
+                fontSize: '14px',
+                letterSpacing: '0.06em',
+                color: selected ? PIP_GREEN : PIP_DIM,
                 pointerEvents: 'none',
+                textShadow: '0 0 3px rgba(51, 255, 51, 0.5)',
             });
             this.wheelInner.appendChild(hotkey);
         }
@@ -225,20 +275,23 @@ export default class ToolbarManager {
         // Center label
         const center = document.createElement('div');
         const highlighted = this.wheelHighlightIndex >= 0 ? this.slots[this.wheelHighlightIndex] : null;
-        center.textContent = highlighted ? highlighted.name : '';
+        center.innerHTML = highlighted
+            ? `<div style="font-size:11px;color:${PIP_DIM};letter-spacing:0.2em;margin-bottom:2px;">EQUIP</div><div>${highlighted.name.toUpperCase()}</div>`
+            : `<div style="color:${PIP_DIM};letter-spacing:0.18em;">SELECT</div>`;
         Object.assign(center.style, {
             position: 'absolute',
             left: '50%',
             top: '50%',
             transform: 'translate(-50%, -50%)',
-            fontFamily: HUD.font,
-            fontSize: '13px',
-            fontWeight: '600',
-            color: HUD.text,
+            fontFamily: PIP_FONT,
+            fontSize: '18px',
+            color: PIP_GREEN,
             textAlign: 'center',
             pointerEvents: 'none',
-            textShadow: '0 1px 3px rgba(0,0,0,0.7)',
-            maxWidth: '90px',
+            textShadow: '0 0 5px rgba(51, 255, 51, 0.7)',
+            letterSpacing: '0.08em',
+            maxWidth: '92px',
+            lineHeight: '1.15',
         });
         this.wheelInner.appendChild(center);
     }


### PR DESCRIPTION
## Summary
This PR introduces a comprehensive crafting system for the lift terminal and unifies the game's UI with a cohesive Pip-Boy phosphor aesthetic. The inventory manager is refactored with drag-and-drop equipment slots, the lift terminal gains a 3-column blueprint crafting interface, and all UI panels now share consistent green-on-black styling with CRT scanline effects.

## Key Changes

**Crafting System**
- Added `src/services/recipes.js` with 7 craftable recipes (metal rope, buttress, rail variants, lamp)
- Recipes consume wood/coal from player inventory and metal from rig stockpile
- Lift terminal now displays blueprints with ingredient costs and craft buttons
- Inventory manager tracks resource counts and consumption across inventory + toolbar via `getResourceCount()` and `consumeResource()`
- Support for both material outputs (refilling rope stockpile) and tool stack increments

**Inventory Manager Refactor**
- Complete UI redesign with Pip-Boy phosphor palette (#33ff33 green on dark background)
- Added equipment slots system (head/chest/legs/feet) with drag-and-drop support
- New layout: character portrait + equipment on left, backpack + hotbar on right
- Injected stylesheet with scanline effects and glow shadows matching terminal aesthetic
- Added helper methods: `_addOrStack()`, `addCoal()`, `addToToolStack()`, `consumeResource()`, `getResourceCount()`
- Equipment state persists across panel opens

**Lift Terminal Redesign**
- Restructured from single-column to 3-column grid layout (rig status/stockpile | travel/extend | blueprints)
- Added stockpile display showing wood/coal counts
- Blueprint section renders all recipes with ingredient requirements and craft buttons
- Recipes highlight missing ingredients in red
- Improved header with SYS-LINK indicator and version display
- Internal scrolling per column without affecting page scroll

**Unified UI Theme**
- Standardized Pip-Boy phosphor palette across inventory, lift terminal, minecart UI, and tool wheel
- Consistent font stack: VT323 + Share Tech Mono
- CRT scanline overlays via CSS `::after` pseudo-elements
- Glow effects and text shadows for phosphor monitor aesthetic
- Tool wheel now uses phosphor styling with inset glow and scanlines

**Minecart & Controls**
- Updated minecart UI with phosphor styling and title bar
- Added `hasCargo()` and `liftControlAdjacent()` methods to MineCart class
- Cart can now unload materials to player inventory when adjacent to lift control

## Implementation Details

- Recipes are data-driven; crafting validates inventory before consuming resources
- Equipment slots accept any item via drag-and-drop but don't affect stats yet (foundation for future armor system)
- Resource consumption is left-to-right (inventory first, then toolbar) with automatic stack cleanup
- All UI panels inject their styles once via ID check to avoid duplicates
- Minecart unloading integrates with inventory's `addWood()` and `addCoal()` methods for consistent stacking

https://claude.ai/code/session_01B8NUScWvj1BJRt1hVJKebU