### PR TITLE
Add player house interior with customizable decor system

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,9 +18,7 @@
       "devDependencies": {
         "electron": "^35.0.0",
         "electron-builder": "^25.1.8",
-        "vite": "^6.2.0",
-        "vite-plugin-electron": "^0.29.0",
-        "vite-plugin-electron-renderer": "^0.14.6"
+        "vite": "^6.2.0"
       }
     },
     "node_modules/@develar/schema-utils": {
@@ -6346,26 +6344,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/vite-plugin-electron": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-electron/-/vite-plugin-electron-0.29.0.tgz",
-      "integrity": "sha512-HP0DI9Shg41hzt55IKYVnbrChWXHX95QtsEQfM+szQBpWjVhVGMlqRjVco6ebfQjWNr+Ga+PeoBjMIl8zMaufw==",
-      "dev": true,
-      "peerDependencies": {
-        "vite-plugin-electron-renderer": "*"
-      },
-      "peerDependenciesMeta": {
-        "vite-plugin-electron-renderer": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vite-plugin-electron-renderer": {
-      "version": "0.14.6",
-      "resolved": "https://registry.npmjs.org/vite-plugin-electron-renderer/-/vite-plugin-electron-renderer-0.14.6.tgz",
-      "integrity": "sha512-oqkWFa7kQIkvHXG7+Mnl1RTroA4sP0yesKatmAy0gjZC4VwUqlvF9IvOpHd1fpLWsqYX/eZlVxlhULNtaQ78Jw==",
-      "dev": true
     },
     "node_modules/wcwidth": {
       "version": "1.0.1",

--- a/src/classes/hut.js
+++ b/src/classes/hut.js
@@ -1,0 +1,282 @@
+import {Tile} from "./tile";
+
+// Each hut occupies a single grid cell (the door cell on the surface row)
+// but its facade sprite spans HUT_TILE_W × HUT_TILE_H tiles around that
+// anchor — pure visual decoration, no collision, so the player walks past
+// the building like in Stardew Valley until they line up with the door
+// and press ↑ to enter.
+const HUT_TILE_W = 5;
+const HUT_TILE_H = 4;
+
+// Per-hut palettes. The first player-house style is pickable in the
+// interior decor menu; the rest are baked-in flavours for ghost-town
+// huts so the row doesn't feel like a copy-paste.
+export const HUT_PALETTES = {
+    cozy: {
+        wall: '#c89a6a', wallShadow: '#8c6336', wallLight: '#e7c089',
+        roof: '#7a3a22', roofShadow: '#4a1d10', roofTrim: '#2a1108',
+        door: '#5a2a14', doorTrim: '#2a1004', doorKnob: '#f4d56a',
+        window: '#e9eef7', shutter: '#3c5a3a',
+    },
+    dusty: {
+        wall: '#8a7a64', wallShadow: '#534739', wallLight: '#a99176',
+        roof: '#5a4a3a', roofShadow: '#2e261d', roofTrim: '#16110b',
+        door: '#3a2a1a', doorTrim: '#1a0f06', doorKnob: '#a08050',
+        window: '#3c4a4a', shutter: '#322a20',
+    },
+    rusted: {
+        wall: '#6a5a48', wallShadow: '#3a302a', wallLight: '#897560',
+        roof: '#4f2a1a', roofShadow: '#241108', roofTrim: '#150804',
+        door: '#2a1a10', doorTrim: '#0f0604', doorKnob: '#7a5a3a',
+        window: '#1a1a1a', shutter: '#2a1d12',
+    },
+    mossy: {
+        wall: '#7c8a6a', wallShadow: '#3f4a32', wallLight: '#a3b285',
+        roof: '#3a4a2a', roofShadow: '#1a2410', roofTrim: '#0b1206',
+        door: '#3a2814', doorTrim: '#1a1006', doorKnob: '#d8b15a',
+        window: '#4a5240', shutter: '#2c3a24',
+    },
+    homestead: {
+        wall: '#d6b078', wallShadow: '#946d3e', wallLight: '#f4d39d',
+        roof: '#a44a2a', roofShadow: '#5a2010', roofTrim: '#2a0c04',
+        door: '#6a3318', doorTrim: '#321408', doorKnob: '#f9e07a',
+        window: '#fff3c8', shutter: '#5a8a4a',
+    },
+};
+
+function ensureHutFacadeTexture(game, paletteKey, abandoned = false) {
+    const key = `hut_facade_${paletteKey}${abandoned ? '_aged' : ''}`;
+    if (game.textures.exists(key)) return key;
+    const palette = HUT_PALETTES[paletteKey] || HUT_PALETTES.cozy;
+    const ts = game.tileSize;
+    const w = HUT_TILE_W * ts;
+    const h = HUT_TILE_H * ts;
+    const tex = game.textures.createCanvas(key, w, h);
+    const ctx = tex.context;
+    ctx.imageSmoothingEnabled = false;
+    ctx.clearRect(0, 0, w, h);
+
+    const roofH = Math.floor(h * 0.42);
+    const wallTop = roofH;
+
+    // Wall body
+    ctx.fillStyle = palette.wall;
+    ctx.fillRect(0, wallTop, w, h - wallTop);
+
+    // Plank seams
+    ctx.fillStyle = palette.wallShadow;
+    for (let y = wallTop + 3; y < h; y += 4) {
+        ctx.fillRect(0, y, w, 1);
+    }
+    ctx.fillStyle = palette.wallLight;
+    for (let y = wallTop + 4; y < h; y += 4) {
+        ctx.fillRect(0, y, w, 1);
+    }
+
+    // Foundation strip
+    ctx.fillStyle = palette.wallShadow;
+    ctx.fillRect(0, h - 2, w, 2);
+
+    // Pitched roof — drawn as horizontal slabs with a peak at center.
+    const peakX = Math.floor(w / 2);
+    for (let y = 0; y < roofH; y++) {
+        const slope = Math.floor((y / roofH) * (w / 2));
+        const x0 = peakX - slope - 1;
+        const x1 = peakX + slope + 1;
+        const colour = (y === 0 || y === 1) ? palette.roofTrim : (y % 3 === 0 ? palette.roofShadow : palette.roof);
+        ctx.fillStyle = colour;
+        ctx.fillRect(Math.max(0, x0), y, Math.min(w, x1) - Math.max(0, x0), 1);
+    }
+    // Roof eaves
+    ctx.fillStyle = palette.roofTrim;
+    ctx.fillRect(0, roofH - 1, w, 2);
+
+    // Door — centered, takes most of the bottom-middle column
+    const doorW = Math.floor(ts * 0.9);
+    const doorH = Math.floor(ts * 1.6);
+    const doorX = Math.floor((w - doorW) / 2);
+    const doorY = h - doorH - 2;
+    ctx.fillStyle = palette.doorTrim;
+    ctx.fillRect(doorX - 1, doorY - 1, doorW + 2, doorH + 2);
+    ctx.fillStyle = palette.door;
+    ctx.fillRect(doorX, doorY, doorW, doorH);
+    // Door planks
+    ctx.fillStyle = palette.doorTrim;
+    for (let y = doorY + 2; y < doorY + doorH; y += 3) {
+        ctx.fillRect(doorX, y, doorW, 1);
+    }
+    // Door knob
+    ctx.fillStyle = palette.doorKnob;
+    ctx.fillRect(doorX + doorW - 2, doorY + Math.floor(doorH * 0.55), 1, 1);
+
+    // Two windows flanking the door
+    const winW = Math.floor(ts * 0.6);
+    const winH = Math.floor(ts * 0.6);
+    const winY = wallTop + Math.floor((h - wallTop - doorH - winH) / 2);
+    const drawWindow = (cx) => {
+        const wx = cx - Math.floor(winW / 2);
+        ctx.fillStyle = palette.doorTrim;
+        ctx.fillRect(wx - 1, winY - 1, winW + 2, winH + 2);
+        ctx.fillStyle = palette.window;
+        ctx.fillRect(wx, winY, winW, winH);
+        // Cross frame
+        ctx.fillStyle = palette.doorTrim;
+        ctx.fillRect(wx + Math.floor(winW / 2), winY, 1, winH);
+        ctx.fillRect(wx, winY + Math.floor(winH / 2), winW, 1);
+        // Shutters
+        ctx.fillStyle = palette.shutter;
+        ctx.fillRect(wx - 3, winY, 2, winH);
+        ctx.fillRect(wx + winW + 1, winY, 2, winH);
+    };
+    drawWindow(Math.floor(w * 0.22));
+    drawWindow(Math.floor(w * 0.78));
+
+    // Chimney — small notch on the right pitch of the roof
+    const chimneyX = Math.floor(w * 0.72);
+    const chimneyW = 3;
+    const chimneyTop = Math.max(0, Math.floor(roofH * 0.25));
+    ctx.fillStyle = palette.roofTrim;
+    ctx.fillRect(chimneyX, chimneyTop, chimneyW, roofH - chimneyTop);
+    ctx.fillStyle = palette.wallLight;
+    ctx.fillRect(chimneyX, chimneyTop, chimneyW, 1);
+
+    if (abandoned) {
+        // Boarded windows + cracks for ghost-town huts
+        ctx.fillStyle = 'rgba(20, 12, 8, 0.55)';
+        for (let i = 0; i < 18; i++) {
+            const x = Math.floor((i * 13.7) % w);
+            const y = wallTop + Math.floor((i * 7.1) % (h - wallTop - 2));
+            ctx.fillRect(x, y, 1, 1);
+        }
+        ctx.fillStyle = palette.doorTrim;
+        ctx.fillRect(Math.floor(w * 0.18), winY + Math.floor(winH * 0.2), Math.floor(winW + 4), 2);
+        ctx.fillRect(Math.floor(w * 0.74), winY + Math.floor(winH * 0.2), Math.floor(winW + 4), 2);
+        // Slight darkening overlay
+        ctx.fillStyle = 'rgba(0, 0, 0, 0.18)';
+        ctx.fillRect(0, 0, w, h);
+    }
+
+    tex.refresh();
+    return key;
+}
+
+export class Hut extends Tile {
+    constructor({game, worldX, worldY, tileDetails, cellDetails}) {
+        super({game, worldX, worldY, tileDetails, cellDetails});
+        this.init();
+    }
+
+    addToGroup() {
+        return this.game.hutGroup.add(this.sprite);
+    }
+
+    removeFromGroup() {
+        return this.game.hutGroup.remove(this.sprite);
+    }
+
+    // Huts sit on the surface row above the soil, but they're pure
+    // decoration — they must not be pulled into the cave-in evaluation
+    // that cascades soil onto whatever is beneath.
+    checkState() {}
+
+    get interactionText() {
+        return this.tileDetails?.isPlayerHouse ? 'Enter Home' : 'Enter Hut';
+    }
+
+    enterHut() {
+        if (this._entering) return;
+        this._entering = true;
+        // Keep the world's frame budget while we're inside; sleeping the
+        // GameScene would also stop the player physics body and the next
+        // wake-up jitter would dump them through any thin floor seam.
+        this.game.scene.pause('GameScene');
+        this.game.scene.launch('HouseScene', {
+            hut: {
+                hutId: this.tileDetails.hutId || `hut_${this.worldX}_${this.worldY}`,
+                isPlayerHouse: !!this.tileDetails.isPlayerHouse,
+                paletteKey: this.tileDetails.paletteKey || 'dusty',
+                decor: this.tileDetails.decor || null,
+            },
+            returnDoor: {
+                worldX: this.worldX,
+                worldY: this.worldY,
+                chunkKey: this.chunkKey,
+                cellX: this.cellX,
+                cellY: this.cellY,
+            },
+        });
+        // Reset the lock once GameScene resumes so the player can re-enter.
+        this.game.scene.get('GameScene').events.once('resume', () => {
+            this._entering = false;
+        });
+    }
+
+    createSprite() {
+        const ts = this.game.tileSize;
+        const facadeW = HUT_TILE_W * ts;
+        const facadeH = HUT_TILE_H * ts;
+
+        // Door hit body — a single tile centred on the door cell. The
+        // surrounding facade is decoration only; the player must be
+        // standing in front of THIS tile to see the "↑ to enter" prompt.
+        // Adding the rectangle to a static physics group auto-assigns a
+        // static body sized to the rectangle.
+        const baseSprite = this.game.add.rectangle(this.worldX, this.worldY, ts, ts * 1.4, 0xffffff);
+        baseSprite.setAlpha(0);
+
+        const paletteKey = this.tileDetails.paletteKey || (this.tileDetails.isPlayerHouse ? 'homestead' : 'dusty');
+        const abandoned = !this.tileDetails.isPlayerHouse;
+        const textureKey = ensureHutFacadeTexture(this.game, paletteKey, abandoned);
+
+        // Anchor the facade so its bottom edge sits exactly at the bottom
+        // of the door cell — same convention as Tree, lining the building
+        // up with the grass line regardless of column surface variation.
+        this.facadeSprite = this.game.add.image(this.worldX, this.worldY + ts / 2, textureKey);
+        this.facadeSprite.setOrigin(0.5, 1);
+        this.facadeSprite.setDisplaySize(facadeW, facadeH);
+        this.facadeSprite.setDepth(0.6);
+
+        // Soft warm glow inside the player house window so they can spot
+        // their place from a distance at dusk. Ghost huts stay dark.
+        if (this.tileDetails.isPlayerHouse) {
+            this.windowGlow = this.game.add.rectangle(
+                this.worldX, this.worldY - ts * 1.6, ts * 0.6, ts * 0.6, 0xffd27a, 0.35
+            );
+            this.windowGlow.setDepth(0.59);
+            this.windowGlow.setBlendMode(Phaser.BlendModes.ADD);
+        }
+
+        // Optional name plate above the door for the player's house.
+        if (this.tileDetails.isPlayerHouse) {
+            this.namePlate = this.game.add.text(
+                this.worldX, this.worldY - ts * 3.4, 'HOME',
+                {font: '4px monospace', fill: '#fff1c4', stroke: '#000000', strokeThickness: 2}
+            ).setOrigin(0.5, 0.5);
+            this.namePlate.setResolution(8);
+            this.namePlate.setDepth(0.61);
+        }
+
+        this.fadeElements = [this.facadeSprite];
+        if (this.windowGlow) this.fadeElements.push(this.windowGlow);
+        if (this.namePlate) this.fadeElements.push(this.namePlate);
+        return baseSprite;
+    }
+
+    destroy(prefs) {
+        this.destroyHandler(() => {
+            if (!this.active) return;
+            this.active = false;
+            this.removeFromGroup();
+            if (this.facadeSprite) this.facadeSprite.destroy();
+            if (this.windowGlow) this.windowGlow.destroy();
+            if (this.namePlate) this.namePlate.destroy();
+            this.sprite.destroy();
+            this._destroyBorderGraphics();
+        }, prefs);
+    }
+
+    onClick() {
+        // Pickaxe + axe shouldn't dismantle the player's home or the ghost
+        // town atmosphere — leave the hut unbreakable from world tools.
+    }
+}

--- a/src/classes/tiles.js
+++ b/src/classes/tiles.js
@@ -6,5 +6,6 @@ import {Buttress} from "./buttress";
 import {Rail} from "./rail";
 import {LiftControl} from "./liftControl";
 import {Tree} from "./tree";
+import {Hut} from "./hut";
 
-export {Breakable, Light, Empty, Liquid, Buttress, Rail, LiftControl, Tree};
+export {Breakable, Light, Empty, Liquid, Buttress, Rail, LiftControl, Tree, Hut};

--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,7 @@ import Phaser from "phaser";
 import GameScene from "./scenes/GameScene.js";
 import MenuScene from "./scenes/MenuScene";
 import PreloadScene from "./scenes/PreloadScene";
+import HouseScene from "./scenes/HouseScene";
 
 // Think about making water move in the save way that cave-ins but it destroys where it came from, so can be finite
 // Delete caved: true from the object once cave in has happened
@@ -30,7 +31,7 @@ const config = {
         default: "arcade",
         arcade: {gravity: {y: 300}, debug: false, fps: 30}
     },
-    scene: [PreloadScene, MenuScene, GameScene],
+    scene: [PreloadScene, MenuScene, GameScene, HouseScene],
 };
 
 const game = new Phaser.Game(config);

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -94,6 +94,9 @@ export default class GameScene extends Phaser.Scene {
             },
             tree: {
                 id: 8
+            },
+            hut: {
+                id: 9
             }
         }
 
@@ -141,6 +144,7 @@ export default class GameScene extends Phaser.Scene {
         this.lightGroup = this.add.group();
         this.treeGroup = this.add.group();
         this.treeTextures = new TreeTextureFactory(this);
+        this.hutGroup = this.physics.add.staticGroup();
         this.liftControlGroup = this.physics.add.staticGroup();
         // interactableGroup is just a stable alias for liftControlGroup —
         // physics.overlap accepts the Group directly, so no per-frame
@@ -232,7 +236,7 @@ export default class GameScene extends Phaser.Scene {
             }, number: 50, limited: true, reclaimFrom: this.tileTypes.rail
         }, {rotate: -this.railRotate});
 
-        this.entityChildren = [this.soilGroup, this.lightGroup, this.emptyGroup, this.liquidGroup, this.buttressGroup, this.railGroup, this.liftControlGroup, this.treeGroup];
+        this.entityChildren = [this.soilGroup, this.lightGroup, this.emptyGroup, this.liquidGroup, this.buttressGroup, this.railGroup, this.liftControlGroup, this.treeGroup, this.hutGroup];
         this.mapService = new MapService(32, 16, this);
         if (this.newGame) {
             this.mapService.generateMap();
@@ -241,6 +245,9 @@ export default class GameScene extends Phaser.Scene {
         // pre-existing saves so the player always has a "call lift to
         // surface" point at the very top.
         this.mapService.ensureSurfaceLiftControls();
+        // Same idempotent pattern — drop the ghost town onto the surface
+        // for existing saves that pre-date the feature.
+        this.mapService.ensureGhostTown();
 
         window.setTimeout(async () => {
             // Parallax backdrop sits underneath the world, behind every

--- a/src/scenes/HouseScene.js
+++ b/src/scenes/HouseScene.js
@@ -1,0 +1,681 @@
+import {HUT_PALETTES} from "../classes/hut";
+
+// Decor catalogue. Each option is a colour or short procedural recipe
+// the interior renderer reads when laying out the room. Adding a new
+// option here is enough for it to show up in the player-house decor
+// panel — the Hut tileDetails just stores its key.
+const DECOR_OPTIONS = {
+    wallpaper: {
+        label: 'Wallpaper',
+        items: [
+            {key: 'cream',  label: 'Cream',     color: '#e9dcc1', accent: '#c9b58a', stripe: '#d6c39d'},
+            {key: 'sage',   label: 'Sage',      color: '#bcd1b4', accent: '#7c9876', stripe: '#a4c19a'},
+            {key: 'rose',   label: 'Rose',      color: '#e0bdb6', accent: '#a96e66', stripe: '#cf9e95'},
+            {key: 'navy',   label: 'Navy',      color: '#3a4a66', accent: '#1c2a48', stripe: '#2d3c58'},
+            {key: 'forest', label: 'Forest',    color: '#3a5a3a', accent: '#1f3b22', stripe: '#2c4830'},
+        ],
+    },
+    floor: {
+        label: 'Floor',
+        items: [
+            {key: 'oak',    label: 'Oak Plank',  base: '#a06a3a', dark: '#5a3818', light: '#bf8554'},
+            {key: 'walnut', label: 'Walnut',     base: '#5a3a22', dark: '#2a1808', light: '#7a5234'},
+            {key: 'stone',  label: 'Slate',      base: '#6a6a6a', dark: '#3a3a3a', light: '#8a8a8a'},
+            {key: 'tile',   label: 'Tile',       base: '#cdb89a', dark: '#7a6a52', light: '#e6d4b6'},
+            {key: 'rug',    label: 'Red Rug',    base: '#7a2a22', dark: '#3a1008', light: '#a8443a'},
+        ],
+    },
+    bed: {
+        label: 'Bed',
+        items: [
+            {key: 'quilt',   label: 'Patchwork',  blanket: '#c43a3a', pillow: '#f4e7c6', frame: '#5a3a18'},
+            {key: 'sky',     label: 'Sky Blue',   blanket: '#5b9dff', pillow: '#f4f4ff', frame: '#3a4a66'},
+            {key: 'pine',    label: 'Pine Green', blanket: '#3a6a3a', pillow: '#e8e1b8', frame: '#2a1808'},
+            {key: 'plum',    label: 'Plum',       blanket: '#5a2a4a', pillow: '#f4d4dc', frame: '#3a1822'},
+        ],
+    },
+    rug: {
+        label: 'Rug',
+        items: [
+            {key: 'rag',     label: 'Rag Rug',     base: '#a8443a', stripe: '#f4d56a'},
+            {key: 'persian', label: 'Persian',     base: '#3a2a48', stripe: '#c8a04a'},
+            {key: 'plain',   label: 'Plain Wool',  base: '#cdb89a', stripe: '#9a8060'},
+            {key: 'none',    label: 'No Rug',      base: null,      stripe: null},
+        ],
+    },
+};
+
+const DEFAULT_DECOR = {
+    wallpaper: 'cream',
+    floor: 'oak',
+    bed: 'quilt',
+    rug: 'rag',
+};
+
+const GHOST_DECOR = {
+    wallpaper: 'navy',
+    floor: 'walnut',
+    bed: 'pine',
+    rug: 'none',
+};
+
+function resolveDecor(group, key) {
+    const options = DECOR_OPTIONS[group]?.items || [];
+    return options.find(o => o.key === key) || options[0];
+}
+
+export default class HouseScene extends Phaser.Scene {
+    constructor() {
+        super('HouseScene');
+    }
+
+    init(data) {
+        this.hut = data?.hut || {hutId: 'unknown', isPlayerHouse: false, paletteKey: 'dusty'};
+        this.returnDoor = data?.returnDoor || null;
+        this.gameScene = this.scene.get('GameScene');
+        // Snapshot the persisted decor (if any) before mutating any fields.
+        // Player house: hut.decor lives on the world tile so changes
+        // survive reloads; ghost huts use the immutable GHOST_DECOR.
+        const persisted = this.hut.isPlayerHouse
+            ? {...DEFAULT_DECOR, ...(this.hut.decor || {})}
+            : {...GHOST_DECOR, ...(this.hut.decor || {})};
+        this.decor = persisted;
+    }
+
+    create() {
+        this.cameras.main.setBackgroundColor(0x000000);
+        this.cameras.main.fadeIn(220, 0, 0, 0);
+
+        this.layout = this.computeLayout();
+        this.buildInterior();
+        this.buildFurniture();
+        this.buildPlayer();
+        this.buildPrompts();
+        if (this.hut.isPlayerHouse) this.buildDecorButton();
+        this.buildExitButton();
+
+        this.cursors = this.input.keyboard.addKeys({
+            left:  Phaser.Input.Keyboard.KeyCodes.A,
+            right: Phaser.Input.Keyboard.KeyCodes.D,
+            up:    Phaser.Input.Keyboard.KeyCodes.UP,
+            down:  Phaser.Input.Keyboard.KeyCodes.S,
+            interact: Phaser.Input.Keyboard.KeyCodes.E,
+            jump:  Phaser.Input.Keyboard.KeyCodes.SPACE,
+        });
+        this.input.keyboard.addCapture('SPACE,UP');
+
+        this.events.once('shutdown', () => this.teardownDom());
+    }
+
+    computeLayout() {
+        const w = this.cameras.main.width;
+        const h = this.cameras.main.height;
+        // Room sits in a fixed-aspect frame regardless of window size so
+        // furniture proportions stay readable.
+        const targetAspect = 16 / 9;
+        const frameH = Math.min(h - 80, 540);
+        const frameW = Math.min(w - 80, frameH * targetAspect);
+        const fx = Math.round((w - frameW) / 2);
+        const fy = Math.round((h - frameH) / 2);
+        return {
+            w, h,
+            frameX: fx,
+            frameY: fy,
+            frameW,
+            frameH,
+            floorY: fy + Math.round(frameH * 0.78),
+            wallTopY: fy + Math.round(frameH * 0.10),
+        };
+    }
+
+    buildInterior() {
+        const {frameX, frameY, frameW, frameH, floorY, wallTopY} = this.layout;
+        const palette = HUT_PALETTES[this.hut.paletteKey] || HUT_PALETTES.dusty;
+        const wallpaper = resolveDecor('wallpaper', this.decor.wallpaper);
+        const floor = resolveDecor('floor', this.decor.floor);
+        this.activeDecor = {wallpaper, floor};
+
+        // Outer frame — soft drop shadow
+        const shadow = this.add.rectangle(frameX + frameW / 2 + 6, frameY + frameH / 2 + 8, frameW, frameH, 0x000000, 0.45);
+        shadow.setDepth(0);
+
+        // Ceiling beam strip
+        const ceiling = this.add.rectangle(frameX + frameW / 2, frameY + (wallTopY - frameY) / 2, frameW, wallTopY - frameY, Phaser.Display.Color.HexStringToColor(palette.roofShadow).color);
+        ceiling.setDepth(1);
+
+        // Wallpapered wall
+        this.wallpaperRect = this.add.rectangle(frameX + frameW / 2, (wallTopY + floorY) / 2, frameW, floorY - wallTopY, Phaser.Display.Color.HexStringToColor(wallpaper.color).color);
+        this.wallpaperRect.setDepth(1);
+
+        // Wallpaper stripes overlay (drawn lazily via Graphics so they
+        // re-render when decor changes)
+        this.wallpaperStripes = this.add.graphics();
+        this.wallpaperStripes.setDepth(2);
+        this.drawWallpaperStripes(wallpaper);
+
+        // Skirting / chair-rail trim above the floor
+        this.add.rectangle(frameX + frameW / 2, floorY - 6, frameW, 4, Phaser.Display.Color.HexStringToColor(palette.roofTrim).color).setDepth(3);
+        this.add.rectangle(frameX + frameW / 2, floorY - 4, frameW, 1, Phaser.Display.Color.HexStringToColor(palette.wallShadow).color).setDepth(3.1);
+
+        // Floor body
+        this.floorRect = this.add.rectangle(frameX + frameW / 2, (floorY + frameY + frameH) / 2, frameW, frameY + frameH - floorY, Phaser.Display.Color.HexStringToColor(floor.base).color);
+        this.floorRect.setDepth(1);
+
+        this.floorPlanks = this.add.graphics();
+        this.floorPlanks.setDepth(2);
+        this.drawFloorPlanks(floor);
+
+        // Front-edge floor shadow line
+        this.add.rectangle(frameX + frameW / 2, floorY, frameW, 2, 0x000000, 0.45).setDepth(3.2);
+
+        // A small framed photo on the wall — gives the room some life
+        const photoX = frameX + Math.round(frameW * 0.18);
+        const photoY = wallTopY + 36;
+        this.add.rectangle(photoX, photoY, 32, 24, 0x2a1808).setDepth(3);
+        this.add.rectangle(photoX, photoY, 28, 20, 0xfff1c4).setDepth(3.1);
+        this.add.rectangle(photoX - 6, photoY + 4, 6, 6, 0x5a8a4a).setDepth(3.2);
+        this.add.rectangle(photoX + 4, photoY + 2, 8, 8, 0x88b4dc).setDepth(3.2);
+
+        // A wall sconce for warmth
+        const sconceX = frameX + Math.round(frameW * 0.5);
+        const sconceY = wallTopY + 24;
+        this.add.rectangle(sconceX, sconceY, 4, 8, 0x2a1808).setDepth(3);
+        this.add.circle(sconceX, sconceY - 6, 4, 0xffd27a, 0.85).setDepth(3.1).setBlendMode(Phaser.BlendModes.ADD);
+        this.add.circle(sconceX, sconceY - 6, 14, 0xffd27a, 0.18).setDepth(3.05).setBlendMode(Phaser.BlendModes.ADD);
+
+        // Window with sky behind it
+        const winX = frameX + Math.round(frameW * 0.82);
+        const winY = wallTopY + 44;
+        this.add.rectangle(winX, winY, 64, 48, 0x2a1808).setDepth(3);
+        this.add.rectangle(winX, winY, 58, 42, 0x88b4dc).setDepth(3.1);
+        this.add.rectangle(winX, winY + 8, 58, 8, 0x4a6a8a).setDepth(3.2);
+        this.add.rectangle(winX, winY, 2, 42, 0x2a1808).setDepth(3.3);
+        this.add.rectangle(winX, winY, 58, 2, 0x2a1808).setDepth(3.3);
+
+        // Optional rug on the floor
+        this.rugRoot = this.add.container(0, 0).setDepth(3);
+        this.drawRug();
+    }
+
+    drawWallpaperStripes(wallpaper) {
+        const {frameX, frameW, frameY} = this.layout;
+        const wallTopY = this.layout.wallTopY;
+        const wallBotY = this.layout.floorY - 4;
+        const g = this.wallpaperStripes;
+        g.clear();
+        const stripeColor = Phaser.Display.Color.HexStringToColor(wallpaper.stripe).color;
+        g.fillStyle(stripeColor, 0.55);
+        const stripeW = 4;
+        const gap = 18;
+        for (let x = frameX + 8; x < frameX + frameW; x += gap) {
+            g.fillRect(x, wallTopY, stripeW, wallBotY - wallTopY);
+        }
+        g.fillStyle(Phaser.Display.Color.HexStringToColor(wallpaper.accent).color, 0.7);
+        g.fillRect(frameX, wallTopY, frameW, 2);
+        g.fillRect(frameX, wallBotY - 2, frameW, 2);
+    }
+
+    drawFloorPlanks(floor) {
+        const {frameX, frameW, floorY, frameY, frameH} = this.layout;
+        const g = this.floorPlanks;
+        g.clear();
+        g.fillStyle(Phaser.Display.Color.HexStringToColor(floor.dark).color, 0.85);
+        const plankH = 12;
+        const bottom = frameY + frameH;
+        for (let y = floorY + plankH; y < bottom; y += plankH) {
+            g.fillRect(frameX, y, frameW, 1);
+        }
+        g.fillStyle(Phaser.Display.Color.HexStringToColor(floor.light).color, 0.45);
+        for (let y = floorY + plankH + 1; y < bottom; y += plankH) {
+            g.fillRect(frameX, y, frameW, 1);
+        }
+    }
+
+    drawRug() {
+        this.rugRoot.removeAll(true);
+        const rug = resolveDecor('rug', this.decor.rug);
+        if (!rug || !rug.base) return;
+        const {frameX, frameW, floorY, frameY, frameH} = this.layout;
+        const rugW = Math.round(frameW * 0.30);
+        const rugH = 26;
+        const rx = frameX + Math.round(frameW * 0.50) - rugW / 2;
+        const ry = floorY + 6;
+        const base = this.add.rectangle(rx + rugW / 2, ry + rugH / 2, rugW, rugH, Phaser.Display.Color.HexStringToColor(rug.base).color);
+        const trim = this.add.rectangle(rx + rugW / 2, ry + rugH / 2, rugW - 4, rugH - 6, Phaser.Display.Color.HexStringToColor(rug.stripe).color, 0.8);
+        const stripeG = this.add.graphics();
+        stripeG.fillStyle(Phaser.Display.Color.HexStringToColor(rug.stripe).color, 0.85);
+        for (let i = 0; i < rugW; i += 8) {
+            stripeG.fillRect(rx + i, ry + 4, 2, rugH - 8);
+        }
+        this.rugRoot.add([base, trim, stripeG]);
+    }
+
+    buildFurniture() {
+        const {frameX, frameW, floorY} = this.layout;
+        this.furniture = [];
+
+        // Door — left third of the room. Walking into it + ↑ exits.
+        const doorX = frameX + Math.round(frameW * 0.13);
+        const doorY = floorY - 30;
+        const doorFrame = this.add.rectangle(doorX, doorY, 28, 60, 0x2a1404).setDepth(3);
+        const door = this.add.rectangle(doorX, doorY, 22, 54, 0x6a3318).setDepth(3.1);
+        this.add.rectangle(doorX + 6, doorY, 2, 2, 0xf4d56a).setDepth(3.2);
+        // Plank lines on the door
+        const doorG = this.add.graphics().setDepth(3.15);
+        doorG.fillStyle(0x2a1404, 0.7);
+        for (let i = -20; i < 20; i += 8) {
+            doorG.fillRect(doorX - 11, doorY + i, 22, 1);
+        }
+        const doorMat = this.add.rectangle(doorX, floorY + 4, 30, 6, 0x7a4a1f).setDepth(3.3);
+        const doorLabel = this.add.text(doorX, doorY - 38, 'Door', {font: '10px monospace', color: '#fff1c4'}).setOrigin(0.5).setDepth(3.4);
+        this.furniture.push({
+            kind: 'door',
+            x: doorX,
+            y: doorY,
+            range: 26,
+            label: 'Leave',
+            sprite: door,
+            interact: () => this.exitHouse(),
+        });
+
+        // Bed — middle-right
+        const bedX = frameX + Math.round(frameW * 0.62);
+        const bedY = floorY - 14;
+        const bed = resolveDecor('bed', this.decor.bed);
+        const bedFrameC = Phaser.Display.Color.HexStringToColor(bed.frame).color;
+        const blanketC = Phaser.Display.Color.HexStringToColor(bed.blanket).color;
+        const pillowC = Phaser.Display.Color.HexStringToColor(bed.pillow).color;
+        this.bedFrame = this.add.rectangle(bedX, bedY, 66, 22, bedFrameC).setDepth(3);
+        this.bedBlanket = this.add.rectangle(bedX + 4, bedY - 2, 56, 16, blanketC).setDepth(3.1);
+        this.bedPillow = this.add.rectangle(bedX - 22, bedY - 6, 14, 8, pillowC).setDepth(3.2);
+        this.add.rectangle(bedX - 30, bedY + 8, 4, 8, bedFrameC).setDepth(2.9);
+        this.add.rectangle(bedX + 30, bedY + 8, 4, 8, bedFrameC).setDepth(2.9);
+        const bedLabel = this.add.text(bedX, bedY - 22, 'Bed', {font: '10px monospace', color: '#fff1c4'}).setOrigin(0.5).setDepth(3.4);
+        this.furniture.push({
+            kind: 'bed',
+            x: bedX,
+            y: bedY,
+            range: 36,
+            label: 'Sleep',
+            interact: () => this.sleepInBed(),
+        });
+
+        // Kitchen — far right
+        const kitchenX = frameX + Math.round(frameW * 0.88);
+        const kitchenY = floorY - 14;
+        const counter = this.add.rectangle(kitchenX, kitchenY, 60, 22, 0x8a6a44).setDepth(3);
+        this.add.rectangle(kitchenX, kitchenY - 8, 60, 6, 0xb5895a).setDepth(3.1);
+        // Stove
+        this.add.rectangle(kitchenX - 16, kitchenY - 4, 18, 14, 0x2a2a2a).setDepth(3.2);
+        this.add.rectangle(kitchenX - 16, kitchenY - 9, 14, 2, 0x6a6a6a).setDepth(3.3);
+        this.add.circle(kitchenX - 20, kitchenY - 4, 1.5, 0xff5a1c).setDepth(3.4);
+        this.add.circle(kitchenX - 12, kitchenY - 4, 1.5, 0xff5a1c).setDepth(3.4);
+        // Sink
+        this.add.rectangle(kitchenX + 16, kitchenY - 4, 16, 12, 0x6a8a99).setDepth(3.2);
+        this.add.rectangle(kitchenX + 16, kitchenY - 8, 4, 6, 0xc0d0d8).setDepth(3.3);
+        const kitchenLabel = this.add.text(kitchenX, kitchenY - 22, 'Kitchen', {font: '10px monospace', color: '#fff1c4'}).setOrigin(0.5).setDepth(3.4);
+        this.furniture.push({
+            kind: 'kitchen',
+            x: kitchenX,
+            y: kitchenY,
+            range: 36,
+            label: 'Cook',
+            interact: () => this.openKitchen(),
+        });
+
+        // TV — left of bed, mounted-style on its own console
+        const tvX = frameX + Math.round(frameW * 0.36);
+        const tvY = floorY - 26;
+        this.add.rectangle(tvX, tvY + 14, 40, 12, 0x4a3a26).setDepth(3); // console
+        this.add.rectangle(tvX, tvY, 36, 22, 0x111111).setDepth(3.1);   // bezel
+        this.tvScreen = this.add.rectangle(tvX, tvY, 30, 16, 0x2a4a8a).setDepth(3.2);
+        // Static lines
+        this.tvStatic = this.add.graphics().setDepth(3.3);
+        this.tvStatic.fillStyle(0xffffff, 0.18);
+        for (let y = -7; y < 7; y += 2) this.tvStatic.fillRect(tvX - 14, tvY + y, 28, 1);
+        this.add.rectangle(tvX - 4, tvY + 14, 8, 2, 0x222222).setDepth(3.4);
+        this.add.rectangle(tvX + 4, tvY + 14, 8, 2, 0x222222).setDepth(3.4);
+        const tvLabel = this.add.text(tvX, tvY - 16, 'TV', {font: '10px monospace', color: '#fff1c4'}).setOrigin(0.5).setDepth(3.4);
+        this.furniture.push({
+            kind: 'tv',
+            x: tvX,
+            y: tvY,
+            range: 32,
+            label: 'Watch TV',
+            interact: () => this.openTv(),
+        });
+
+        // Subtle TV flicker
+        this.tweens.add({
+            targets: this.tvScreen,
+            alpha: {from: 0.85, to: 1},
+            duration: 600,
+            yoyo: true,
+            repeat: -1,
+            ease: 'Sine.easeInOut',
+        });
+    }
+
+    buildPlayer() {
+        const {frameX, frameW, floorY} = this.layout;
+        // Drop the player just inside the door so the very first thing
+        // they see is themselves having walked in. Use the existing
+        // player_walk spritesheet for visual consistency with the world.
+        const startX = frameX + Math.round(frameW * 0.20);
+        const startY = floorY - 16;
+        this.player = this.physics.add.sprite(startX, startY, 'player_stationary');
+        this.player.setDisplaySize(20, 28);
+        this.player.setDepth(4);
+        this.player.body.setAllowGravity(false);
+        this.player.body.setSize(14, 28);
+        // Reuse the global animations registered by PlayerManager.
+        if (this.anims.exists('walk')) this.player.play('stationary');
+
+        this.playerHead = this.add.sprite(startX, startY - 8, 'player_head');
+        this.playerHead.setDisplaySize(20, 20);
+        this.playerHead.setDepth(4.1);
+
+        this.shadow = this.add.ellipse(startX, floorY - 1, 24, 6, 0x000000, 0.4).setDepth(3.5);
+    }
+
+    buildPrompts() {
+        // Floating prompt that follows the player when they're in range
+        // of an interactable.
+        this.prompt = this.add.text(0, 0, '', {
+            font: '12px monospace',
+            color: '#fff1c4',
+            backgroundColor: 'rgba(0, 0, 0, 0.65)',
+            padding: {left: 6, right: 6, top: 3, bottom: 3},
+        }).setOrigin(0.5, 1).setDepth(50).setVisible(false);
+
+        this.title = this.add.text(this.layout.frameX + this.layout.frameW / 2, this.layout.frameY + 24,
+            this.hut.isPlayerHouse ? 'HOME' : 'ABANDONED HUT', {
+                font: '14px monospace',
+                color: '#fff1c4',
+                stroke: '#000000',
+                strokeThickness: 3,
+        }).setOrigin(0.5).setDepth(50);
+    }
+
+    buildExitButton() {
+        const {frameX, frameY} = this.layout;
+        const exit = document.createElement('button');
+        exit.id = 'house_exit_btn';
+        exit.className = 'hud-btn';
+        exit.dataset.variant = 'accent';
+        exit.innerHTML = '<span>Leave House (Esc)</span>';
+        Object.assign(exit.style, {
+            position: 'absolute',
+            top: (frameY - 8) + 'px',
+            right: (this.cameras.main.width - frameX - this.layout.frameW + 4) + 'px',
+            zIndex: '1001',
+        });
+        document.body.appendChild(exit);
+        exit.addEventListener('click', () => this.exitHouse());
+        this._exitBtn = exit;
+
+        this.input.keyboard.on('keydown-ESC', () => this.exitHouse());
+    }
+
+    buildDecorButton() {
+        const {frameX, frameY, frameW} = this.layout;
+        const btn = document.createElement('button');
+        btn.id = 'house_decor_btn';
+        btn.className = 'hud-btn';
+        btn.dataset.variant = 'primary';
+        btn.innerHTML = '<span>Decorate</span>';
+        Object.assign(btn.style, {
+            position: 'absolute',
+            top: (frameY - 8) + 'px',
+            left: (frameX + 4) + 'px',
+            zIndex: '1001',
+        });
+        document.body.appendChild(btn);
+        btn.addEventListener('click', () => this.openDecorPanel());
+        this._decorBtn = btn;
+    }
+
+    teardownDom() {
+        this._exitBtn?.remove();
+        this._decorBtn?.remove();
+        this._decorPanel?.remove();
+    }
+
+    update() {
+        if (!this.player) return;
+        const speed = 90;
+        let vx = 0;
+        if (this.cursors.left.isDown)  vx -= speed;
+        if (this.cursors.right.isDown) vx += speed;
+        this.player.setVelocityX(vx);
+        if (vx < 0) {
+            this.player.flipX = true;
+            this.playerHead.flipX = true;
+            if (this.anims.exists('walk')) this.player.play('walk', true);
+        } else if (vx > 0) {
+            this.player.flipX = false;
+            this.playerHead.flipX = false;
+            if (this.anims.exists('walk')) this.player.play('walk', true);
+        } else {
+            if (this.anims.exists('stationary')) this.player.play('stationary', true);
+        }
+
+        // Clamp player to the room walls
+        const minX = this.layout.frameX + 14;
+        const maxX = this.layout.frameX + this.layout.frameW - 14;
+        if (this.player.x < minX) this.player.x = minX;
+        if (this.player.x > maxX) this.player.x = maxX;
+        // Pin Y so they walk along the floor (no gravity in the house)
+        this.player.y = this.layout.floorY - 16;
+
+        this.playerHead.x = this.player.x;
+        this.playerHead.y = this.player.y - 10;
+        this.shadow.x = this.player.x;
+
+        // Find the nearest interactable in range
+        let nearest = null;
+        let bestDist = Infinity;
+        for (const f of this.furniture) {
+            const d = Math.abs(this.player.x - f.x);
+            if (d < f.range && d < bestDist) {
+                nearest = f;
+                bestDist = d;
+            }
+        }
+        this.activeFurniture = nearest;
+
+        if (nearest) {
+            const isDoor = nearest.kind === 'door';
+            const key = isDoor ? '↑' : 'E';
+            this.prompt.setText(`${key} to ${nearest.label}`);
+            this.prompt.setPosition(nearest.x, nearest.y - 30);
+            this.prompt.setVisible(true);
+        } else {
+            this.prompt.setVisible(false);
+        }
+
+        if (nearest) {
+            if (nearest.kind === 'door') {
+                if (Phaser.Input.Keyboard.JustDown(this.cursors.up)) {
+                    nearest.interact();
+                    return;
+                }
+            } else {
+                if (Phaser.Input.Keyboard.JustDown(this.cursors.interact)) {
+                    nearest.interact();
+                    return;
+                }
+            }
+        }
+    }
+
+    exitHouse() {
+        if (this._exiting) return;
+        this._exiting = true;
+        this.cameras.main.fadeOut(220, 0, 0, 0);
+        this.cameras.main.once('camerafadeoutcomplete', () => {
+            this.scene.stop();
+            this.gameScene?.scene.resume();
+        });
+    }
+
+    sleepInBed() {
+        const player = this.gameScene?.player;
+        if (!player) return;
+        // Quick rest: top energy + breath, dim the screen for a beat.
+        const overlay = this.add.rectangle(
+            this.layout.w / 2, this.layout.h / 2,
+            this.layout.w, this.layout.h,
+            0x000000, 0
+        ).setDepth(80);
+        this.prompt.setVisible(false);
+        this.tweens.add({
+            targets: overlay,
+            alpha: 0.85,
+            duration: 600,
+            yoyo: true,
+            hold: 600,
+            onComplete: () => {
+                player.energy = player.maxEnergy;
+                player.breath = player.maxBreath;
+                player.health = Math.min(player.maxHealth, player.health + 25);
+                overlay.destroy();
+                this.flashToast('Rested. Energy restored.');
+            },
+        });
+    }
+
+    openKitchen() {
+        this.flashToast('Kitchen — recipes coming soon.');
+    }
+
+    openTv() {
+        // Cycle the screen through a few channel colours as a teaser.
+        const channels = [0x2a4a8a, 0x8a3a3a, 0x3a8a4a, 0x6a2a8a, 0xc0a040];
+        this._tvIdx = ((this._tvIdx ?? 0) + 1) % channels.length;
+        this.tvScreen.setFillStyle(channels[this._tvIdx]);
+        this.flashToast(`Channel ${this._tvIdx + 1} — programming coming soon.`);
+    }
+
+    flashToast(text) {
+        if (this._toast) this._toast.destroy();
+        this._toast = this.add.text(this.layout.w / 2, this.layout.h - 80, text, {
+            font: '12px monospace',
+            color: '#fff1c4',
+            backgroundColor: 'rgba(0, 0, 0, 0.7)',
+            padding: {left: 8, right: 8, top: 4, bottom: 4},
+        }).setOrigin(0.5).setDepth(80);
+        this.tweens.add({
+            targets: this._toast,
+            alpha: {from: 1, to: 0},
+            delay: 1400,
+            duration: 600,
+            onComplete: () => {
+                this._toast?.destroy();
+                this._toast = null;
+            },
+        });
+    }
+
+    openDecorPanel() {
+        if (this._decorPanel) {
+            this._decorPanel.remove();
+            this._decorPanel = null;
+            return;
+        }
+        const panel = document.createElement('div');
+        panel.className = 'hud-panel';
+        panel.id = 'house_decor_panel';
+        Object.assign(panel.style, {
+            position: 'absolute',
+            top: (this.layout.frameY + 30) + 'px',
+            left: (this.layout.frameX + 8) + 'px',
+            zIndex: '1002',
+            padding: '12px',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '8px',
+            minWidth: '220px',
+        });
+        const title = document.createElement('div');
+        title.textContent = 'Decorate Home';
+        title.style.fontWeight = '700';
+        title.style.letterSpacing = '0.05em';
+        panel.appendChild(title);
+
+        for (const group of Object.keys(DECOR_OPTIONS)) {
+            const cfg = DECOR_OPTIONS[group];
+            const row = document.createElement('div');
+            row.style.display = 'flex';
+            row.style.flexDirection = 'column';
+            row.style.gap = '4px';
+            const label = document.createElement('div');
+            label.textContent = cfg.label;
+            label.style.fontSize = '11px';
+            label.style.opacity = '0.7';
+            row.appendChild(label);
+
+            const buttons = document.createElement('div');
+            buttons.style.display = 'flex';
+            buttons.style.flexWrap = 'wrap';
+            buttons.style.gap = '4px';
+            cfg.items.forEach(item => {
+                const b = document.createElement('button');
+                b.className = 'hud-btn';
+                b.textContent = item.label;
+                b.style.padding = '4px 8px';
+                b.style.fontSize = '10px';
+                if (this.decor[group] === item.key) {
+                    b.style.borderColor = 'rgba(91, 157, 255, 0.6)';
+                    b.style.color = '#cfe1ff';
+                }
+                b.addEventListener('click', () => this.applyDecor(group, item.key));
+                buttons.appendChild(b);
+            });
+            row.appendChild(buttons);
+            panel.appendChild(row);
+        }
+
+        document.body.appendChild(panel);
+        this._decorPanel = panel;
+    }
+
+    applyDecor(group, key) {
+        this.decor[group] = key;
+        // Persist on the world tile for the player house so reloads keep
+        // the same look. Find the hut tile from the returnDoor coords.
+        if (this.hut.isPlayerHouse && this.returnDoor && this.gameScene?.grid) {
+            const grid = this.gameScene.grid;
+            const {chunkKey, cellX, cellY} = this.returnDoor;
+            const cell = grid?.[chunkKey]?.[cellY]?.[cellX];
+            if (cell) {
+                cell.decor = {...(cell.decor || {}), [group]: key};
+            }
+        }
+
+        // Re-render the affected layer
+        if (group === 'wallpaper') {
+            const wp = resolveDecor('wallpaper', key);
+            this.wallpaperRect.setFillStyle(Phaser.Display.Color.HexStringToColor(wp.color).color);
+            this.drawWallpaperStripes(wp);
+        } else if (group === 'floor') {
+            const fl = resolveDecor('floor', key);
+            this.floorRect.setFillStyle(Phaser.Display.Color.HexStringToColor(fl.base).color);
+            this.drawFloorPlanks(fl);
+        } else if (group === 'bed') {
+            const bd = resolveDecor('bed', key);
+            this.bedFrame.setFillStyle(Phaser.Display.Color.HexStringToColor(bd.frame).color);
+            this.bedBlanket.setFillStyle(Phaser.Display.Color.HexStringToColor(bd.blanket).color);
+            this.bedPillow.setFillStyle(Phaser.Display.Color.HexStringToColor(bd.pillow).color);
+        } else if (group === 'rug') {
+            this.drawRug();
+        }
+
+        // Refresh decorate panel so the active highlight follows
+        if (this._decorPanel) {
+            this._decorPanel.remove();
+            this._decorPanel = null;
+            this.openDecorPanel();
+        }
+    }
+}

--- a/src/scenes/HouseScene.js
+++ b/src/scenes/HouseScene.js
@@ -52,17 +52,27 @@ const DEFAULT_DECOR = {
     rug: 'rag',
 };
 
-const GHOST_DECOR = {
-    wallpaper: 'navy',
-    floor: 'walnut',
-    bed: 'pine',
-    rug: 'none',
+// Abandoned huts use a fixed dim palette and a different room layout —
+// no functional furniture, just dust and dilapidation.
+const GHOST_PALETTE = {
+    wallpaper: {key: 'aged', color: '#4a3a30', accent: '#241a14', stripe: '#3a2a22'},
+    floor:     {key: 'rot',  base: '#3a2a1a', dark: '#1a0f08', light: '#5a4030'},
 };
 
 function resolveDecor(group, key) {
     const options = DECOR_OPTIONS[group]?.items || [];
     return options.find(o => o.key === key) || options[0];
 }
+
+// Room is laid out on a small fixed-pixel canvas and then zoomed up by
+// the scene camera so it reads at the same pixel-art density as the
+// outdoors. Keeping the logical size tight makes the room feel like a
+// hut interior rather than a warehouse, and lets us snap furniture
+// positions to whole pixels.
+const ROOM_W = 200;
+const ROOM_H = 130;
+const FLOOR_Y = 110;    // top of floor line
+const WALL_TOP_Y = 24;  // top of wallpapered band
 
 export default class HouseScene extends Phaser.Scene {
     constructor() {
@@ -73,24 +83,47 @@ export default class HouseScene extends Phaser.Scene {
         this.hut = data?.hut || {hutId: 'unknown', isPlayerHouse: false, paletteKey: 'dusty'};
         this.returnDoor = data?.returnDoor || null;
         this.gameScene = this.scene.get('GameScene');
+        // Scenes are reused across launches — reset every per-run flag
+        // here so a previous exit lock doesn't trap the player on the
+        // second visit ("can't leave the house" repro).
+        this._exiting = false;
+        this._toast = null;
+        this._tvIdx = 0;
         // Snapshot the persisted decor (if any) before mutating any fields.
         // Player house: hut.decor lives on the world tile so changes
-        // survive reloads; ghost huts use the immutable GHOST_DECOR.
-        const persisted = this.hut.isPlayerHouse
+        // survive reloads; ghost huts ignore decor entirely.
+        this.decor = this.hut.isPlayerHouse
             ? {...DEFAULT_DECOR, ...(this.hut.decor || {})}
-            : {...GHOST_DECOR, ...(this.hut.decor || {})};
-        this.decor = persisted;
+            : null;
     }
 
     create() {
-        this.cameras.main.setBackgroundColor(0x000000);
+        // Tight room frame; the camera zoom magnifies it so the inside
+        // feels close to the player rather than a vast empty hall.
+        this.cameras.main.setBackgroundColor(0x0a0806);
+        const targetZoom = Math.max(3, Math.floor(Math.min(
+            this.cameras.main.width / ROOM_W,
+            this.cameras.main.height / ROOM_H
+        )));
+        this.cameras.main.setZoom(targetZoom);
+        // Centre the room logical origin (0,0) in screen space.
+        this.cameras.main.centerOn(ROOM_W / 2, ROOM_H / 2);
         this.cameras.main.fadeIn(220, 0, 0, 0);
 
-        this.layout = this.computeLayout();
+        // Hide the world-scene DOM overlays (light canvas, minimap,
+        // toolbar) so they don't bleed through the house. Restored in
+        // exitHouse via teardownDom.
+        this.hideWorldOverlays();
+
         this.buildInterior();
-        this.buildFurniture();
+        if (this.hut.isPlayerHouse) {
+            this.buildHomeFurniture();
+        } else {
+            this.buildAbandonedFurniture();
+        }
         this.buildPlayer();
         this.buildPrompts();
+        this.buildVignette();
         if (this.hut.isPlayerHouse) this.buildDecorButton();
         this.buildExitButton();
 
@@ -98,136 +131,158 @@ export default class HouseScene extends Phaser.Scene {
             left:  Phaser.Input.Keyboard.KeyCodes.A,
             right: Phaser.Input.Keyboard.KeyCodes.D,
             up:    Phaser.Input.Keyboard.KeyCodes.UP,
+            w:     Phaser.Input.Keyboard.KeyCodes.W,
             down:  Phaser.Input.Keyboard.KeyCodes.S,
             interact: Phaser.Input.Keyboard.KeyCodes.E,
             jump:  Phaser.Input.Keyboard.KeyCodes.SPACE,
         });
-        this.input.keyboard.addCapture('SPACE,UP');
+        this.input.keyboard.addCapture('SPACE,UP,W');
 
         this.events.once('shutdown', () => this.teardownDom());
     }
 
-    computeLayout() {
-        const w = this.cameras.main.width;
-        const h = this.cameras.main.height;
-        // Room sits in a fixed-aspect frame regardless of window size so
-        // furniture proportions stay readable.
-        const targetAspect = 16 / 9;
-        const frameH = Math.min(h - 80, 540);
-        const frameW = Math.min(w - 80, frameH * targetAspect);
-        const fx = Math.round((w - frameW) / 2);
-        const fy = Math.round((h - frameH) / 2);
-        return {
-            w, h,
-            frameX: fx,
-            frameY: fy,
-            frameW,
-            frameH,
-            floorY: fy + Math.round(frameH * 0.78),
-            wallTopY: fy + Math.round(frameH * 0.10),
-        };
+    // ---------- DOM overlay hiding ---------------------------------------
+
+    hideWorldOverlays() {
+        // Track every selector we toggled so teardown can restore exactly
+        // what we hid, even if the scene gained new HUD pieces over time.
+        // The light canvas in particular is critical — it overlays world
+        // darkness on top of the screen and would otherwise persist into
+        // the interior.
+        const selectors = [
+            '#light_canvas',
+            '#dialogue_canvas',
+            '#minimapContainer',
+            '#mapViewOverlay',
+            '#mapMarkerSwatch',
+            '#toolbarContainer',
+            '#saveButton',
+            '#backToMenuButton',
+        ];
+        this._hiddenEls = [];
+        for (const sel of selectors) {
+            document.querySelectorAll(sel).forEach((el) => {
+                this._hiddenEls.push({el, prev: el.style.display});
+                el.style.display = 'none';
+            });
+        }
     }
 
+    restoreWorldOverlays() {
+        if (!this._hiddenEls) return;
+        for (const entry of this._hiddenEls) {
+            entry.el.style.display = entry.prev || '';
+        }
+        this._hiddenEls = null;
+    }
+
+    // ---------- Room layers ----------------------------------------------
+
     buildInterior() {
-        const {frameX, frameY, frameW, frameH, floorY, wallTopY} = this.layout;
         const palette = HUT_PALETTES[this.hut.paletteKey] || HUT_PALETTES.dusty;
-        const wallpaper = resolveDecor('wallpaper', this.decor.wallpaper);
-        const floor = resolveDecor('floor', this.decor.floor);
+        const wallpaper = this.hut.isPlayerHouse
+            ? resolveDecor('wallpaper', this.decor.wallpaper)
+            : GHOST_PALETTE.wallpaper;
+        const floor = this.hut.isPlayerHouse
+            ? resolveDecor('floor', this.decor.floor)
+            : GHOST_PALETTE.floor;
         this.activeDecor = {wallpaper, floor};
 
-        // Outer frame — soft drop shadow
-        const shadow = this.add.rectangle(frameX + frameW / 2 + 6, frameY + frameH / 2 + 8, frameW, frameH, 0x000000, 0.45);
-        shadow.setDepth(0);
+        const W = ROOM_W;
+        const H = ROOM_H;
 
-        // Ceiling beam strip
-        const ceiling = this.add.rectangle(frameX + frameW / 2, frameY + (wallTopY - frameY) / 2, frameW, wallTopY - frameY, Phaser.Display.Color.HexStringToColor(palette.roofShadow).color);
-        ceiling.setDepth(1);
+        // Outer floor-plan bounds
+        this.add.rectangle(W / 2, H / 2, W, H, 0x0a0806).setDepth(0);
 
-        // Wallpapered wall
-        this.wallpaperRect = this.add.rectangle(frameX + frameW / 2, (wallTopY + floorY) / 2, frameW, floorY - wallTopY, Phaser.Display.Color.HexStringToColor(wallpaper.color).color);
-        this.wallpaperRect.setDepth(1);
+        // Ceiling band (dark beam)
+        this.add.rectangle(W / 2, WALL_TOP_Y / 2, W, WALL_TOP_Y,
+            Phaser.Display.Color.HexStringToColor(palette.roofShadow).color
+        ).setDepth(1);
+        this.add.rectangle(W / 2, WALL_TOP_Y - 1, W, 2,
+            Phaser.Display.Color.HexStringToColor(palette.roofTrim).color
+        ).setDepth(1.1);
 
-        // Wallpaper stripes overlay (drawn lazily via Graphics so they
-        // re-render when decor changes)
-        this.wallpaperStripes = this.add.graphics();
-        this.wallpaperStripes.setDepth(2);
+        // Wallpapered band
+        this.wallpaperRect = this.add.rectangle(
+            W / 2, (WALL_TOP_Y + FLOOR_Y) / 2, W, FLOOR_Y - WALL_TOP_Y,
+            Phaser.Display.Color.HexStringToColor(wallpaper.color).color
+        ).setDepth(1);
+
+        this.wallpaperStripes = this.add.graphics().setDepth(2);
         this.drawWallpaperStripes(wallpaper);
 
-        // Skirting / chair-rail trim above the floor
-        this.add.rectangle(frameX + frameW / 2, floorY - 6, frameW, 4, Phaser.Display.Color.HexStringToColor(palette.roofTrim).color).setDepth(3);
-        this.add.rectangle(frameX + frameW / 2, floorY - 4, frameW, 1, Phaser.Display.Color.HexStringToColor(palette.wallShadow).color).setDepth(3.1);
+        // Skirting board strip
+        this.add.rectangle(W / 2, FLOOR_Y - 2, W, 3,
+            Phaser.Display.Color.HexStringToColor(palette.roofTrim).color
+        ).setDepth(3);
 
         // Floor body
-        this.floorRect = this.add.rectangle(frameX + frameW / 2, (floorY + frameY + frameH) / 2, frameW, frameY + frameH - floorY, Phaser.Display.Color.HexStringToColor(floor.base).color);
-        this.floorRect.setDepth(1);
+        this.floorRect = this.add.rectangle(
+            W / 2, (FLOOR_Y + H) / 2, W, H - FLOOR_Y,
+            Phaser.Display.Color.HexStringToColor(floor.base).color
+        ).setDepth(1);
 
-        this.floorPlanks = this.add.graphics();
-        this.floorPlanks.setDepth(2);
+        this.floorPlanks = this.add.graphics().setDepth(2);
         this.drawFloorPlanks(floor);
 
-        // Front-edge floor shadow line
-        this.add.rectangle(frameX + frameW / 2, floorY, frameW, 2, 0x000000, 0.45).setDepth(3.2);
+        this.add.rectangle(W / 2, FLOOR_Y + 1, W, 1, 0x000000, 0.5).setDepth(3.2);
 
-        // A small framed photo on the wall — gives the room some life
-        const photoX = frameX + Math.round(frameW * 0.18);
-        const photoY = wallTopY + 36;
-        this.add.rectangle(photoX, photoY, 32, 24, 0x2a1808).setDepth(3);
-        this.add.rectangle(photoX, photoY, 28, 20, 0xfff1c4).setDepth(3.1);
-        this.add.rectangle(photoX - 6, photoY + 4, 6, 6, 0x5a8a4a).setDepth(3.2);
-        this.add.rectangle(photoX + 4, photoY + 2, 8, 8, 0x88b4dc).setDepth(3.2);
+        // Window — only player house gets clear glass; ghost huts get
+        // boarded windows handled in buildAbandonedFurniture.
+        if (this.hut.isPlayerHouse) {
+            const winX = 32, winY = WALL_TOP_Y + 26;
+            this.add.rectangle(winX, winY, 26, 22, 0x2a1808).setDepth(3);
+            this.add.rectangle(winX, winY, 22, 18, 0x88b4dc).setDepth(3.1);
+            this.add.rectangle(winX, winY + 4, 22, 4, 0x4a6a8a).setDepth(3.2);
+            this.add.rectangle(winX, winY, 1, 18, 0x2a1808).setDepth(3.3);
+            this.add.rectangle(winX, winY, 22, 1, 0x2a1808).setDepth(3.3);
 
-        // A wall sconce for warmth
-        const sconceX = frameX + Math.round(frameW * 0.5);
-        const sconceY = wallTopY + 24;
-        this.add.rectangle(sconceX, sconceY, 4, 8, 0x2a1808).setDepth(3);
-        this.add.circle(sconceX, sconceY - 6, 4, 0xffd27a, 0.85).setDepth(3.1).setBlendMode(Phaser.BlendModes.ADD);
-        this.add.circle(sconceX, sconceY - 6, 14, 0xffd27a, 0.18).setDepth(3.05).setBlendMode(Phaser.BlendModes.ADD);
+            // Framed photo above the bed area
+            this.add.rectangle(W - 60, WALL_TOP_Y + 14, 16, 12, 0x2a1808).setDepth(3);
+            this.add.rectangle(W - 60, WALL_TOP_Y + 14, 14, 10, 0xfff1c4).setDepth(3.1);
+            this.add.circle(W - 62, WALL_TOP_Y + 14, 1.5, 0x5a8a4a).setDepth(3.2);
 
-        // Window with sky behind it
-        const winX = frameX + Math.round(frameW * 0.82);
-        const winY = wallTopY + 44;
-        this.add.rectangle(winX, winY, 64, 48, 0x2a1808).setDepth(3);
-        this.add.rectangle(winX, winY, 58, 42, 0x88b4dc).setDepth(3.1);
-        this.add.rectangle(winX, winY + 8, 58, 8, 0x4a6a8a).setDepth(3.2);
-        this.add.rectangle(winX, winY, 2, 42, 0x2a1808).setDepth(3.3);
-        this.add.rectangle(winX, winY, 58, 2, 0x2a1808).setDepth(3.3);
+            // Wall sconce — warm pin of light, baked into the room layer.
+            const sconceX = W / 2;
+            const sconceY = WALL_TOP_Y + 10;
+            this.add.rectangle(sconceX, sconceY, 2, 4, 0x2a1808).setDepth(3);
+            this.add.circle(sconceX, sconceY - 3, 2, 0xffd27a, 0.95).setDepth(3.1).setBlendMode(Phaser.BlendModes.ADD);
+            this.add.circle(sconceX, sconceY - 3, 7, 0xffd27a, 0.22).setDepth(3.05).setBlendMode(Phaser.BlendModes.ADD);
+        }
 
-        // Optional rug on the floor
+        // Optional rug — player only
         this.rugRoot = this.add.container(0, 0).setDepth(3);
-        this.drawRug();
+        if (this.hut.isPlayerHouse) this.drawRug();
+
+        if (!this.hut.isPlayerHouse) this.drawDilapidation();
     }
 
     drawWallpaperStripes(wallpaper) {
-        const {frameX, frameW, frameY} = this.layout;
-        const wallTopY = this.layout.wallTopY;
-        const wallBotY = this.layout.floorY - 4;
         const g = this.wallpaperStripes;
         g.clear();
         const stripeColor = Phaser.Display.Color.HexStringToColor(wallpaper.stripe).color;
-        g.fillStyle(stripeColor, 0.55);
-        const stripeW = 4;
-        const gap = 18;
-        for (let x = frameX + 8; x < frameX + frameW; x += gap) {
-            g.fillRect(x, wallTopY, stripeW, wallBotY - wallTopY);
+        g.fillStyle(stripeColor, 0.5);
+        const stripeW = 2;
+        const gap = 10;
+        for (let x = 4; x < ROOM_W; x += gap) {
+            g.fillRect(x, WALL_TOP_Y, stripeW, FLOOR_Y - WALL_TOP_Y - 2);
         }
         g.fillStyle(Phaser.Display.Color.HexStringToColor(wallpaper.accent).color, 0.7);
-        g.fillRect(frameX, wallTopY, frameW, 2);
-        g.fillRect(frameX, wallBotY - 2, frameW, 2);
+        g.fillRect(0, WALL_TOP_Y, ROOM_W, 1);
+        g.fillRect(0, FLOOR_Y - 3, ROOM_W, 1);
     }
 
     drawFloorPlanks(floor) {
-        const {frameX, frameW, floorY, frameY, frameH} = this.layout;
         const g = this.floorPlanks;
         g.clear();
-        g.fillStyle(Phaser.Display.Color.HexStringToColor(floor.dark).color, 0.85);
-        const plankH = 12;
-        const bottom = frameY + frameH;
-        for (let y = floorY + plankH; y < bottom; y += plankH) {
-            g.fillRect(frameX, y, frameW, 1);
-        }
-        g.fillStyle(Phaser.Display.Color.HexStringToColor(floor.light).color, 0.45);
-        for (let y = floorY + plankH + 1; y < bottom; y += plankH) {
-            g.fillRect(frameX, y, frameW, 1);
+        const darkC = Phaser.Display.Color.HexStringToColor(floor.dark).color;
+        const lightC = Phaser.Display.Color.HexStringToColor(floor.light).color;
+        const plankH = 6;
+        for (let y = FLOOR_Y + plankH; y < ROOM_H; y += plankH) {
+            g.fillStyle(darkC, 0.8);
+            g.fillRect(0, y, ROOM_W, 1);
+            g.fillStyle(lightC, 0.4);
+            g.fillRect(0, y + 1, ROOM_W, 1);
         }
     }
 
@@ -235,170 +290,302 @@ export default class HouseScene extends Phaser.Scene {
         this.rugRoot.removeAll(true);
         const rug = resolveDecor('rug', this.decor.rug);
         if (!rug || !rug.base) return;
-        const {frameX, frameW, floorY, frameY, frameH} = this.layout;
-        const rugW = Math.round(frameW * 0.30);
-        const rugH = 26;
-        const rx = frameX + Math.round(frameW * 0.50) - rugW / 2;
-        const ry = floorY + 6;
-        const base = this.add.rectangle(rx + rugW / 2, ry + rugH / 2, rugW, rugH, Phaser.Display.Color.HexStringToColor(rug.base).color);
-        const trim = this.add.rectangle(rx + rugW / 2, ry + rugH / 2, rugW - 4, rugH - 6, Phaser.Display.Color.HexStringToColor(rug.stripe).color, 0.8);
+        const rugW = 56;
+        const rugH = 12;
+        const rx = ROOM_W / 2 - rugW / 2;
+        const ry = FLOOR_Y + 4;
+        const base = this.add.rectangle(rx + rugW / 2, ry + rugH / 2, rugW, rugH,
+            Phaser.Display.Color.HexStringToColor(rug.base).color);
+        const trim = this.add.rectangle(rx + rugW / 2, ry + rugH / 2, rugW - 4, rugH - 4,
+            Phaser.Display.Color.HexStringToColor(rug.stripe).color, 0.75);
         const stripeG = this.add.graphics();
         stripeG.fillStyle(Phaser.Display.Color.HexStringToColor(rug.stripe).color, 0.85);
-        for (let i = 0; i < rugW; i += 8) {
-            stripeG.fillRect(rx + i, ry + 4, 2, rugH - 8);
+        for (let i = 2; i < rugW - 2; i += 4) {
+            stripeG.fillRect(rx + i, ry + 2, 1, rugH - 4);
         }
         this.rugRoot.add([base, trim, stripeG]);
     }
 
-    buildFurniture() {
-        const {frameX, frameW, floorY} = this.layout;
+    // Dust, cobwebs, cracks, and graffiti for ghost huts. Drawn straight
+    // onto the room layer (no animation) so the abandoned look reads
+    // immediately and doesn't need per-frame work.
+    drawDilapidation() {
+        const g = this.add.graphics().setDepth(3.5);
+        // Cobwebs in the upper corners
+        g.lineStyle(1, 0xc8c0b0, 0.45);
+        const webCorner = (cx, cy, dir) => {
+            for (let i = 0; i < 6; i++) {
+                g.beginPath();
+                g.moveTo(cx, cy);
+                g.lineTo(cx + dir * (8 + i * 2), cy + i * 3);
+                g.strokePath();
+            }
+            for (let r = 4; r <= 14; r += 4) {
+                g.beginPath();
+                g.moveTo(cx + dir * 4, cy + 2);
+                g.lineTo(cx + dir * (r + 2), cy + r - 2);
+                g.lineTo(cx + dir * (r - 2), cy + r + 2);
+                g.strokePath();
+            }
+        };
+        webCorner(0, WALL_TOP_Y, 1);
+        webCorner(ROOM_W, WALL_TOP_Y, -1);
+
+        // Wall cracks
+        g.lineStyle(1, 0x000000, 0.45);
+        const crack = (x, y) => {
+            g.beginPath();
+            g.moveTo(x, y);
+            let cx = x, cy = y;
+            for (let i = 0; i < 8; i++) {
+                cx += (Math.random() - 0.5) * 6;
+                cy += 4;
+                g.lineTo(cx, cy);
+            }
+            g.strokePath();
+        };
+        crack(40, WALL_TOP_Y + 4);
+        crack(120, WALL_TOP_Y + 14);
+        crack(170, WALL_TOP_Y + 6);
+
+        // Dust speckles on the floor
+        const dust = this.add.graphics().setDepth(3.6);
+        dust.fillStyle(0x000000, 0.35);
+        for (let i = 0; i < 80; i++) {
+            const x = Math.floor(Math.random() * ROOM_W);
+            const y = FLOOR_Y + 2 + Math.floor(Math.random() * (ROOM_H - FLOOR_Y - 2));
+            dust.fillRect(x, y, 1, 1);
+        }
+        dust.fillStyle(0xfff1c4, 0.18);
+        for (let i = 0; i < 40; i++) {
+            const x = Math.floor(Math.random() * ROOM_W);
+            const y = FLOOR_Y + 2 + Math.floor(Math.random() * (ROOM_H - FLOOR_Y - 2));
+            dust.fillRect(x, y, 1, 1);
+        }
+
+        // Boarded-up window where the player-house window would sit
+        const winX = 32, winY = WALL_TOP_Y + 26;
+        this.add.rectangle(winX, winY, 26, 22, 0x2a1808).setDepth(3);
+        this.add.rectangle(winX, winY, 22, 18, 0x1a1208).setDepth(3.1);
+        const boardG = this.add.graphics().setDepth(3.4);
+        boardG.fillStyle(0x6a4a28, 1);
+        boardG.fillRect(winX - 12, winY - 4, 24, 3);
+        boardG.fillRect(winX - 12, winY + 2, 24, 3);
+        boardG.fillStyle(0x2a1808, 1);
+        boardG.fillRect(winX - 12, winY - 4, 24, 1);
+        boardG.fillRect(winX - 12, winY + 2, 24, 1);
+        // Nails
+        boardG.fillStyle(0xc8c0b0, 1);
+        for (const yy of [winY - 3, winY + 3]) {
+            boardG.fillRect(winX - 10, yy, 1, 1);
+            boardG.fillRect(winX + 10, yy, 1, 1);
+        }
+
+        // Lone falling leaf / debris pile on the floor
+        const debris = this.add.graphics().setDepth(3.7);
+        debris.fillStyle(0x5a3a18, 0.85);
+        debris.fillRect(110, FLOOR_Y + 14, 8, 2);
+        debris.fillRect(112, FLOOR_Y + 12, 4, 2);
+        debris.fillStyle(0x3a2a18, 0.85);
+        debris.fillRect(140, FLOOR_Y + 16, 6, 2);
+    }
+
+    // ---------- Furniture ------------------------------------------------
+
+    buildHomeFurniture() {
+        const W = ROOM_W;
         this.furniture = [];
 
-        // Door — left third of the room. Walking into it + ↑ exits.
-        const doorX = frameX + Math.round(frameW * 0.13);
-        const doorY = floorY - 30;
-        const doorFrame = this.add.rectangle(doorX, doorY, 28, 60, 0x2a1404).setDepth(3);
-        const door = this.add.rectangle(doorX, doorY, 22, 54, 0x6a3318).setDepth(3.1);
-        this.add.rectangle(doorX + 6, doorY, 2, 2, 0xf4d56a).setDepth(3.2);
-        // Plank lines on the door
+        // Door — left side. Walking up against it + W/↑ exits.
+        const doorX = 22, doorY = FLOOR_Y - 14;
+        this.add.rectangle(doorX, doorY, 14, 26, 0x2a1404).setDepth(3);
+        this.add.rectangle(doorX, doorY, 10, 22, 0x6a3318).setDepth(3.1);
         const doorG = this.add.graphics().setDepth(3.15);
         doorG.fillStyle(0x2a1404, 0.7);
-        for (let i = -20; i < 20; i += 8) {
-            doorG.fillRect(doorX - 11, doorY + i, 22, 1);
-        }
-        const doorMat = this.add.rectangle(doorX, floorY + 4, 30, 6, 0x7a4a1f).setDepth(3.3);
-        const doorLabel = this.add.text(doorX, doorY - 38, 'Door', {font: '10px monospace', color: '#fff1c4'}).setOrigin(0.5).setDepth(3.4);
+        for (let i = -9; i < 9; i += 4) doorG.fillRect(doorX - 5, doorY + i, 10, 1);
+        this.add.rectangle(doorX + 3, doorY, 1, 1, 0xf4d56a).setDepth(3.2);
+        // Welcome mat
+        this.add.rectangle(doorX, FLOOR_Y + 5, 14, 3, 0x7a4a1f).setDepth(3.3);
         this.furniture.push({
             kind: 'door',
-            x: doorX,
-            y: doorY,
-            range: 26,
-            label: 'Leave',
-            sprite: door,
-            interact: () => this.exitHouse(),
+            x: doorX, y: doorY, range: 12,
+            label: 'Leave', interact: () => this.exitHouse(),
+        });
+
+        // TV — left of bed, mounted-style on its own console
+        const tvX = 70, tvY = FLOOR_Y - 18;
+        this.add.rectangle(tvX, tvY + 8, 22, 6, 0x4a3a26).setDepth(3);
+        this.add.rectangle(tvX, tvY, 20, 12, 0x111111).setDepth(3.1);
+        this.tvScreen = this.add.rectangle(tvX, tvY, 16, 8, 0x2a4a8a).setDepth(3.2);
+        this.tvStatic = this.add.graphics().setDepth(3.3);
+        this.tvStatic.fillStyle(0xffffff, 0.18);
+        for (let y = -3; y <= 3; y += 2) this.tvStatic.fillRect(tvX - 8, tvY + y, 16, 1);
+        this.add.rectangle(tvX - 2, tvY + 8, 4, 1, 0x222222).setDepth(3.4);
+        this.add.rectangle(tvX + 2, tvY + 8, 4, 1, 0x222222).setDepth(3.4);
+        this.tweens.add({
+            targets: this.tvScreen,
+            alpha: {from: 0.85, to: 1},
+            duration: 600, yoyo: true, repeat: -1, ease: 'Sine.easeInOut',
+        });
+        this.furniture.push({
+            kind: 'tv', x: tvX, y: tvY, range: 14,
+            label: 'Watch TV', interact: () => this.openTv(),
         });
 
         // Bed — middle-right
-        const bedX = frameX + Math.round(frameW * 0.62);
-        const bedY = floorY - 14;
+        const bedX = 122, bedY = FLOOR_Y - 6;
         const bed = resolveDecor('bed', this.decor.bed);
         const bedFrameC = Phaser.Display.Color.HexStringToColor(bed.frame).color;
         const blanketC = Phaser.Display.Color.HexStringToColor(bed.blanket).color;
         const pillowC = Phaser.Display.Color.HexStringToColor(bed.pillow).color;
-        this.bedFrame = this.add.rectangle(bedX, bedY, 66, 22, bedFrameC).setDepth(3);
-        this.bedBlanket = this.add.rectangle(bedX + 4, bedY - 2, 56, 16, blanketC).setDepth(3.1);
-        this.bedPillow = this.add.rectangle(bedX - 22, bedY - 6, 14, 8, pillowC).setDepth(3.2);
-        this.add.rectangle(bedX - 30, bedY + 8, 4, 8, bedFrameC).setDepth(2.9);
-        this.add.rectangle(bedX + 30, bedY + 8, 4, 8, bedFrameC).setDepth(2.9);
-        const bedLabel = this.add.text(bedX, bedY - 22, 'Bed', {font: '10px monospace', color: '#fff1c4'}).setOrigin(0.5).setDepth(3.4);
+        this.bedFrame = this.add.rectangle(bedX, bedY, 32, 10, bedFrameC).setDepth(3);
+        this.bedBlanket = this.add.rectangle(bedX + 2, bedY - 1, 26, 6, blanketC).setDepth(3.1);
+        this.bedPillow = this.add.rectangle(bedX - 10, bedY - 3, 6, 3, pillowC).setDepth(3.2);
+        this.add.rectangle(bedX - 14, bedY + 6, 2, 4, bedFrameC).setDepth(2.9);
+        this.add.rectangle(bedX + 14, bedY + 6, 2, 4, bedFrameC).setDepth(2.9);
         this.furniture.push({
-            kind: 'bed',
-            x: bedX,
-            y: bedY,
-            range: 36,
-            label: 'Sleep',
-            interact: () => this.sleepInBed(),
+            kind: 'bed', x: bedX, y: bedY, range: 16,
+            label: 'Sleep', interact: () => this.sleepInBed(),
         });
 
         // Kitchen — far right
-        const kitchenX = frameX + Math.round(frameW * 0.88);
-        const kitchenY = floorY - 14;
-        const counter = this.add.rectangle(kitchenX, kitchenY, 60, 22, 0x8a6a44).setDepth(3);
-        this.add.rectangle(kitchenX, kitchenY - 8, 60, 6, 0xb5895a).setDepth(3.1);
+        const kitchenX = 168, kitchenY = FLOOR_Y - 6;
+        this.add.rectangle(kitchenX, kitchenY, 28, 10, 0x8a6a44).setDepth(3);
+        this.add.rectangle(kitchenX, kitchenY - 4, 28, 2, 0xb5895a).setDepth(3.1);
         // Stove
-        this.add.rectangle(kitchenX - 16, kitchenY - 4, 18, 14, 0x2a2a2a).setDepth(3.2);
-        this.add.rectangle(kitchenX - 16, kitchenY - 9, 14, 2, 0x6a6a6a).setDepth(3.3);
-        this.add.circle(kitchenX - 20, kitchenY - 4, 1.5, 0xff5a1c).setDepth(3.4);
-        this.add.circle(kitchenX - 12, kitchenY - 4, 1.5, 0xff5a1c).setDepth(3.4);
+        this.add.rectangle(kitchenX - 8, kitchenY - 1, 8, 6, 0x2a2a2a).setDepth(3.2);
+        this.add.rectangle(kitchenX - 8, kitchenY - 3, 7, 1, 0x6a6a6a).setDepth(3.3);
+        this.add.circle(kitchenX - 10, kitchenY - 1, 0.8, 0xff5a1c).setDepth(3.4);
+        this.add.circle(kitchenX - 6, kitchenY - 1, 0.8, 0xff5a1c).setDepth(3.4);
         // Sink
-        this.add.rectangle(kitchenX + 16, kitchenY - 4, 16, 12, 0x6a8a99).setDepth(3.2);
-        this.add.rectangle(kitchenX + 16, kitchenY - 8, 4, 6, 0xc0d0d8).setDepth(3.3);
-        const kitchenLabel = this.add.text(kitchenX, kitchenY - 22, 'Kitchen', {font: '10px monospace', color: '#fff1c4'}).setOrigin(0.5).setDepth(3.4);
+        this.add.rectangle(kitchenX + 8, kitchenY - 1, 8, 5, 0x6a8a99).setDepth(3.2);
+        this.add.rectangle(kitchenX + 8, kitchenY - 3, 2, 2, 0xc0d0d8).setDepth(3.3);
         this.furniture.push({
-            kind: 'kitchen',
-            x: kitchenX,
-            y: kitchenY,
-            range: 36,
-            label: 'Cook',
-            interact: () => this.openKitchen(),
-        });
-
-        // TV — left of bed, mounted-style on its own console
-        const tvX = frameX + Math.round(frameW * 0.36);
-        const tvY = floorY - 26;
-        this.add.rectangle(tvX, tvY + 14, 40, 12, 0x4a3a26).setDepth(3); // console
-        this.add.rectangle(tvX, tvY, 36, 22, 0x111111).setDepth(3.1);   // bezel
-        this.tvScreen = this.add.rectangle(tvX, tvY, 30, 16, 0x2a4a8a).setDepth(3.2);
-        // Static lines
-        this.tvStatic = this.add.graphics().setDepth(3.3);
-        this.tvStatic.fillStyle(0xffffff, 0.18);
-        for (let y = -7; y < 7; y += 2) this.tvStatic.fillRect(tvX - 14, tvY + y, 28, 1);
-        this.add.rectangle(tvX - 4, tvY + 14, 8, 2, 0x222222).setDepth(3.4);
-        this.add.rectangle(tvX + 4, tvY + 14, 8, 2, 0x222222).setDepth(3.4);
-        const tvLabel = this.add.text(tvX, tvY - 16, 'TV', {font: '10px monospace', color: '#fff1c4'}).setOrigin(0.5).setDepth(3.4);
-        this.furniture.push({
-            kind: 'tv',
-            x: tvX,
-            y: tvY,
-            range: 32,
-            label: 'Watch TV',
-            interact: () => this.openTv(),
-        });
-
-        // Subtle TV flicker
-        this.tweens.add({
-            targets: this.tvScreen,
-            alpha: {from: 0.85, to: 1},
-            duration: 600,
-            yoyo: true,
-            repeat: -1,
-            ease: 'Sine.easeInOut',
+            kind: 'kitchen', x: kitchenX, y: kitchenY, range: 16,
+            label: 'Cook', interact: () => this.openKitchen(),
         });
     }
 
+    buildAbandonedFurniture() {
+        this.furniture = [];
+
+        // Door is the only working fixture. Aged wood + a sagging mat.
+        const doorX = 22, doorY = FLOOR_Y - 14;
+        this.add.rectangle(doorX, doorY, 14, 26, 0x1a0e04).setDepth(3);
+        this.add.rectangle(doorX, doorY, 10, 22, 0x3a2210).setDepth(3.1);
+        const doorG = this.add.graphics().setDepth(3.15);
+        doorG.fillStyle(0x0a0604, 0.8);
+        for (let i = -9; i < 9; i += 4) doorG.fillRect(doorX - 5, doorY + i, 10, 1);
+        // Hanging crooked sign
+        this.add.rectangle(doorX, doorY - 16, 16, 4, 0x4a3a22).setDepth(3.4).setAngle(-4);
+        this.furniture.push({
+            kind: 'door', x: doorX, y: doorY, range: 12,
+            label: 'Leave', interact: () => this.exitHouse(),
+        });
+
+        // Broken bed frame — no blanket, tilted, mattress half off
+        const bedX = 122, bedY = FLOOR_Y - 5;
+        this.add.rectangle(bedX, bedY, 32, 8, 0x2a1808).setDepth(3).setAngle(-3);
+        this.add.rectangle(bedX + 4, bedY - 1, 18, 4, 0x5a4232).setDepth(3.1).setAngle(-3);
+        this.add.rectangle(bedX - 14, bedY + 5, 2, 4, 0x2a1808).setDepth(2.9);
+        this.add.rectangle(bedX + 14, bedY + 7, 2, 6, 0x2a1808).setDepth(2.9);
+
+        // Knocked-over stove + shattered counter — no flames, no power
+        const kitchenX = 168, kitchenY = FLOOR_Y - 5;
+        this.add.rectangle(kitchenX, kitchenY, 26, 8, 0x4a3a26).setDepth(3);
+        this.add.rectangle(kitchenX, kitchenY - 3, 26, 2, 0x2a1808).setDepth(3.1);
+        // Crack across the counter top
+        const counterG = this.add.graphics().setDepth(3.2);
+        counterG.lineStyle(1, 0x0a0604, 0.9);
+        counterG.beginPath();
+        counterG.moveTo(kitchenX - 12, kitchenY - 2);
+        counterG.lineTo(kitchenX - 4, kitchenY - 1);
+        counterG.lineTo(kitchenX + 6, kitchenY - 3);
+        counterG.lineTo(kitchenX + 12, kitchenY - 2);
+        counterG.strokePath();
+        // Knocked-over stove (lying on its side)
+        this.add.rectangle(kitchenX - 8, kitchenY + 2, 8, 4, 0x2a2a2a).setDepth(3.3).setAngle(20);
+        this.add.rectangle(kitchenX - 6, kitchenY + 3, 5, 1, 0x4a4a4a).setDepth(3.4).setAngle(20);
+
+        // Broken TV on the floor, screen smashed
+        const tvX = 72, tvY = FLOOR_Y + 8;
+        this.add.rectangle(tvX, tvY, 20, 12, 0x111111).setDepth(3).setAngle(-12);
+        this.add.rectangle(tvX, tvY, 16, 8, 0x222222).setDepth(3.1).setAngle(-12);
+        const smashG = this.add.graphics().setDepth(3.2);
+        smashG.lineStyle(1, 0xc0c0c0, 0.8);
+        const lines = [
+            [-6, -3, 6, 3], [-4, 2, 4, -2], [-6, 0, 6, 0],
+            [-2, -3, 2, 3], [0, -3, 1, 3],
+        ];
+        for (const [x1, y1, x2, y2] of lines) {
+            smashG.beginPath();
+            smashG.moveTo(tvX + x1, tvY + y1);
+            smashG.lineTo(tvX + x2, tvY + y2);
+            smashG.strokePath();
+        }
+
+        // A toppled chair off to the side
+        const chairX = 96, chairY = FLOOR_Y + 6;
+        this.add.rectangle(chairX, chairY, 8, 6, 0x4a3220).setDepth(3).setAngle(70);
+        this.add.rectangle(chairX + 4, chairY - 2, 1, 8, 0x4a3220).setDepth(3.1).setAngle(70);
+    }
+
+    // ---------- Player ---------------------------------------------------
+
     buildPlayer() {
-        const {frameX, frameW, floorY} = this.layout;
-        // Drop the player just inside the door so the very first thing
-        // they see is themselves having walked in. Use the existing
-        // player_walk spritesheet for visual consistency with the world.
-        const startX = frameX + Math.round(frameW * 0.20);
-        const startY = floorY - 16;
+        // Spawn just inside the room — past the door's interaction range
+        // so the leave-prompt doesn't immediately appear the instant the
+        // player walks in (otherwise the very first input "leave" would
+        // bounce them straight back outside).
+        const startX = 44;
+        const startY = FLOOR_Y - 7;
         this.player = this.physics.add.sprite(startX, startY, 'player_stationary');
-        this.player.setDisplaySize(20, 28);
+        this.player.setDisplaySize(7, 10);
         this.player.setDepth(4);
         this.player.body.setAllowGravity(false);
-        this.player.body.setSize(14, 28);
-        // Reuse the global animations registered by PlayerManager.
-        if (this.anims.exists('walk')) this.player.play('stationary');
+        this.player.body.setSize(6, 10);
+        if (this.anims.exists('stationary')) this.player.play('stationary');
 
-        this.playerHead = this.add.sprite(startX, startY - 8, 'player_head');
-        this.playerHead.setDisplaySize(20, 20);
+        this.playerHead = this.add.sprite(startX, startY - 4, 'player_head');
+        this.playerHead.setDisplaySize(7, 7);
         this.playerHead.setDepth(4.1);
 
-        this.shadow = this.add.ellipse(startX, floorY - 1, 24, 6, 0x000000, 0.4).setDepth(3.5);
+        this.shadow = this.add.ellipse(startX, FLOOR_Y, 8, 2, 0x000000, 0.45).setDepth(3.5);
     }
 
     buildPrompts() {
-        // Floating prompt that follows the player when they're in range
-        // of an interactable.
         this.prompt = this.add.text(0, 0, '', {
-            font: '12px monospace',
+            font: '6px monospace',
             color: '#fff1c4',
-            backgroundColor: 'rgba(0, 0, 0, 0.65)',
-            padding: {left: 6, right: 6, top: 3, bottom: 3},
+            backgroundColor: 'rgba(0, 0, 0, 0.75)',
+            padding: {left: 2, right: 2, top: 1, bottom: 1},
         }).setOrigin(0.5, 1).setDepth(50).setVisible(false);
+        this.prompt.setResolution(6);
 
-        this.title = this.add.text(this.layout.frameX + this.layout.frameW / 2, this.layout.frameY + 24,
+        this.title = this.add.text(ROOM_W / 2, 6,
             this.hut.isPlayerHouse ? 'HOME' : 'ABANDONED HUT', {
-                font: '14px monospace',
-                color: '#fff1c4',
+                font: '7px monospace',
+                color: this.hut.isPlayerHouse ? '#fff1c4' : '#a89888',
                 stroke: '#000000',
-                strokeThickness: 3,
-        }).setOrigin(0.5).setDepth(50);
+                strokeThickness: 2,
+        }).setOrigin(0.5, 0).setDepth(50);
+        this.title.setResolution(6);
     }
 
+    buildVignette() {
+        // Soft dark border that pulls focus inwards. Drawn as four
+        // gradients on the edges of the logical room.
+        const v = this.add.graphics().setDepth(60);
+        v.fillStyle(0x000000, 0.35);
+        v.fillRect(0, 0, ROOM_W, 4);
+        v.fillRect(0, ROOM_H - 4, ROOM_W, 4);
+        v.fillRect(0, 0, 4, ROOM_H);
+        v.fillRect(ROOM_W - 4, 0, 4, ROOM_H);
+    }
+
+    // ---------- HUD buttons ---------------------------------------------
+
     buildExitButton() {
-        const {frameX, frameY} = this.layout;
         const exit = document.createElement('button');
         exit.id = 'house_exit_btn';
         exit.className = 'hud-btn';
@@ -406,8 +593,8 @@ export default class HouseScene extends Phaser.Scene {
         exit.innerHTML = '<span>Leave House (Esc)</span>';
         Object.assign(exit.style, {
             position: 'absolute',
-            top: (frameY - 8) + 'px',
-            right: (this.cameras.main.width - frameX - this.layout.frameW + 4) + 'px',
+            top: '18px',
+            right: '18px',
             zIndex: '1001',
         });
         document.body.appendChild(exit);
@@ -418,7 +605,6 @@ export default class HouseScene extends Phaser.Scene {
     }
 
     buildDecorButton() {
-        const {frameX, frameY, frameW} = this.layout;
         const btn = document.createElement('button');
         btn.id = 'house_decor_btn';
         btn.className = 'hud-btn';
@@ -426,8 +612,8 @@ export default class HouseScene extends Phaser.Scene {
         btn.innerHTML = '<span>Decorate</span>';
         Object.assign(btn.style, {
             position: 'absolute',
-            top: (frameY - 8) + 'px',
-            left: (frameX + 4) + 'px',
+            top: '18px',
+            left: '18px',
             zIndex: '1001',
         });
         document.body.appendChild(btn);
@@ -439,11 +625,17 @@ export default class HouseScene extends Phaser.Scene {
         this._exitBtn?.remove();
         this._decorBtn?.remove();
         this._decorPanel?.remove();
+        this._exitBtn = null;
+        this._decorBtn = null;
+        this._decorPanel = null;
+        this.restoreWorldOverlays();
     }
+
+    // ---------- Update loop ---------------------------------------------
 
     update() {
         if (!this.player) return;
-        const speed = 90;
+        const speed = 36;
         let vx = 0;
         if (this.cursors.left.isDown)  vx -= speed;
         if (this.cursors.right.isDown) vx += speed;
@@ -460,19 +652,17 @@ export default class HouseScene extends Phaser.Scene {
             if (this.anims.exists('stationary')) this.player.play('stationary', true);
         }
 
-        // Clamp player to the room walls
-        const minX = this.layout.frameX + 14;
-        const maxX = this.layout.frameX + this.layout.frameW - 14;
+        // Keep the player inside the walls
+        const minX = 10, maxX = ROOM_W - 10;
         if (this.player.x < minX) this.player.x = minX;
         if (this.player.x > maxX) this.player.x = maxX;
-        // Pin Y so they walk along the floor (no gravity in the house)
-        this.player.y = this.layout.floorY - 16;
+        this.player.y = FLOOR_Y - 7;
 
         this.playerHead.x = this.player.x;
-        this.playerHead.y = this.player.y - 10;
+        this.playerHead.y = this.player.y - 4;
         this.shadow.x = this.player.x;
 
-        // Find the nearest interactable in range
+        // Find nearest interactable
         let nearest = null;
         let bestDist = Infinity;
         for (const f of this.furniture) {
@@ -486,9 +676,9 @@ export default class HouseScene extends Phaser.Scene {
 
         if (nearest) {
             const isDoor = nearest.kind === 'door';
-            const key = isDoor ? '↑' : 'E';
-            this.prompt.setText(`${key} to ${nearest.label}`);
-            this.prompt.setPosition(nearest.x, nearest.y - 30);
+            const key = isDoor ? 'W/↑' : 'E';
+            this.prompt.setText(`${key} ${nearest.label}`);
+            this.prompt.setPosition(nearest.x, nearest.y - 14);
             this.prompt.setVisible(true);
         } else {
             this.prompt.setVisible(false);
@@ -496,7 +686,8 @@ export default class HouseScene extends Phaser.Scene {
 
         if (nearest) {
             if (nearest.kind === 'door') {
-                if (Phaser.Input.Keyboard.JustDown(this.cursors.up)) {
+                if (Phaser.Input.Keyboard.JustDown(this.cursors.up) ||
+                    Phaser.Input.Keyboard.JustDown(this.cursors.w)) {
                     nearest.interact();
                     return;
                 }
@@ -509,32 +700,31 @@ export default class HouseScene extends Phaser.Scene {
         }
     }
 
+    // ---------- Actions --------------------------------------------------
+
     exitHouse() {
         if (this._exiting) return;
         this._exiting = true;
         this.cameras.main.fadeOut(220, 0, 0, 0);
         this.cameras.main.once('camerafadeoutcomplete', () => {
+            this.teardownDom();
+            const gs = this.gameScene;
             this.scene.stop();
-            this.gameScene?.scene.resume();
+            gs?.scene.resume();
         });
     }
 
     sleepInBed() {
         const player = this.gameScene?.player;
         if (!player) return;
-        // Quick rest: top energy + breath, dim the screen for a beat.
         const overlay = this.add.rectangle(
-            this.layout.w / 2, this.layout.h / 2,
-            this.layout.w, this.layout.h,
-            0x000000, 0
+            ROOM_W / 2, ROOM_H / 2, ROOM_W, ROOM_H, 0x000000, 0
         ).setDepth(80);
         this.prompt.setVisible(false);
         this.tweens.add({
             targets: overlay,
             alpha: 0.85,
-            duration: 600,
-            yoyo: true,
-            hold: 600,
+            duration: 600, yoyo: true, hold: 600,
             onComplete: () => {
                 player.energy = player.maxEnergy;
                 player.breath = player.maxBreath;
@@ -550,7 +740,6 @@ export default class HouseScene extends Phaser.Scene {
     }
 
     openTv() {
-        // Cycle the screen through a few channel colours as a teaser.
         const channels = [0x2a4a8a, 0x8a3a3a, 0x3a8a4a, 0x6a2a8a, 0xc0a040];
         this._tvIdx = ((this._tvIdx ?? 0) + 1) % channels.length;
         this.tvScreen.setFillStyle(channels[this._tvIdx]);
@@ -559,17 +748,17 @@ export default class HouseScene extends Phaser.Scene {
 
     flashToast(text) {
         if (this._toast) this._toast.destroy();
-        this._toast = this.add.text(this.layout.w / 2, this.layout.h - 80, text, {
-            font: '12px monospace',
+        this._toast = this.add.text(ROOM_W / 2, ROOM_H - 12, text, {
+            font: '5px monospace',
             color: '#fff1c4',
-            backgroundColor: 'rgba(0, 0, 0, 0.7)',
-            padding: {left: 8, right: 8, top: 4, bottom: 4},
+            backgroundColor: 'rgba(0, 0, 0, 0.8)',
+            padding: {left: 2, right: 2, top: 1, bottom: 1},
         }).setOrigin(0.5).setDepth(80);
+        this._toast.setResolution(6);
         this.tweens.add({
             targets: this._toast,
             alpha: {from: 1, to: 0},
-            delay: 1400,
-            duration: 600,
+            delay: 1400, duration: 600,
             onComplete: () => {
                 this._toast?.destroy();
                 this._toast = null;
@@ -588,8 +777,8 @@ export default class HouseScene extends Phaser.Scene {
         panel.id = 'house_decor_panel';
         Object.assign(panel.style, {
             position: 'absolute',
-            top: (this.layout.frameY + 30) + 'px',
-            left: (this.layout.frameX + 8) + 'px',
+            top: '60px',
+            left: '18px',
             zIndex: '1002',
             padding: '12px',
             display: 'flex',
@@ -642,8 +831,6 @@ export default class HouseScene extends Phaser.Scene {
 
     applyDecor(group, key) {
         this.decor[group] = key;
-        // Persist on the world tile for the player house so reloads keep
-        // the same look. Find the hut tile from the returnDoor coords.
         if (this.hut.isPlayerHouse && this.returnDoor && this.gameScene?.grid) {
             const grid = this.gameScene.grid;
             const {chunkKey, cellX, cellY} = this.returnDoor;
@@ -653,7 +840,6 @@ export default class HouseScene extends Phaser.Scene {
             }
         }
 
-        // Re-render the affected layer
         if (group === 'wallpaper') {
             const wp = resolveDecor('wallpaper', key);
             this.wallpaperRect.setFillStyle(Phaser.Display.Color.HexStringToColor(wp.color).color);
@@ -671,7 +857,6 @@ export default class HouseScene extends Phaser.Scene {
             this.drawRug();
         }
 
-        // Refresh decorate panel so the active highlight follows
         if (this._decorPanel) {
             this._decorPanel.remove();
             this._decorPanel = null;

--- a/src/services/controls.js
+++ b/src/services/controls.js
@@ -11,11 +11,21 @@ export default class ControlsManager {
             up: Phaser.Input.Keyboard.KeyCodes.W,
             left: Phaser.Input.Keyboard.KeyCodes.A,
             right: Phaser.Input.Keyboard.KeyCodes.D,
-            down: Phaser.Input.Keyboard.KeyCodes.S
+            down: Phaser.Input.Keyboard.KeyCodes.S,
+            jump: Phaser.Input.Keyboard.KeyCodes.SPACE,
+            enter: Phaser.Input.Keyboard.KeyCodes.UP
         });
+        // SPACE doubles as the page-scroll trigger in browsers; suppress it
+        // when the game has focus so jumping doesn't also flick the window.
+        this.game.input.keyboard.addCapture('SPACE,UP');
 
 
         window.addEventListener("keydown", (e) => {
+            // Don't fire surface-world prompts while the player is inside
+            // a house (HouseScene runs paused-on-top of GameScene). Stale
+            // showInteractionPrompt callbacks could otherwise call crane
+            // moves while the player is sleeping.
+            if (this.game.scene && !this.game.scene.isActive()) return;
             if (e.key === "e") {
                 if (this.game.showInteractionPrompt) {
                     this.game.showInteractionPrompt();
@@ -200,6 +210,24 @@ export default class ControlsManager {
             }
         });
 
+        // Standing-at-the-door hut entry. Up arrow is the dedicated
+        // "open this door" key (jump is now SPACE) so the prompt stays
+        // legible even on a controller-style WASD layout.
+        this.game.activeHut = null;
+        this.game.hutEnterPrompt = null;
+        if (this.game.hutGroup) {
+            this.game.physics.overlap(this.game.player, this.game.hutGroup, (obj1, obj2) => {
+                const ref = obj2?.tileRef;
+                if (!ref) return;
+                this.game.activeHut = ref;
+                const label = ref.tileDetails?.isPlayerHouse ? 'Enter Home' : 'Enter Hut';
+                this.game.hutEnterPrompt = label;
+            });
+            if (this.game.activeHut && Phaser.Input.Keyboard.JustDown(this.game.keys.enter)) {
+                this.game.activeHut.enterHut();
+            }
+        }
+
         this.game.mineCartGroup.getChildren().forEach(child => {
             child.cartRef.playerOver = false;
         })
@@ -282,11 +310,15 @@ export default class ControlsManager {
         // pinning Y every frame. Letting jump/swim impulses through here
         // would just be overwritten on the next crane.update() tick.
         if (!onLift) {
-            if (this.game.keys.up.isDown) {
+            // Jump is on SPACE so the up arrow stays free for entering
+            // buildings on the surface. W still swims upward when floating
+            // so divers can rise without thumb-stretching to space.
+            const wantsUp = this.game.keys.jump.isDown || this.game.keys.up.isDown;
+            if (wantsUp) {
                 if (this.game.isFloating) {
                     this.game.player.anims.play('jump', true);
                     this.game.player.setVelocityY(-30);
-                } else if (this.game.player.body.blocked.down) {
+                } else if (this.game.keys.jump.isDown && this.game.player.body.blocked.down) {
                     this.game.player.setVelocityY(-100);
                 }
             }
@@ -296,7 +328,7 @@ export default class ControlsManager {
                     this.game.player.setVelocityY(30);
                 }
             }
-            if (this.game.isFloating && !this.game.keys.down.isDown && !this.game.keys.up.isDown) {
+            if (this.game.isFloating && !this.game.keys.down.isDown && !wantsUp) {
                 this.game.player.anims.play('jump', true);
                 this.game.player.setVelocityY(20);
             }
@@ -320,12 +352,24 @@ export default class ControlsManager {
             this.game.player.anims.play('jump', true);
         }
 
-        if (this.game.showInteractionPrompt) {
+        const hutPrompt = this.game.hutEnterPrompt;
+        if (this.game.showInteractionPrompt || hutPrompt) {
             const playerX = this.game.player.body.x - 10;
             const playerY = this.game.player.body.y - 5;
 
+            const promptLines = [];
+            if (this.game.showInteractionPrompt) {
+                promptLines.push(`E to ${this.game.interactionText || 'Interact'}`);
+            }
+            if (this.game.secondaryInteractionText) {
+                promptLines.push(`Q to ${this.game.secondaryInteractionText}`);
+            }
+            if (hutPrompt) {
+                promptLines.push(`↑ to ${hutPrompt}`);
+            }
+
             const textX = playerX;
-            const textY = playerY - (this.game.secondaryInteractionText ? 9 : 5);
+            const textY = playerY - (promptLines.length > 1 ? 4 + promptLines.length * 4 : 5);
 
             const style = {
                 font: '3px',
@@ -334,34 +378,20 @@ export default class ControlsManager {
                 padding: {left: 3, right: 3, top: 2, bottom: 1}
             };
 
-            const primary = `E to ${this.game.interactionText || 'Interact'}`;
-            const secondary = this.game.secondaryInteractionText
-                ? `\nQ to ${this.game.secondaryInteractionText}`
-                : '';
-            const promptText = primary + secondary;
+            const promptText = promptLines.join('\n');
 
             if (!this.interactionText) {
                 this.interactionText = this.game.add.text(textX, textY, promptText, style);
-                // this.interactionText.setOrigin(0.5);
             } else {
                 this.interactionText.setText(promptText);
                 this.interactionText.setPosition(textX, textY);
                 this.interactionText.setDepth(999999);
             }
-            // this.interactionText.setOrigin(0.5);
             this.interactionText.setResolution(10);
         } else {
-            if (
-
-                this
-                    .interactionText
-            ) {
-                this
-                    .interactionText
-                    .destroy();
-
-                this
-                    .interactionText = null;
+            if (this.interactionText) {
+                this.interactionText.destroy();
+                this.interactionText = null;
             }
         }
 

--- a/src/services/controls.js
+++ b/src/services/controls.js
@@ -210,9 +210,9 @@ export default class ControlsManager {
             }
         });
 
-        // Standing-at-the-door hut entry. Up arrow is the dedicated
-        // "open this door" key (jump is now SPACE) so the prompt stays
-        // legible even on a controller-style WASD layout.
+        // Standing-at-the-door hut entry. Both ↑ and W open the door
+        // (W now does double duty since jump is on SPACE) so the player
+        // can keep their hand in the WASD pocket.
         this.game.activeHut = null;
         this.game.hutEnterPrompt = null;
         if (this.game.hutGroup) {
@@ -223,7 +223,10 @@ export default class ControlsManager {
                 const label = ref.tileDetails?.isPlayerHouse ? 'Enter Home' : 'Enter Hut';
                 this.game.hutEnterPrompt = label;
             });
-            if (this.game.activeHut && Phaser.Input.Keyboard.JustDown(this.game.keys.enter)) {
+            if (this.game.activeHut && (
+                Phaser.Input.Keyboard.JustDown(this.game.keys.enter) ||
+                Phaser.Input.Keyboard.JustDown(this.game.keys.up)
+            )) {
                 this.game.activeHut.enterHut();
             }
         }

--- a/src/services/map.js
+++ b/src/services/map.js
@@ -452,6 +452,56 @@ export default class MapService {
             {dx: +30, paletteKey: 'rusted'},
         ];
 
+        // For each hut, take the door column's soil row as the reference
+        // and flatten the surrounding ±2 columns to the same row so the
+        // facade sits on a clean horizontal foundation regardless of the
+        // procedural rolling-hills offsets. Without this the hut visual
+        // floats over dips or sinks into peaks where adjacent columns
+        // differ by 1-3 rows.
+        const flattenFootprint = (centerX, doorRow) => {
+            const targetSoilTop = doorRow + 1;
+            for (let dx = -2; dx <= 2; dx++) {
+                const cx = centerX + dx;
+                if (cx < 1 || cx >= this.game.mapWidth - 1) continue;
+                // Walk down each column: rows above targetSoilTop become
+                // empty (carving away any high terrain), rows from
+                // targetSoilTop downward stay/become soil until we hit
+                // the existing soil column.
+                for (let y = 1; y < targetSoilTop; y++) {
+                    const cell = this._cellAt(cx, y);
+                    if (!cell) continue;
+                    // Preserve chasm walls + the lift-control row, which
+                    // carry strength 999999 and must not be carved.
+                    if (cell.id === tileTypes.soil.id && (cell.strength ?? 0) >= 999999) continue;
+                    if (cell.id === tileTypes.liftControl?.id) continue;
+                    this._setCell(cx, y, {...tileTypes.empty});
+                }
+                // Top soil row: ensure it's a surface-tagged soil cell so
+                // grass + breakable edges draw correctly.
+                this._setCell(cx, targetSoilTop, {
+                    ...tileTypes.soil,
+                    strength: 100,
+                    surface: true,
+                });
+                // One row below: if it's currently empty or weak, fill so
+                // there's no gap between the new top and the existing
+                // column.
+                const below = this._cellAt(cx, targetSoilTop + 1);
+                if (below && below.id !== tileTypes.soil.id) {
+                    this._setCell(cx, targetSoilTop + 1, {...tileTypes.soil, strength: 100});
+                }
+                // Surface-tag may have been left on a now-buried cell —
+                // walk down a few rows clearing stale surface flags.
+                for (let y = targetSoilTop + 1; y <= targetSoilTop + 6; y++) {
+                    const c = this._cellAt(cx, y);
+                    if (c?.surface === true) {
+                        const {surface, ...rest} = c;
+                        this._setCell(cx, y, rest);
+                    }
+                }
+            }
+        };
+
         layout.forEach((entry, idx) => {
             const baseX = entry.dx > 0 ? chasm[1] : chasm[0];
             const x = baseX + entry.dx;
@@ -460,15 +510,24 @@ export default class MapService {
             const doorRow = findDoorRow(x);
             if (doorRow == null || doorRow < 1) return;
 
-            // Carve out trees + decorations under the facade footprint so
-            // the building isn't impaled by oaks. Half-width 2 covers the
-            // 5-tile facade.
+            // Level the footprint first so the door cell's row matches
+            // the soil-top row across the whole facade.
+            flattenFootprint(x, doorRow);
+
+            // Carve out trees + leftover decorations in the door row so
+            // the building isn't impaled by oaks. Half-width 2 covers
+            // the 5-tile facade; height 4 covers the vertical extent so
+            // a tree can't poke out of the roof either.
             for (let dx = -2; dx <= 2; dx++) {
-                const cx = x + dx;
-                const cell = this._cellAt(cx, doorRow);
-                if (!cell) continue;
-                if (cell.id === tileTypes.tree?.id || cell.id === tileTypes.hut.id) {
-                    this._setCell(cx, doorRow, {...tileTypes.empty});
+                for (let dy = -3; dy <= 0; dy++) {
+                    const cx = x + dx;
+                    const cy = doorRow + dy;
+                    if (cy < 1) continue;
+                    const cell = this._cellAt(cx, cy);
+                    if (!cell) continue;
+                    if (cell.id === tileTypes.tree?.id) {
+                        this._setCell(cx, cy, {...tileTypes.empty});
+                    }
                 }
             }
 

--- a/src/services/map.js
+++ b/src/services/map.js
@@ -1,5 +1,5 @@
 import * as ROT from "rot-js";
-import {Breakable, Light, Empty, Liquid, Buttress, Rail, LiftControl, Tree} from "../classes/tiles";
+import {Breakable, Light, Empty, Liquid, Buttress, Rail, LiftControl, Tree, Hut} from "../classes/tiles";
 import TilePool from "../classes/TilePool";
 import TileTextureAtlas from "./tileTextureAtlas";
 
@@ -132,6 +132,7 @@ export default class MapService {
         this.buttressPool = new TilePool((params) => new Buttress(params));
         this.railPool = new TilePool((params) => new Rail(params));
         this.treePool = new TilePool((params) => new Tree(params));
+        this.hutPool = new TilePool((params) => new Hut(params));
     }
 
     getLayer(y) {
@@ -217,6 +218,11 @@ export default class MapService {
         // Trees follow the post-variation surface row per column and cluster
         // into single-breed groves with occasional mixed neighbours.
         this.placeSurfaceTrees();
+
+        // A small ghost town spans the surface either side of the chasm,
+        // with one hut flagged as the player's home. Placed AFTER trees so
+        // we can clear nearby trunks that would clip into the facades.
+        this.placeGhostTown();
 
         // worldX, worldY, tileType, cellItem
         // Update region: every cell in columns 40 through 48 gets updated to a new tile type.
@@ -402,6 +408,124 @@ export default class MapService {
                 groveLength = 0;
             }
         }
+    }
+
+    /**
+     * Drop a row of huts onto the surface around the spawn point. The
+     * westernmost (closest to the chasm on the right side) is the
+     * player's home; the rest are weather-beaten ghost-town facades.
+     * Each hut occupies a single cell — its `door cell` — and the Hut
+     * tile renders a multi-tile facade around it for the player to walk
+     * past. Trees that would clip the facade get cleared in a small
+     * clearance window so saplings don't poke out of roofs.
+     */
+    placeGhostTown() {
+        const tileTypes = this.game.tileTypes;
+        if (!tileTypes?.hut) return;
+        const chasm = this.game.chasmRange;
+        const maxScan = this.game.aboveGround + (this.game.maxSurfaceDrop || 0) + 6;
+
+        const findDoorRow = (x) => {
+            for (let y = 1; y <= maxScan; y++) {
+                const cell = this._cellAt(x, y);
+                if (!cell) continue;
+                if (cell.id !== tileTypes.soil.id) continue;
+                return y - 1;
+            }
+            return null;
+        };
+
+        // Anchored relative to the chasm so the player spawns next door
+        // to their home regardless of map width changes. Spread out enough
+        // (8 tiles between doors) that the 5-tile-wide facades don't
+        // overlap or look wallpapered together. The spawn point sits on
+        // the left chasm wall (walking right plunges into the shaft) so
+        // the player house lives on the LEFT side, immediately reachable.
+        const layout = [
+            {dx: -6,  isPlayer: true, paletteKey: 'homestead'},
+            {dx: -14, paletteKey: 'cozy'},
+            {dx: -22, paletteKey: 'dusty'},
+            {dx: -30, paletteKey: 'mossy'},
+            {dx: +6,  paletteKey: 'rusted'},
+            {dx: +14, paletteKey: 'dusty'},
+            {dx: +22, paletteKey: 'mossy'},
+            {dx: +30, paletteKey: 'rusted'},
+        ];
+
+        layout.forEach((entry, idx) => {
+            const baseX = entry.dx > 0 ? chasm[1] : chasm[0];
+            const x = baseX + entry.dx;
+            if (x < 4 || x > this.game.mapWidth - 4) return;
+
+            const doorRow = findDoorRow(x);
+            if (doorRow == null || doorRow < 1) return;
+
+            // Carve out trees + decorations under the facade footprint so
+            // the building isn't impaled by oaks. Half-width 2 covers the
+            // 5-tile facade.
+            for (let dx = -2; dx <= 2; dx++) {
+                const cx = x + dx;
+                const cell = this._cellAt(cx, doorRow);
+                if (!cell) continue;
+                if (cell.id === tileTypes.tree?.id || cell.id === tileTypes.hut.id) {
+                    this._setCell(cx, doorRow, {...tileTypes.empty});
+                }
+            }
+
+            // The player house defaults its decor to a comfortable starter
+            // set; ghost huts get a fixed dusty interior we don't surface
+            // an editor for.
+            const decor = entry.isPlayer
+                ? {
+                    wallpaper: 'cream',
+                    floor: 'oak',
+                    bed: 'quilt',
+                    rug: 'rag',
+                }
+                : null;
+
+            this._setCell(x, doorRow, {
+                ...tileTypes.hut,
+                hutId: `hut_${idx}`,
+                isPlayerHouse: !!entry.isPlayer,
+                paletteKey: entry.paletteKey || (entry.isPlayer ? 'homestead' : 'dusty'),
+                decor,
+            });
+        });
+    }
+
+    /**
+     * Idempotent ghost-town injection. New worlds already get the town
+     * placed by generateMap; existing saves call this on load so the
+     * surface picks up the new buildings without forcing a fresh start.
+     * Runs the placement pass only when no hut tile is found in the
+     * spawn band — the per-cell layout is otherwise authoritative.
+     */
+    ensureGhostTown() {
+        const hutId = this.game.tileTypes?.hut?.id;
+        if (hutId == null || !this.game.grid) return;
+        const chasm = this.game.chasmRange;
+        const cs = this.game.chunkSize;
+        const scanColumns = [
+            chasm[0] - 30, chasm[0] - 22, chasm[0] - 14, chasm[0] - 6,
+            chasm[1] + 6, chasm[1] + 14, chasm[1] + 22, chasm[1] + 30,
+        ];
+        const maxScan = this.game.aboveGround + (this.game.maxSurfaceDrop || 0) + 6;
+        for (const x of scanColumns) {
+            if (x < 0 || x >= this.game.mapWidth) continue;
+            for (let y = 0; y <= maxScan; y++) {
+                const cell = this._cellAt(x, y);
+                if (cell?.id === hutId) return; // already populated
+            }
+        }
+        // Surface offsets are only set during generateMap. Stub them for
+        // legacy grids so findDoorRow doesn't read undefined.
+        if (!this.game.surfaceOffsets) {
+            this.game.surfaceOffsets = new Array(this.game.mapWidth).fill(0);
+        }
+        if (this.game.maxSurfaceDrop == null) this.game.maxSurfaceDrop = 4;
+        if (this.game.maxSurfaceLift == null) this.game.maxSurfaceLift = 5;
+        this.placeGhostTown();
     }
 
     ensureSurfaceLiftControls() {
@@ -822,6 +946,9 @@ export default class MapService {
         }
         if (tileType.id === this.game.tileTypes.tree.id) {
             newTile = this.treePool.acquire(params);
+        }
+        if (tileType.id === this.game.tileTypes.hut.id) {
+            newTile = this.hutPool.acquire(params);
         }
         if (newTile?.sprite && cellDetails) {
             this._registerSpriteAt(cellDetails.chunkKey, cellDetails.cellY, cellDetails.cellX, newTile.sprite);


### PR DESCRIPTION
## Summary
Introduces a fully playable house interior scene with a customizable decor system. Players can now enter their home from the surface world, interact with furniture, sleep to restore health/energy, and personalize the interior with different wallpapers, floors, beds, and rugs.

## Key Changes

- **New HouseScene** (`src/scenes/HouseScene.js`): Complete interior rendering and interaction system
  - Responsive room layout that maintains 16:9 aspect ratio regardless of window size
  - Furniture interactions: door (exit), bed (sleep/restore), kitchen (placeholder), TV (placeholder)
  - Dynamic decor system with real-time preview and persistence
  - Floating interaction prompts and toast notifications
  - Player movement constrained to room bounds with shadow and head sprite

- **Hut tile class** (`src/classes/hut.js`): New world tile type for buildings
  - Procedurally generated facade textures with 5 distinct palettes (cozy, dusty, rusted, mossy, homestead)
  - Multi-tile visual facade (5×4 tiles) anchored to a single door cell
  - Window glow effect for player's home; abandoned appearance for ghost-town huts
  - Nameplate display above player's home
  - Interaction to launch HouseScene with proper state handoff

- **Ghost town placement** (`src/services/map.js`): Procedural village generation
  - 8 huts placed symmetrically around spawn point relative to chasm
  - Automatic tree clearing under facade footprints to prevent clipping
  - One hut flagged as player's home with customizable decor persistence
  - Idempotent placement for existing saves via `ensureGhostTown()`

- **Decor system** (`src/scenes/HouseScene.js`):
  - 4 decor categories: wallpaper (5 options), floor (5 options), bed (4 options), rug (4 options)
  - Each option defines color palette for procedural rendering
  - Player house decor persists to world tile; ghost huts use immutable defaults
  - Interactive panel with real-time preview of changes

- **Control updates** (`src/services/controls.js`):
  - Jump remapped to SPACE (was UP arrow)
  - UP arrow now dedicated to entering buildings at doors
  - Hut overlap detection with prompt display
  - Scene pause/resume handling to prevent stale callbacks while inside house

- **Scene integration** (`src/scenes/GameScene.js`, `src/main.js`):
  - New hut tile type (id: 9) registered in tile system
  - HouseScene added to scene config
  - Hut group created for physics overlap detection

## Notable Implementation Details

- Room interior uses fixed-aspect frame with responsive scaling to keep furniture proportions readable
- Wallpaper and floor patterns drawn via Graphics objects for efficient re-rendering on decor changes
- Decor panel is DOM-based (not canvas) for native form controls and accessibility
- Player house decor stored directly on world tile's `tileDetails` for save persistence
- Facade textures generated once per palette and cached to avoid recreation
- Scene pause (not stop) preserves GameScene physics state while HouseScene runs on top

https://claude.ai/code/session_01DaXdn5DVKvq5WiA5p1NgUV