### PR TITLE
Add drilling, ore progression, and tiered shelter system

### DIFF
--- a/src/classes/breakable.js
+++ b/src/classes/breakable.js
@@ -365,12 +365,17 @@ export class Breakable extends Tile {
                     this.game.dustEmitter.explode(50);
                     baseCell = this.tileDetails.trapped || {...this.game.tileTypes.empty};
                     this.clicking = false;
-                    // Coal veins also drop a unit straight to the player's
-                    // inventory so crafting at the lift doesn't require a
-                    // minecart pickup. The minecart catch path still works
-                    // for the visible debris that scatters from the break.
+                    // Coal/copper/iron veins drop a unit straight to the
+                    // player's inventory so crafting at the lift doesn't
+                    // require a minecart pickup. The minecart catch path
+                    // still works for the visible debris that scatters from
+                    // the break.
                     if (this.tileDetails.type === 1) {
                         this.game.inventoryManager?.addCoal?.(1);
+                    } else if (this.tileDetails.type === 4) {
+                        this.game.inventoryManager?.addCopper?.(1);
+                    } else if (this.tileDetails.type === 5) {
+                        this.game.inventoryManager?.addIron?.(1);
                     }
                     this.game.mapService.setTile(this.worldX, this.worldY, baseCell, this.sprite);
                 } else {

--- a/src/classes/breakable.js
+++ b/src/classes/breakable.js
@@ -3,6 +3,9 @@ import {darkenColor} from "../services/colourManager";
 
 const hexStringToInt = (str) => parseInt(str.replace(/^0x/, ''), 16);
 
+// Pickaxe tier → mining hitPower multiplier. Worn → Copper → Iron.
+const PICKAXE_TIER_MULT = [1, 1.6, 2.5];
+
 export class Breakable extends Tile {
     constructor({game, worldX, worldY, tileDetails, cellDetails}) {
         super({game, worldX, worldY, tileDetails, cellDetails});
@@ -344,7 +347,14 @@ export class Breakable extends Tile {
                 if (this.clicking) return;
                 this.clicking = true;
                 this.game.player.energy -= 1;
-                const hitPower = this.game.player.hitPower;
+                // Pickaxe tier (forged at the cabin Forge) multiplies the
+                // raw hitPower so harder veins crack proportionally faster.
+                // Tiers come from the toolbar item's metadata.toolTier and
+                // map: 0 = worn (×1), 1 = copper (×1.6), 2 = iron (×2.5).
+                const tierMult = PICKAXE_TIER_MULT[
+                    this.game.selectedTool?.metadata?.toolTier | 0
+                ] || 1;
+                const hitPower = this.game.player.hitPower * tierMult;
                 let baseCell, damageAmount = this.tileDetails.damageAmount || 0;
                 damageAmount += hitPower;
                 let health = -(damageAmount / this.tileDetails.strength - 1);

--- a/src/classes/minecart.js
+++ b/src/classes/minecart.js
@@ -107,6 +107,8 @@ export class MineCart {
         const handlers = {
             coal: (n) => im.addCoal(n),
             wood: (n) => im.addWood(n),
+            copper: (n) => im.addCopper(n),
+            iron: (n) => im.addIron(n),
         };
         Object.entries(this.inventory).forEach(([key, count]) => {
             if (count > 0 && handlers[key]) handlers[key](count);

--- a/src/classes/tree.js
+++ b/src/classes/tree.js
@@ -139,7 +139,12 @@ export class Tree extends Tile {
 
             const matDef = this.maturityDef();
             const maxHealth = matDef.hitsToFell;
-            const newHealth = (this.tileDetails.health ?? maxHealth) - 1;
+            // Axe tier 0/1/2 (worn / copper / iron) chops 1/2/3 health per
+            // swing — copper and iron axes earn their forge cost by felling
+            // even ancient trunks in a handful of hits.
+            const tier = this.game.selectedTool?.metadata?.toolTier | 0;
+            const chop = [1, 2, 3][Math.max(0, Math.min(2, tier))] || 1;
+            const newHealth = (this.tileDetails.health ?? maxHealth) - chop;
 
             // Wobble feedback toward the swing side.
             if (this.treeSprite) {

--- a/src/main.js
+++ b/src/main.js
@@ -35,6 +35,10 @@ const config = {
 };
 
 const game = new Phaser.Game(config);
+// Exposed for in-browser debugging + headless smoke tests so the running
+// scenes / managers can be poked from the dev console without rooting
+// through Phaser internals.
+window.game = game;
 
 window.addEventListener("resize", () => {
     game.scale.resize(window.innerWidth, window.innerHeight);

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -45,6 +45,15 @@ export default class GameScene extends Phaser.Scene {
             },
             2: {
                 image: 'wood'
+            },
+            3: {
+                image: 'bedrock'
+            },
+            4: {
+                image: 'copper'
+            },
+            5: {
+                image: 'iron'
             }
         }
         this.railTypes = {
@@ -73,6 +82,28 @@ export default class GameScene extends Phaser.Scene {
                 strength: 1000,
                 weight: 100,
                 type: 1
+            },
+            // Layer-cap bedrock that fills the chasm interior at each band
+            // boundary. Unbreakable by pickaxe (strength 999999 short-circuits
+            // the damage maths in Breakable.onClick) — only the platform-
+            // mounted drill can clear it.
+            bedrock: {
+                id: 1,
+                strength: 999999,
+                type: 3,
+                cap: true
+            },
+            copper: {
+                id: 1,
+                strength: 1500,
+                weight: 100,
+                type: 4
+            },
+            iron: {
+                id: 1,
+                strength: 2500,
+                weight: 100,
+                type: 5
             },
             liquid: {
                 id: 2
@@ -108,8 +139,36 @@ export default class GameScene extends Phaser.Scene {
                 widthRange: [2, 3],
                 heightRange: [2, 3],
                 count: 1000,
-                layerWeights: [1, 0, 0, 0, 0, 0, 0],
+                // Coal stays useful below the surface band so the player can
+                // keep refuelling the drill on the way down even after they've
+                // unlocked copper.
+                layerWeights: [2, 1, 1, 0, 0, 0, 0],
                 columnWeights: [0, 1, 0, 0, 0, 1, 0]
+            },
+            // Copper veins seed layers 2-3 — discovered on the first drill
+            // descent, used for the Copper Drill Bit and the Tier-2 platform
+            // upgrade.
+            {
+                tile: {
+                    ...this.tileTypes.copper
+                },
+                widthRange: [2, 3],
+                heightRange: [2, 3],
+                count: 700,
+                layerWeights: [0, 1, 1, 0, 0, 0, 0],
+                columnWeights: [0, 1, 0, 0, 1, 0, 0]
+            },
+            // Iron deeper still — layer 4-5. Required for the Iron Drill Bit
+            // that cracks the deepest caps.
+            {
+                tile: {
+                    ...this.tileTypes.iron
+                },
+                widthRange: [2, 3],
+                heightRange: [2, 3],
+                count: 600,
+                layerWeights: [0, 0, 0, 1, 1, 0, 0],
+                columnWeights: [0, 0, 1, 0, 0, 1, 0]
             },
             {
                 tile: {
@@ -248,6 +307,9 @@ export default class GameScene extends Phaser.Scene {
         // Same idempotent pattern — drop the ghost town onto the surface
         // for existing saves that pre-date the feature.
         this.mapService.ensureGhostTown();
+        // Backfill bedrock layer caps onto pre-existing saves so the
+        // drill-down progression applies to in-progress runs too.
+        this.mapService.ensureLayerCaps();
 
         window.setTimeout(async () => {
             // Parallax backdrop sits underneath the world, behind every

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -216,8 +216,8 @@ export default class GameScene extends Phaser.Scene {
         this.toolBarManager = new ToolbarManager(this);
         this.inventoryManager = new InventoryManager(this);
 
-        const pickaxe = new InventoryItem('pickaxe', null, 'Iron Pickaxe', 'tool', 'images/pickaxe.png', {interactsWith: [this.tileTypes.soil]});
-        const axe = new InventoryItem('axe', null, 'Iron Axe', 'tool', this.textures.exists('axe') ? this.textures.get('axe').getSourceImage().toDataURL() : 'images/pickaxe.png', {interactsWith: [this.tileTypes.tree]});
+        const pickaxe = new InventoryItem('pickaxe', null, 'Worn Pickaxe', 'tool', 'images/pickaxe.png', {interactsWith: [this.tileTypes.soil], toolTier: 0});
+        const axe = new InventoryItem('axe', null, 'Worn Axe', 'tool', this.textures.exists('axe') ? this.textures.get('axe').getSourceImage().toDataURL() : 'images/pickaxe.png', {interactsWith: [this.tileTypes.tree], toolTier: 0});
         const glowStick = new InventoryItem('glowstick', null, 'Glow-stick', 'tool', 'images/glow-stick.png', {
             throwable: true,
             number: 100,

--- a/src/scenes/HouseScene.js
+++ b/src/scenes/HouseScene.js
@@ -70,10 +70,22 @@ function resolveDecor(group, key) {
 // outdoors. Keeping the logical size tight makes the room feel like a
 // hut interior rather than a warehouse, and lets us snap furniture
 // positions to whole pixels.
+//
+// Cabin dimensions are the original full-size layout. Lower tiers
+// override them in init() so the tent/raft visuals can sit on a
+// smaller logical canvas the camera then zooms tighter on — entering
+// a tent should feel like ducking into a tent, not a cabin with
+// fewer sprites.
 const ROOM_W = 200;
 const ROOM_H = 130;
 const FLOOR_Y = 110;    // top of floor line
 const WALL_TOP_Y = 24;  // top of wallpapered band
+
+const TIER_LAYOUT = {
+    0: {w: 110, h: 80, floorY: 64, wallTopY: 14, minX: 24, maxX: 86, exitX: 32},
+    1: {w: 150, h: 100, floorY: 84, wallTopY: 18, minX: 32, maxX: 118, exitX: 38},
+    2: {w: ROOM_W, h: ROOM_H, floorY: FLOOR_Y, wallTopY: WALL_TOP_Y, minX: 10, maxX: ROOM_W - 10, exitX: 22},
+};
 
 export default class HouseScene extends Phaser.Scene {
     constructor() {
@@ -95,6 +107,19 @@ export default class HouseScene extends Phaser.Scene {
         // 1 = pitched tent, 2 = full cabin. World-placed huts (ghost town)
         // pre-date the tier system and stay at the legacy "full" interior.
         this.homeTier = this.hut.isPlayerHouse ? (this.hut.homeTier ?? 2) : 2;
+        // Pull tier-specific canvas dimensions onto the scene so every
+        // render method works in the same coordinate space — the cabin
+        // keeps its 200×130 layout, the tent shrinks to 150×100, the
+        // bedroll camp shrinks further still so the camera zoom packs
+        // the whole tent into the viewport.
+        const layout = TIER_LAYOUT[this.homeTier] || TIER_LAYOUT[2];
+        this.roomW = layout.w;
+        this.roomH = layout.h;
+        this.floorY = layout.floorY;
+        this.wallTopY = layout.wallTopY;
+        this.playerMinX = layout.minX;
+        this.playerMaxX = layout.maxX;
+        this.exitX = layout.exitX;
         // Snapshot the persisted decor (if any) before mutating any fields.
         // Player house: hut.decor lives on the world tile so changes
         // survive reloads; ghost huts ignore decor entirely.
@@ -108,12 +133,12 @@ export default class HouseScene extends Phaser.Scene {
         // feels close to the player rather than a vast empty hall.
         this.cameras.main.setBackgroundColor(0x0a0806);
         const targetZoom = Math.max(3, Math.floor(Math.min(
-            this.cameras.main.width / ROOM_W,
-            this.cameras.main.height / ROOM_H
+            this.cameras.main.width / this.roomW,
+            this.cameras.main.height / this.roomH
         )));
         this.cameras.main.setZoom(targetZoom);
         // Centre the room logical origin (0,0) in screen space.
-        this.cameras.main.centerOn(ROOM_W / 2, ROOM_H / 2);
+        this.cameras.main.centerOn(this.roomW / 2, this.roomH / 2);
         this.cameras.main.fadeIn(220, 0, 0, 0);
 
         // Hide the world-scene DOM overlays (light canvas, minimap,
@@ -187,6 +212,18 @@ export default class HouseScene extends Phaser.Scene {
     // ---------- Room layers ----------------------------------------------
 
     buildInterior() {
+        // Player house at tiers 0/1 doesn't have walls/wallpaper — the
+        // shelter is a bedroll or a tent, drawn as its own composition
+        // instead of the cabin's layered painted-wall look.
+        if (this.hut.isPlayerHouse && this.homeTier === 0) {
+            this.buildBedrollInterior();
+            return;
+        }
+        if (this.hut.isPlayerHouse && this.homeTier === 1) {
+            this.buildTentInterior();
+            return;
+        }
+
         const palette = HUT_PALETTES[this.hut.paletteKey] || HUT_PALETTES.dusty;
         const wallpaper = this.hut.isPlayerHouse
             ? resolveDecor('wallpaper', this.decor.wallpaper)
@@ -401,6 +438,11 @@ export default class HouseScene extends Phaser.Scene {
     // ---------- Furniture ------------------------------------------------
 
     buildHomeFurniture() {
+        // Tier 0 / 1 swap the cabin's full furniture layout for a much
+        // smaller compositions that match the bedroll / tent visuals.
+        if (this.homeTier === 0) return this.buildBedrollFurniture();
+        if (this.homeTier === 1) return this.buildTentFurniture();
+
         const W = ROOM_W;
         this.furniture = [];
         const tier = this.homeTier;
@@ -518,6 +560,175 @@ export default class HouseScene extends Phaser.Scene {
         }
     }
 
+    // -------- Tier-0 bedroll camp ---------------------------------------
+
+    /**
+     * Bedroll camp interior — the player has no shelter yet, just a
+     * bedroll on a wooden platform under the open sky. Tiny scene, no
+     * walls, just enough room for the bedroll + a tin lantern.
+     *
+     * Layout sits inside the smaller logical canvas (110×80) configured
+     * in init() so the camera zoom packs the whole composition into the
+     * viewport — entering reads as crouching down beside a tarp rather
+     * than walking into a cabin.
+     */
+    buildBedrollInterior() {
+        const W = this.roomW, H = this.roomH;
+        const floorY = this.floorY;
+        // Night sky background — deep navy with a few stars so the player
+        // feels exposed, not just looking at a dark void.
+        this.add.rectangle(W / 2, floorY / 2, W, floorY, 0x0a0e1a).setDepth(0);
+        const stars = this.add.graphics().setDepth(0.5);
+        stars.fillStyle(0xffffff, 0.7);
+        const starPositions = [[18, 12], [42, 8], [66, 18], [86, 10], [102, 22], [30, 28], [78, 32], [56, 6]];
+        for (const [sx, sy] of starPositions) stars.fillRect(sx, sy, 1, 1);
+        // Faint horizon glow on the right (suggesting dusk / the chasm).
+        const glow = this.add.rectangle(W - 12, floorY - 8, 28, 14, 0xff8a3a, 0.18).setDepth(0.6);
+        glow.setBlendMode(Phaser.BlendModes.ADD);
+
+        // Wooden platform deck — the visible top of the lift's deck. Plank
+        // seams give it texture.
+        this.add.rectangle(W / 2, (floorY + H) / 2, W, H - floorY, 0x7a5230).setDepth(1);
+        this.add.rectangle(W / 2, floorY, W, 1, 0xa8804e).setDepth(1.1);
+        this.add.rectangle(W / 2, H - 1, W, 1, 0x3c2412).setDepth(1.1);
+        const planks = this.add.graphics().setDepth(1.2);
+        planks.fillStyle(0x3c2412, 0.85);
+        for (let x = 0; x < W; x += 14) planks.fillRect(x, floorY, 1, H - floorY);
+        // Metal end-caps to evoke the lift deck's bolted look.
+        this.add.rectangle(2, floorY + (H - floorY) / 2, 3, H - floorY, 0x3a4248).setDepth(1.3);
+        this.add.rectangle(W - 2, floorY + (H - floorY) / 2, 3, H - floorY, 0x3a4248).setDepth(1.3);
+    }
+
+    buildBedrollFurniture() {
+        this.furniture = [];
+        const W = this.roomW;
+        const floorY = this.floorY;
+
+        // Exit hotspot — there's no door here, just a "step off the
+        // platform" prompt at the left edge. The player walks toward it
+        // and presses W/↑ to leave.
+        const exitX = this.exitX;
+        this.furniture.push({
+            kind: 'door', x: exitX, y: floorY - 5, range: 10,
+            label: 'Leave', interact: () => this.exitHouse(),
+        });
+
+        // Bedroll — centred. Drawn by hand so it sits on the deck rather
+        // than floating in a generic furniture position.
+        const bedX = Math.floor(W / 2) + 4, bedY = floorY - 2;
+        this.add.rectangle(bedX, bedY + 1, 28, 4, 0x5a3a22).setDepth(3);   // mat
+        this.add.rectangle(bedX, bedY, 28, 1, 0x7a4a28).setDepth(3.05);     // mat highlight
+        this.add.rectangle(bedX + 2, bedY - 1, 22, 4, 0xa8443a).setDepth(3.1); // blanket
+        this.add.rectangle(bedX + 2, bedY - 2, 22, 1, 0xc46044).setDepth(3.15);
+        this.add.rectangle(bedX - 8, bedY - 3, 5, 2, 0xf4e7c6).setDepth(3.2); // pillow
+        this.furniture.push({
+            kind: 'bed', x: bedX, y: bedY, range: 14,
+            label: 'Doze (light rest)', interact: () => this.sleepInBed(),
+        });
+
+        // Tin lantern beside the bedroll — warm glow against the night sky.
+        const lampX = bedX - 18, lampY = floorY - 4;
+        this.add.rectangle(lampX, lampY + 2, 4, 4, 0x3a3a3a).setDepth(3);
+        this.add.rectangle(lampX, lampY, 5, 2, 0x6a6a6a).setDepth(3.1);
+        this.add.rectangle(lampX, lampY, 3, 3, 0xff9a3a, 0.95).setDepth(3.2).setBlendMode(Phaser.BlendModes.ADD);
+        this.add.circle(lampX, lampY, 9, 0xffd27a, 0.18).setDepth(3.15).setBlendMode(Phaser.BlendModes.ADD);
+    }
+
+    // -------- Tier-1 tent -----------------------------------------------
+
+    /**
+     * Tent interior — a single small canvas tent on a tarp floor. The
+     * sloped tent walls are drawn directly into the scene (no atlas) so
+     * the shape can taper from a peak to the floor without piecing tile
+     * sprites together. There's just enough room inside for a cot and a
+     * lantern — anything bigger needs the cabin upgrade.
+     */
+    buildTentInterior() {
+        const W = this.roomW, H = this.roomH;
+        const floorY = this.floorY;
+
+        // Dark outside-the-tent ground (sky-line above peak is also dark,
+        // makes the canvas read as illuminated from within).
+        this.add.rectangle(W / 2, H / 2, W, H, 0x05080c).setDepth(0);
+
+        // Tarp floor — a wider patch than the tent footprint so the tent
+        // walls sit on something.
+        const tarpX0 = 22, tarpX1 = W - 22;
+        const tarpW = tarpX1 - tarpX0;
+        this.add.rectangle((tarpX0 + tarpX1) / 2, (floorY + H) / 2, tarpW, H - floorY, 0x3a2a18).setDepth(1);
+        this.add.rectangle((tarpX0 + tarpX1) / 2, floorY, tarpW, 1, 0x5a4232).setDepth(1.1);
+
+        // Tent silhouette — a filled triangle from peak to two ground
+        // corners. Phaser.Polygon makes the shape; we then trace the
+        // outline with a slightly darker edge so it doesn't blur into
+        // the background.
+        const peakX = W / 2, peakY = this.wallTopY;
+        const baseLeft = {x: 28, y: floorY};
+        const baseRight = {x: W - 28, y: floorY};
+        const tent = this.add.polygon(0, 0, [peakX, peakY, baseRight.x, baseRight.y, baseLeft.x, baseLeft.y], 0xb89a5e);
+        tent.setOrigin(0, 0);
+        tent.setDepth(1.5);
+        // Right slope shading for a hint of dimensionality.
+        const shade = this.add.polygon(0, 0, [peakX, peakY, baseRight.x, baseRight.y, peakX, baseRight.y], 0x7a5a28, 0.45);
+        shade.setOrigin(0, 0);
+        shade.setDepth(1.6);
+        // Ridge pole running down the centre seam.
+        this.add.rectangle(peakX, (peakY + floorY) / 2, 1, floorY - peakY, 0x3a2a10).setDepth(1.7);
+
+        // Tent flap doorway — a darker rectangle at the front-left where
+        // the door collider sits, so the exit prompt has visible context.
+        const flapX = this.exitX, flapTop = floorY - 22;
+        this.add.rectangle(flapX, (flapTop + floorY) / 2, 11, floorY - flapTop, 0x3a2a18).setDepth(2);
+        this.add.rectangle(flapX - 5, (flapTop + floorY) / 2, 1, floorY - flapTop, 0x5a4222).setDepth(2.1);
+        this.add.rectangle(flapX + 5, (flapTop + floorY) / 2, 1, floorY - flapTop, 0x5a4222).setDepth(2.1);
+        // Triangular flap pulled aside, hint of the chasm beyond.
+        this.add.polygon(0, 0,
+            [flapX - 5, flapTop, flapX, flapTop + 6, flapX - 5, floorY],
+            0x1a0e06).setOrigin(0, 0).setDepth(2.2);
+
+        // Hanging lantern at the apex — small bulb of warm light keeps the
+        // interior from reading as a single brown wedge.
+        const lampX = peakX + 18, lampY = peakY + 18;
+        this.add.rectangle(lampX, peakY + 4, 1, lampY - peakY - 4, 0x2a1808).setDepth(2.5); // chain
+        this.add.rectangle(lampX, lampY, 4, 4, 0x2a1808).setDepth(2.6);
+        this.add.rectangle(lampX, lampY, 3, 3, 0xffd27a, 1).setDepth(2.7).setBlendMode(Phaser.BlendModes.ADD);
+        this.add.circle(lampX, lampY, 16, 0xffd27a, 0.18).setDepth(2.65).setBlendMode(Phaser.BlendModes.ADD);
+    }
+
+    buildTentFurniture() {
+        this.furniture = [];
+        const W = this.roomW;
+        const floorY = this.floorY;
+
+        // Exit — through the tent flap on the left.
+        const exitX = this.exitX;
+        this.furniture.push({
+            kind: 'door', x: exitX, y: floorY - 8, range: 12,
+            label: 'Leave', interact: () => this.exitHouse(),
+        });
+
+        // Cot — a low frame with a thin mattress + pillow. Sits a little
+        // right of centre so the lantern's pool of light frames it.
+        const bedX = Math.floor(W / 2) + 8, bedY = floorY - 5;
+        this.add.rectangle(bedX, bedY + 1, 30, 4, 0x4a3220).setDepth(3);     // frame
+        this.add.rectangle(bedX, bedY - 2, 28, 4, 0x9a7a5a).setDepth(3.1);   // mattress
+        this.add.rectangle(bedX, bedY - 3, 28, 1, 0xb89a7a).setDepth(3.15);
+        this.add.rectangle(bedX - 11, bedY - 4, 5, 2, 0xe7d8b8).setDepth(3.2); // pillow
+        this.add.rectangle(bedX - 14, bedY + 4, 1, 4, 0x2a1808).setDepth(2.9); // legs
+        this.add.rectangle(bedX + 14, bedY + 4, 1, 4, 0x2a1808).setDepth(2.9);
+        this.furniture.push({
+            kind: 'bed', x: bedX, y: bedY, range: 14,
+            label: 'Sleep', interact: () => this.sleepInBed(),
+        });
+
+        // A small rolled bedroll / kit bundle in the back-right corner —
+        // visual flavour to hint at "you're roughing it out here".
+        const kitX = W - 36, kitY = floorY - 2;
+        this.add.rectangle(kitX, kitY, 8, 4, 0x5a3a22).setDepth(3);
+        this.add.rectangle(kitX, kitY - 1, 8, 1, 0x7a4a28).setDepth(3.1);
+        this.add.rectangle(kitX, kitY, 1, 4, 0x3a1808).setDepth(3.15);
+    }
+
     buildAbandonedFurniture() {
         this.furniture = [];
 
@@ -588,9 +799,11 @@ export default class HouseScene extends Phaser.Scene {
         // Spawn just inside the room — past the door's interaction range
         // so the leave-prompt doesn't immediately appear the instant the
         // player walks in (otherwise the very first input "leave" would
-        // bounce them straight back outside).
-        const startX = 44;
-        const startY = FLOOR_Y - 7;
+        // bounce them straight back outside). Offset relative to the
+        // tier's exit position so even the cramped tent doesn't dump the
+        // player on top of the flap.
+        const startX = Math.min(this.exitX + 22, this.roomW - 12);
+        const startY = this.floorY - 7;
         this.player = this.physics.add.sprite(startX, startY, 'player_stationary');
         this.player.setDisplaySize(7, 10);
         this.player.setDepth(4);
@@ -602,7 +815,7 @@ export default class HouseScene extends Phaser.Scene {
         this.playerHead.setDisplaySize(7, 7);
         this.playerHead.setDepth(4.1);
 
-        this.shadow = this.add.ellipse(startX, FLOOR_Y, 8, 2, 0x000000, 0.45).setDepth(3.5);
+        this.shadow = this.add.ellipse(startX, this.floorY, 8, 2, 0x000000, 0.45).setDepth(3.5);
     }
 
     buildPrompts() {
@@ -618,7 +831,7 @@ export default class HouseScene extends Phaser.Scene {
         if (!this.hut.isPlayerHouse) title = 'ABANDONED HUT';
         else if (this.homeTier === 0) title = 'BEDROLL CAMP';
         else if (this.homeTier === 1) title = 'TENT';
-        this.title = this.add.text(ROOM_W / 2, 6,
+        this.title = this.add.text(this.roomW / 2, 6,
             title, {
                 font: '7px monospace',
                 color: this.hut.isPlayerHouse ? '#fff1c4' : '#a89888',
@@ -633,10 +846,10 @@ export default class HouseScene extends Phaser.Scene {
         // gradients on the edges of the logical room.
         const v = this.add.graphics().setDepth(60);
         v.fillStyle(0x000000, 0.35);
-        v.fillRect(0, 0, ROOM_W, 4);
-        v.fillRect(0, ROOM_H - 4, ROOM_W, 4);
-        v.fillRect(0, 0, 4, ROOM_H);
-        v.fillRect(ROOM_W - 4, 0, 4, ROOM_H);
+        v.fillRect(0, 0, this.roomW, 4);
+        v.fillRect(0, this.roomH - 4, this.roomW, 4);
+        v.fillRect(0, 0, 4, this.roomH);
+        v.fillRect(this.roomW - 4, 0, 4, this.roomH);
     }
 
     // ---------- HUD buttons ---------------------------------------------
@@ -710,11 +923,12 @@ export default class HouseScene extends Phaser.Scene {
             if (this.anims.exists('stationary')) this.player.play('stationary', true);
         }
 
-        // Keep the player inside the walls
-        const minX = 10, maxX = ROOM_W - 10;
-        if (this.player.x < minX) this.player.x = minX;
-        if (this.player.x > maxX) this.player.x = maxX;
-        this.player.y = FLOOR_Y - 7;
+        // Keep the player inside the walls (tier-specific clamp — the
+        // tent's much narrower than the cabin, so the cabin's defaults
+        // would let the player walk straight through the canvas walls).
+        if (this.player.x < this.playerMinX) this.player.x = this.playerMinX;
+        if (this.player.x > this.playerMaxX) this.player.x = this.playerMaxX;
+        this.player.y = this.floorY - 7;
 
         this.playerHead.x = this.player.x;
         this.playerHead.y = this.player.y - 1.5;
@@ -776,7 +990,7 @@ export default class HouseScene extends Phaser.Scene {
         const player = this.gameScene?.player;
         if (!player) return;
         const overlay = this.add.rectangle(
-            ROOM_W / 2, ROOM_H / 2, ROOM_W, ROOM_H, 0x000000, 0
+            this.roomW / 2, this.roomH / 2, this.roomW, this.roomH, 0x000000, 0
         ).setDepth(80);
         this.prompt.setVisible(false);
         // Restoration scales with the rig tier so the upgrade ladder pays
@@ -1018,7 +1232,7 @@ export default class HouseScene extends Phaser.Scene {
 
     flashToast(text) {
         if (this._toast) this._toast.destroy();
-        this._toast = this.add.text(ROOM_W / 2, ROOM_H - 12, text, {
+        this._toast = this.add.text(this.roomW / 2, this.roomH - 12, text, {
             font: '5px monospace',
             color: '#fff1c4',
             backgroundColor: 'rgba(0, 0, 0, 0.8)',

--- a/src/scenes/HouseScene.js
+++ b/src/scenes/HouseScene.js
@@ -1,4 +1,5 @@
 import {HUT_PALETTES} from "../classes/hut";
+import {FORGE_RECIPES} from "../services/recipes";
 
 // Decor catalogue. Each option is a colour or short procedural recipe
 // the interior renderer reads when laying out the room. Adding a new
@@ -478,22 +479,41 @@ export default class HouseScene extends Phaser.Scene {
         });
 
         if (tier >= 2) {
-            // Kitchen — far right. Locked behind the cabin upgrade so the
-            // tent/raft tiers feel meaningfully sparse.
-            const kitchenX = 168, kitchenY = FLOOR_Y - 6;
-            this.add.rectangle(kitchenX, kitchenY, 28, 10, 0x8a6a44).setDepth(3);
-            this.add.rectangle(kitchenX, kitchenY - 4, 28, 2, 0xb5895a).setDepth(3.1);
-            // Stove
-            this.add.rectangle(kitchenX - 8, kitchenY - 1, 8, 6, 0x2a2a2a).setDepth(3.2);
-            this.add.rectangle(kitchenX - 8, kitchenY - 3, 7, 1, 0x6a6a6a).setDepth(3.3);
-            this.add.circle(kitchenX - 10, kitchenY - 1, 0.8, 0xff5a1c).setDepth(3.4);
-            this.add.circle(kitchenX - 6, kitchenY - 1, 0.8, 0xff5a1c).setDepth(3.4);
-            // Sink
-            this.add.rectangle(kitchenX + 8, kitchenY - 1, 8, 5, 0x6a8a99).setDepth(3.2);
-            this.add.rectangle(kitchenX + 8, kitchenY - 3, 2, 2, 0xc0d0d8).setDepth(3.3);
+            // Forge — far right. Locked behind the cabin upgrade. Hot coal
+            // bed under a stone-rimmed pit + a small anvil on a wooden
+            // stump. Press E to open the forge panel and craft tool tiers.
+            const forgeX = 168, forgeY = FLOOR_Y - 6;
+            // Hearth base (stone foundation)
+            this.add.rectangle(forgeX, forgeY + 2, 30, 6, 0x4a4a4a).setDepth(3);
+            this.add.rectangle(forgeX, forgeY - 1, 30, 2, 0x6a6a6a).setDepth(3.05);
+            // Brick rim around the coal pit
+            this.add.rectangle(forgeX - 10, forgeY - 4, 4, 6, 0x6a2a18).setDepth(3.1);
+            this.add.rectangle(forgeX + 5, forgeY - 4, 4, 6, 0x6a2a18).setDepth(3.1);
+            this.add.rectangle(forgeX - 2, forgeY - 6, 14, 2, 0x6a2a18).setDepth(3.1);
+            // Glowing coal bed (additive)
+            this.add.rectangle(forgeX - 2, forgeY - 3, 12, 3, 0xff5a1c, 0.95).setDepth(3.2).setBlendMode(Phaser.BlendModes.ADD);
+            this.add.rectangle(forgeX - 2, forgeY - 3, 12, 1, 0xffd27a, 0.9).setDepth(3.3).setBlendMode(Phaser.BlendModes.ADD);
+            // Embers
+            this.forgeEmbers = this.add.graphics().setDepth(3.4);
+            this.forgeEmbers.fillStyle(0xfff1c4, 1);
+            for (let i = 0; i < 6; i++) {
+                this.forgeEmbers.fillRect(forgeX - 6 + (i * 2), forgeY - 3 - (i % 2), 1, 1);
+            }
+            // Smoke wisp above the hearth
+            const smoke = this.add.rectangle(forgeX + 1, forgeY - 11, 3, 4, 0xaaaaaa, 0.5).setDepth(3.5);
+            this.tweens.add({
+                targets: smoke,
+                y: forgeY - 18, alpha: {from: 0.55, to: 0},
+                duration: 1800, repeat: -1, ease: 'Sine.easeOut',
+            });
+            // Anvil + stump on the right
+            this.add.rectangle(forgeX + 11, forgeY + 2, 5, 5, 0x4a3220).setDepth(3.1); // stump
+            this.add.rectangle(forgeX + 11, forgeY - 2, 7, 2, 0x2a2a2a).setDepth(3.2); // anvil base
+            this.add.rectangle(forgeX + 11, forgeY - 3, 9, 1, 0x6a6a6a).setDepth(3.3); // anvil top
+            this.add.rectangle(forgeX + 14, forgeY - 3, 2, 1, 0x2a2a2a).setDepth(3.4); // horn
             this.furniture.push({
-                kind: 'kitchen', x: kitchenX, y: kitchenY, range: 16,
-                label: 'Cook', interact: () => this.openKitchen(),
+                kind: 'forge', x: forgeX, y: forgeY, range: 18,
+                label: 'Use Forge', interact: () => this.openForgePanel(),
             });
         }
     }
@@ -661,9 +681,11 @@ export default class HouseScene extends Phaser.Scene {
         this._exitBtn?.remove();
         this._decorBtn?.remove();
         this._decorPanel?.remove();
+        this._forgePanel?.remove();
         this._exitBtn = null;
         this._decorBtn = null;
         this._decorPanel = null;
+        this._forgePanel = null;
         this.restoreWorldOverlays();
     }
 
@@ -785,6 +807,206 @@ export default class HouseScene extends Phaser.Scene {
 
     openKitchen() {
         this.flashToast('Kitchen — recipes coming soon.');
+    }
+
+    /**
+     * Open / toggle the forge panel — the cabin-tier station that gates
+     * pickaxe + axe tier upgrades. Reads inventory + tool tiers from
+     * GameScene, mutates the toolbar item directly on craft so the next
+     * mining swing already lands at the new hitPower multiplier.
+     */
+    openForgePanel() {
+        if (this._forgePanel) {
+            this._forgePanel.remove();
+            this._forgePanel = null;
+            return;
+        }
+        const panel = document.createElement('div');
+        panel.className = 'hud-panel';
+        panel.id = 'house_forge_panel';
+        Object.assign(panel.style, {
+            position: 'absolute',
+            top: '60px',
+            right: '18px',
+            zIndex: '1002',
+            padding: '12px',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '8px',
+            minWidth: '260px',
+            maxWidth: '320px',
+            color: '#33ff33',
+            fontFamily: "'VT323','Share Tech Mono',monospace",
+            background: 'rgba(0, 16, 0, 0.97)',
+            border: '2px solid #33ff33',
+            textShadow: '0 0 4px rgba(51,255,51,0.6)',
+        });
+        const title = document.createElement('div');
+        title.textContent = '◆ FORGE ◆';
+        title.style.fontSize = '18px';
+        title.style.textAlign = 'center';
+        title.style.letterSpacing = '0.18em';
+        title.style.borderBottom = '1px dashed #1a8a1a';
+        title.style.paddingBottom = '6px';
+        panel.appendChild(title);
+
+        this._forgePanelTitle = title;
+        this._forgePanelBody = document.createElement('div');
+        this._forgePanelBody.style.display = 'flex';
+        this._forgePanelBody.style.flexDirection = 'column';
+        this._forgePanelBody.style.gap = '8px';
+        panel.appendChild(this._forgePanelBody);
+
+        document.body.appendChild(panel);
+        this._forgePanel = panel;
+        this._renderForgePanel();
+    }
+
+    _renderForgePanel() {
+        const body = this._forgePanelBody;
+        if (!body) return;
+        body.innerHTML = '';
+        const gs = this.gameScene;
+        const im = gs?.inventoryManager;
+        if (!im) return;
+
+        // Current tier readout — gives the player something to read while
+        // they assemble the materials for the next bump.
+        const tb = gs.toolBarManager;
+        const findItem = (id) =>
+            im.slots.find(s => s && s.id === id)
+            || tb?.slots?.find(s => s && s.id === id);
+        const pickaxe = findItem('pickaxe');
+        const axe = findItem('axe');
+        const status = document.createElement('div');
+        status.style.fontSize = '13px';
+        status.style.lineHeight = '1.4';
+        status.style.color = '#1a8a1a';
+        status.innerHTML =
+            `<div>PICKAXE: <span style="color:#33ff33">${pickaxe?.name || '—'}</span></div>` +
+            `<div>AXE: <span style="color:#33ff33">${axe?.name || '—'}</span></div>`;
+        body.appendChild(status);
+
+        const divider = document.createElement('div');
+        divider.style.borderTop = '1px dashed #1a8a1a';
+        body.appendChild(divider);
+
+        FORGE_RECIPES.forEach(recipe => {
+            const card = document.createElement('div');
+            card.style.border = '1px solid #1a8a1a';
+            card.style.padding = '6px 8px';
+            card.style.display = 'flex';
+            card.style.flexDirection = 'column';
+            card.style.gap = '4px';
+
+            const head = document.createElement('div');
+            head.style.fontSize = '14px';
+            head.style.letterSpacing = '0.05em';
+            head.textContent = recipe.name.toUpperCase();
+            card.appendChild(head);
+
+            const desc = document.createElement('div');
+            desc.style.fontSize = '11px';
+            desc.style.color = '#1a8a1a';
+            desc.textContent = recipe.description || '';
+            card.appendChild(desc);
+
+            const costs = document.createElement('div');
+            costs.style.fontSize = '12px';
+            costs.style.display = 'flex';
+            costs.style.gap = '10px';
+            costs.style.color = '#1a8a1a';
+            let canAfford = true;
+            recipe.inputs.forEach(input => {
+                const have = im.getResourceCount?.(input.id) || 0;
+                const short = have < input.amount;
+                if (short) canAfford = false;
+                const tag = document.createElement('span');
+                tag.textContent = `${input.id.toUpperCase()} ${have}/${input.amount}`;
+                if (short) tag.style.color = '#ff5050';
+                costs.appendChild(tag);
+            });
+            card.appendChild(costs);
+
+            // One-shot upgrade owned-state check: each recipe targets a
+            // specific tool + tier; if the matching tool's metadata.toolTier
+            // is already at or above the recipe target, it's installed.
+            const targetItem = findItem(recipe.output.toolId);
+            const curTier = targetItem?.metadata?.toolTier | 0;
+            const owned = curTier >= recipe.output.tier;
+            // Also need to require the previous tier — skipping rungs would
+            // let the player jump straight to iron with no copper detour.
+            const meetsPrereq = curTier >= recipe.output.tier - 1;
+
+            const btn = document.createElement('button');
+            btn.className = 'hud-btn';
+            btn.style.padding = '5px 10px';
+            btn.style.fontSize = '12px';
+            btn.style.background = 'transparent';
+            btn.style.border = '1px solid #33ff33';
+            btn.style.color = '#33ff33';
+            btn.style.fontFamily = 'inherit';
+            btn.style.cursor = 'pointer';
+            btn.disabled = owned || !canAfford || !meetsPrereq;
+            btn.textContent = owned
+                ? '[ INSTALLED ]'
+                : !meetsPrereq
+                    ? '[ NEEDS PRIOR TIER ]'
+                    : canAfford
+                        ? '[ FORGE ]'
+                        : '[ INSUFFICIENT ]';
+            if (btn.disabled) {
+                btn.style.borderColor = '#1a8a1a';
+                btn.style.color = '#1a8a1a';
+                btn.style.cursor = 'not-allowed';
+            }
+            btn.addEventListener('click', () => {
+                if (!btn.disabled) this._craftAtForge(recipe);
+            });
+            card.appendChild(btn);
+
+            body.appendChild(card);
+        });
+    }
+
+    _craftAtForge(recipe) {
+        const gs = this.gameScene;
+        const im = gs?.inventoryManager;
+        const tb = gs?.toolBarManager;
+        if (!im) return;
+
+        // Re-check costs in case state shifted between render and click.
+        for (const input of recipe.inputs) {
+            if ((im.getResourceCount?.(input.id) || 0) < input.amount) return;
+        }
+        const findItem = (id) =>
+            im.slots.find(s => s && s.id === id)
+            || tb?.slots?.find(s => s && s.id === id);
+        const target = findItem(recipe.output.toolId);
+        if (!target) {
+            this.flashToast(`Need a ${recipe.output.toolId} in your kit.`);
+            return;
+        }
+        const curTier = target.metadata?.toolTier | 0;
+        if (curTier >= recipe.output.tier) return;
+        if (curTier < recipe.output.tier - 1) return;
+
+        for (const input of recipe.inputs) {
+            im.consumeResource?.(input.id, input.amount);
+        }
+        // Mutate the toolbar item in place — keeps the same slot + icon
+        // sprite but bumps the tier metadata that breakable / tree damage
+        // reads on every swing. updateMetaData also nudges renderers.
+        target.name = recipe.output.newName;
+        target.updateMetaData?.({
+            ...(target.metadata || {}),
+            toolTier: recipe.output.tier,
+        });
+        tb?.render?.();
+        if (gs.selectedIndex != null) tb?.setSelected?.(gs.selectedIndex);
+        im.render?.();
+        this.flashToast(`Forged: ${recipe.output.newName}`);
+        this._renderForgePanel();
     }
 
     openTv() {

--- a/src/scenes/HouseScene.js
+++ b/src/scenes/HouseScene.js
@@ -90,6 +90,10 @@ export default class HouseScene extends Phaser.Scene {
         this._exiting = false;
         this._toast = null;
         this._tvIdx = 0;
+        // Tier the platform shelter is sitting at. 0 = bedroll/tarp,
+        // 1 = pitched tent, 2 = full cabin. World-placed huts (ghost town)
+        // pre-date the tier system and stay at the legacy "full" interior.
+        this.homeTier = this.hut.isPlayerHouse ? (this.hut.homeTier ?? 2) : 2;
         // Snapshot the persisted decor (if any) before mutating any fields.
         // Player house: hut.decor lives on the world tile so changes
         // survive reloads; ghost huts ignore decor entirely.
@@ -125,7 +129,9 @@ export default class HouseScene extends Phaser.Scene {
         this.buildPlayer();
         this.buildPrompts();
         this.buildVignette();
-        if (this.hut.isPlayerHouse) this.buildDecorButton();
+        // Decorating only makes sense once the player has a real cabin;
+        // before that there's no wallpaper or floor to swap.
+        if (this.hut.isPlayerHouse && this.homeTier >= 2) this.buildDecorButton();
         this.buildExitButton();
 
         this.cursors = this.input.keyboard.addKeys({
@@ -396,6 +402,7 @@ export default class HouseScene extends Phaser.Scene {
     buildHomeFurniture() {
         const W = ROOM_W;
         this.furniture = [];
+        const tier = this.homeTier;
 
         // Door — left side. Walking up against it + W/↑ exits.
         const doorX = 22, doorY = FLOOR_Y - 14;
@@ -413,58 +420,82 @@ export default class HouseScene extends Phaser.Scene {
             label: 'Leave', interact: () => this.exitHouse(),
         });
 
-        // TV — left of bed, mounted-style on its own console
-        const tvX = 70, tvY = FLOOR_Y - 18;
-        this.add.rectangle(tvX, tvY + 8, 22, 6, 0x4a3a26).setDepth(3);
-        this.add.rectangle(tvX, tvY, 20, 12, 0x111111).setDepth(3.1);
-        this.tvScreen = this.add.rectangle(tvX, tvY, 16, 8, 0x2a4a8a).setDepth(3.2);
-        this.tvStatic = this.add.graphics().setDepth(3.3);
-        this.tvStatic.fillStyle(0xffffff, 0.18);
-        for (let y = -3; y <= 3; y += 2) this.tvStatic.fillRect(tvX - 8, tvY + y, 16, 1);
-        this.add.rectangle(tvX - 2, tvY + 8, 4, 1, 0x222222).setDepth(3.4);
-        this.add.rectangle(tvX + 2, tvY + 8, 4, 1, 0x222222).setDepth(3.4);
-        this.tweens.add({
-            targets: this.tvScreen,
-            alpha: {from: 0.85, to: 1},
-            duration: 600, yoyo: true, repeat: -1, ease: 'Sine.easeInOut',
-        });
-        this.furniture.push({
-            kind: 'tv', x: tvX, y: tvY, range: 14,
-            label: 'Watch TV', interact: () => this.openTv(),
-        });
+        if (tier >= 2) {
+            // TV — left of bed, mounted-style on its own console
+            const tvX = 70, tvY = FLOOR_Y - 18;
+            this.add.rectangle(tvX, tvY + 8, 22, 6, 0x4a3a26).setDepth(3);
+            this.add.rectangle(tvX, tvY, 20, 12, 0x111111).setDepth(3.1);
+            this.tvScreen = this.add.rectangle(tvX, tvY, 16, 8, 0x2a4a8a).setDepth(3.2);
+            this.tvStatic = this.add.graphics().setDepth(3.3);
+            this.tvStatic.fillStyle(0xffffff, 0.18);
+            for (let y = -3; y <= 3; y += 2) this.tvStatic.fillRect(tvX - 8, tvY + y, 16, 1);
+            this.add.rectangle(tvX - 2, tvY + 8, 4, 1, 0x222222).setDepth(3.4);
+            this.add.rectangle(tvX + 2, tvY + 8, 4, 1, 0x222222).setDepth(3.4);
+            this.tweens.add({
+                targets: this.tvScreen,
+                alpha: {from: 0.85, to: 1},
+                duration: 600, yoyo: true, repeat: -1, ease: 'Sine.easeInOut',
+            });
+            this.furniture.push({
+                kind: 'tv', x: tvX, y: tvY, range: 14,
+                label: 'Watch TV', interact: () => this.openTv(),
+            });
+        }
 
-        // Bed — middle-right
+        // Bed (or its lower-tier stand-in). All three tiers have somewhere
+        // to sleep, but the visible piece changes:
+        //   tier 0 = bedroll on the floor
+        //   tier 1 = simple cot
+        //   tier 2 = full bed with decor swatches
         const bedX = 122, bedY = FLOOR_Y - 6;
-        const bed = resolveDecor('bed', this.decor.bed);
-        const bedFrameC = Phaser.Display.Color.HexStringToColor(bed.frame).color;
-        const blanketC = Phaser.Display.Color.HexStringToColor(bed.blanket).color;
-        const pillowC = Phaser.Display.Color.HexStringToColor(bed.pillow).color;
-        this.bedFrame = this.add.rectangle(bedX, bedY, 32, 10, bedFrameC).setDepth(3);
-        this.bedBlanket = this.add.rectangle(bedX + 2, bedY - 1, 26, 6, blanketC).setDepth(3.1);
-        this.bedPillow = this.add.rectangle(bedX - 10, bedY - 3, 6, 3, pillowC).setDepth(3.2);
-        this.add.rectangle(bedX - 14, bedY + 6, 2, 4, bedFrameC).setDepth(2.9);
-        this.add.rectangle(bedX + 14, bedY + 6, 2, 4, bedFrameC).setDepth(2.9);
+        if (tier >= 2) {
+            const bed = resolveDecor('bed', this.decor.bed);
+            const bedFrameC = Phaser.Display.Color.HexStringToColor(bed.frame).color;
+            const blanketC = Phaser.Display.Color.HexStringToColor(bed.blanket).color;
+            const pillowC = Phaser.Display.Color.HexStringToColor(bed.pillow).color;
+            this.bedFrame = this.add.rectangle(bedX, bedY, 32, 10, bedFrameC).setDepth(3);
+            this.bedBlanket = this.add.rectangle(bedX + 2, bedY - 1, 26, 6, blanketC).setDepth(3.1);
+            this.bedPillow = this.add.rectangle(bedX - 10, bedY - 3, 6, 3, pillowC).setDepth(3.2);
+            this.add.rectangle(bedX - 14, bedY + 6, 2, 4, bedFrameC).setDepth(2.9);
+            this.add.rectangle(bedX + 14, bedY + 6, 2, 4, bedFrameC).setDepth(2.9);
+        } else if (tier === 1) {
+            // Cot: low frame + thin mattress + small pillow.
+            this.add.rectangle(bedX, bedY + 2, 28, 4, 0x4a3220).setDepth(3);
+            this.add.rectangle(bedX, bedY - 1, 26, 4, 0x9a7a5a).setDepth(3.1);
+            this.add.rectangle(bedX - 9, bedY - 3, 5, 2, 0xe7d8b8).setDepth(3.2);
+            this.add.rectangle(bedX - 12, bedY + 5, 1, 4, 0x2a1808).setDepth(2.9);
+            this.add.rectangle(bedX + 12, bedY + 5, 1, 4, 0x2a1808).setDepth(2.9);
+        } else {
+            // Bedroll: blanket-on-floor with a tiny pillow.
+            this.add.rectangle(bedX, bedY + 4, 30, 4, 0x5a3a22).setDepth(3);
+            this.add.rectangle(bedX, bedY + 2, 26, 5, 0xa8443a).setDepth(3.1);
+            this.add.rectangle(bedX - 10, bedY + 1, 5, 2, 0xe7d8b8).setDepth(3.2);
+        }
+        const bedLabel = tier === 0 ? 'Doze (light rest)' : tier === 1 ? 'Sleep' : 'Sleep';
         this.furniture.push({
             kind: 'bed', x: bedX, y: bedY, range: 16,
-            label: 'Sleep', interact: () => this.sleepInBed(),
+            label: bedLabel, interact: () => this.sleepInBed(),
         });
 
-        // Kitchen — far right
-        const kitchenX = 168, kitchenY = FLOOR_Y - 6;
-        this.add.rectangle(kitchenX, kitchenY, 28, 10, 0x8a6a44).setDepth(3);
-        this.add.rectangle(kitchenX, kitchenY - 4, 28, 2, 0xb5895a).setDepth(3.1);
-        // Stove
-        this.add.rectangle(kitchenX - 8, kitchenY - 1, 8, 6, 0x2a2a2a).setDepth(3.2);
-        this.add.rectangle(kitchenX - 8, kitchenY - 3, 7, 1, 0x6a6a6a).setDepth(3.3);
-        this.add.circle(kitchenX - 10, kitchenY - 1, 0.8, 0xff5a1c).setDepth(3.4);
-        this.add.circle(kitchenX - 6, kitchenY - 1, 0.8, 0xff5a1c).setDepth(3.4);
-        // Sink
-        this.add.rectangle(kitchenX + 8, kitchenY - 1, 8, 5, 0x6a8a99).setDepth(3.2);
-        this.add.rectangle(kitchenX + 8, kitchenY - 3, 2, 2, 0xc0d0d8).setDepth(3.3);
-        this.furniture.push({
-            kind: 'kitchen', x: kitchenX, y: kitchenY, range: 16,
-            label: 'Cook', interact: () => this.openKitchen(),
-        });
+        if (tier >= 2) {
+            // Kitchen — far right. Locked behind the cabin upgrade so the
+            // tent/raft tiers feel meaningfully sparse.
+            const kitchenX = 168, kitchenY = FLOOR_Y - 6;
+            this.add.rectangle(kitchenX, kitchenY, 28, 10, 0x8a6a44).setDepth(3);
+            this.add.rectangle(kitchenX, kitchenY - 4, 28, 2, 0xb5895a).setDepth(3.1);
+            // Stove
+            this.add.rectangle(kitchenX - 8, kitchenY - 1, 8, 6, 0x2a2a2a).setDepth(3.2);
+            this.add.rectangle(kitchenX - 8, kitchenY - 3, 7, 1, 0x6a6a6a).setDepth(3.3);
+            this.add.circle(kitchenX - 10, kitchenY - 1, 0.8, 0xff5a1c).setDepth(3.4);
+            this.add.circle(kitchenX - 6, kitchenY - 1, 0.8, 0xff5a1c).setDepth(3.4);
+            // Sink
+            this.add.rectangle(kitchenX + 8, kitchenY - 1, 8, 5, 0x6a8a99).setDepth(3.2);
+            this.add.rectangle(kitchenX + 8, kitchenY - 3, 2, 2, 0xc0d0d8).setDepth(3.3);
+            this.furniture.push({
+                kind: 'kitchen', x: kitchenX, y: kitchenY, range: 16,
+                label: 'Cook', interact: () => this.openKitchen(),
+            });
+        }
     }
 
     buildAbandonedFurniture() {
@@ -563,8 +594,12 @@ export default class HouseScene extends Phaser.Scene {
         }).setOrigin(0.5, 1).setDepth(50).setVisible(false);
         this.prompt.setResolution(6);
 
+        let title = 'HOME';
+        if (!this.hut.isPlayerHouse) title = 'ABANDONED HUT';
+        else if (this.homeTier === 0) title = 'BEDROLL CAMP';
+        else if (this.homeTier === 1) title = 'TENT';
         this.title = this.add.text(ROOM_W / 2, 6,
-            this.hut.isPlayerHouse ? 'HOME' : 'ABANDONED HUT', {
+            title, {
                 font: '7px monospace',
                 color: this.hut.isPlayerHouse ? '#fff1c4' : '#a89888',
                 stroke: '#000000',
@@ -722,16 +757,28 @@ export default class HouseScene extends Phaser.Scene {
             ROOM_W / 2, ROOM_H / 2, ROOM_W, ROOM_H, 0x000000, 0
         ).setDepth(80);
         this.prompt.setVisible(false);
+        // Restoration scales with the rig tier so the upgrade ladder pays
+        // off in survivability, not just looks. Tier 0 is a stop-gap "doze"
+        // worth ~30%, tier 1 is a comfortable cot at 60%, tier 2 maxes out.
+        const factor = this.homeTier >= 2 ? 1.0 : this.homeTier === 1 ? 0.6 : 0.3;
+        const energyGain = Math.round(player.maxEnergy * factor);
+        const breathGain = Math.round(player.maxBreath * factor);
+        const healthGain = Math.round(25 * factor);
         this.tweens.add({
             targets: overlay,
             alpha: 0.85,
             duration: 600, yoyo: true, hold: 600,
             onComplete: () => {
-                player.energy = player.maxEnergy;
-                player.breath = player.maxBreath;
-                player.health = Math.min(player.maxHealth, player.health + 25);
+                player.energy = Math.min(player.maxEnergy, player.energy + energyGain);
+                player.breath = Math.min(player.maxBreath, player.breath + breathGain);
+                player.health = Math.min(player.maxHealth, player.health + healthGain);
                 overlay.destroy();
-                this.flashToast('Rested. Energy restored.');
+                const msg = this.homeTier >= 2
+                    ? 'Rested. Stats restored.'
+                    : this.homeTier === 1
+                        ? 'Rough sleep in the tent. Partially rested.'
+                        : 'Catnap on the bedroll. Lightly rested.';
+                this.flashToast(msg);
             },
         });
     }

--- a/src/scenes/PreloadScene.js
+++ b/src/scenes/PreloadScene.js
@@ -46,6 +46,11 @@ export default class PreloadScene extends Phaser.Scene {
 
     create() {
         this.generateAxeTexture();
+        this.generateOreTexture('copper', '#a86038', '#d68a52', '#5a2e10', '#f0b070');
+        this.generateOreTexture('iron',   '#9aa0a8', '#cdd2d9', '#3a4048', '#eef0f4');
+        this.generateBedrockTexture();
+        this.generateBedrollTexture();
+        this.generateTentTexture();
         this.scene.start("MenuScene");
     }
 
@@ -93,6 +98,151 @@ export default class PreloadScene extends Phaser.Scene {
         }
 
         tex.refresh();
+    }
+
+    // Ore overlay sprites that sit on top of the dark dirt tile texture.
+    // Same authoring shape as the existing coal art (dark base, flecks of
+    // ore colour clustered into a vein) so all three ores read as the same
+    // family at different richness/colour.
+    generateOreTexture(key, base, light, shadow, sparkle) {
+        if (this.textures.exists(key)) return;
+        const w = 16, h = 16;
+        const tex = this.textures.createCanvas(key, w, h);
+        const ctx = tex.context;
+        ctx.imageSmoothingEnabled = false;
+        ctx.clearRect(0, 0, w, h);
+
+        const veins = [
+            [3, 4], [4, 4], [5, 5], [6, 5], [6, 6], [7, 6],
+            [8, 7], [9, 7], [10, 8], [11, 8], [12, 9],
+            [4, 9], [5, 10], [6, 10], [7, 11], [8, 11],
+            [9, 12], [10, 12], [3, 12], [11, 5], [12, 6],
+        ];
+        ctx.fillStyle = shadow;
+        for (const [x, y] of veins) ctx.fillRect(x, y + 1, 1, 1);
+        ctx.fillStyle = base;
+        for (const [x, y] of veins) ctx.fillRect(x, y, 1, 1);
+        ctx.fillStyle = light;
+        const highlights = [[5, 4], [7, 5], [9, 6], [11, 8], [6, 9], [8, 10]];
+        for (const [x, y] of highlights) ctx.fillRect(x, y, 1, 1);
+        ctx.fillStyle = sparkle;
+        const sparkles = [[5, 5], [9, 8], [11, 9]];
+        for (const [x, y] of sparkles) ctx.fillRect(x, y, 1, 1);
+
+        tex.refresh();
+    }
+
+    // Bedrock layer-cap tile. Reads as solid stone — uniform mid-grey
+    // body with a few darker pits and lighter chips so it doesn't tile
+    // into a flat stripe across the chasm. Players see it as the floor
+    // they need to drill through to descend further.
+    generateBedrockTexture() {
+        if (this.textures.exists('bedrock')) return;
+        const w = 16, h = 16;
+        const tex = this.textures.createCanvas('bedrock', w, h);
+        const ctx = tex.context;
+        ctx.imageSmoothingEnabled = false;
+        ctx.fillStyle = '#4a4a4a';
+        ctx.fillRect(0, 0, w, h);
+        ctx.fillStyle = '#5e5e5e';
+        for (let y = 0; y < h; y += 3) ctx.fillRect(0, y, w, 1);
+        ctx.fillStyle = '#3a3a3a';
+        const pits = [[2,3],[5,1],[8,4],[12,2],[3,7],[10,8],[14,10],[6,11],[1,13],[11,14]];
+        for (const [x, y] of pits) ctx.fillRect(x, y, 2, 2);
+        ctx.fillStyle = '#777';
+        const chips = [[4,6],[9,3],[13,7],[7,9],[2,11],[12,12]];
+        for (const [x, y] of chips) ctx.fillRect(x, y, 1, 1);
+        ctx.fillStyle = '#222';
+        for (let i = 0; i < 14; i++) {
+            const x = (i * 5 + 3) % w;
+            const y = (i * 7 + 2) % h;
+            ctx.fillRect(x, y, 1, 1);
+        }
+        tex.refresh();
+    }
+
+    // Tier-0 home: a rolled sleeping bag on the platform deck. Tiny
+    // sprite, drawn pixel-perfect at 1× and scaled up by setDisplaySize
+    // when the rig mounts it. Brown pad + red blanket + a small pillow.
+    generateBedrollTexture() {
+        if (this.textures.exists('bedroll')) return;
+        const w = 18, h = 8;
+        const tex = this.textures.createCanvas('bedroll', w, h);
+        const ctx = tex.context;
+        ctx.imageSmoothingEnabled = false;
+        // Mat
+        ctx.fillStyle = '#5a3a22';
+        ctx.fillRect(0, 4, w, 4);
+        ctx.fillStyle = '#7a4a28';
+        ctx.fillRect(0, 4, w, 1);
+        ctx.fillStyle = '#2a1808';
+        ctx.fillRect(0, h - 1, w, 1);
+        // Blanket
+        ctx.fillStyle = '#a8443a';
+        ctx.fillRect(2, 2, w - 4, 4);
+        ctx.fillStyle = '#c46044';
+        ctx.fillRect(2, 2, w - 4, 1);
+        ctx.fillStyle = '#5a1a10';
+        ctx.fillRect(2, 5, w - 4, 1);
+        // Stitching seams
+        ctx.fillStyle = '#3a1008';
+        for (let x = 4; x < w - 2; x += 3) ctx.fillRect(x, 3, 1, 2);
+        // Pillow at the head
+        ctx.fillStyle = '#f4e7c6';
+        ctx.fillRect(1, 1, 5, 3);
+        ctx.fillStyle = '#c9b58a';
+        ctx.fillRect(1, 3, 5, 1);
+    }
+
+    // Tier-1 home: a small canvas tent pitched on the platform. Low
+    // triangular silhouette with a darker open flap and a couple of guy
+    // ropes. Sits a bit taller than the bedroll without yet hitting full
+    // hut size — same width footprint as the bedroll so the upgrade reads.
+    generateTentTexture() {
+        if (this.textures.exists('tent')) return;
+        const w = 28, h = 22;
+        const tex = this.textures.createCanvas('tent', w, h);
+        const ctx = tex.context;
+        ctx.imageSmoothingEnabled = false;
+        // Triangular tent body — two coloured slopes for depth.
+        const apex = w / 2;
+        const baseY = h - 3;
+        for (let y = 2; y <= baseY; y++) {
+            const half = Math.round(((y - 2) / (baseY - 2)) * (w / 2 - 2));
+            const x0 = apex - half;
+            const x1 = apex + half;
+            ctx.fillStyle = (y - 2) < 5 ? '#b89a5e' : '#a08240';
+            ctx.fillRect(x0, y, x1 - x0, 1);
+        }
+        // Right slope shading
+        for (let y = 4; y <= baseY; y++) {
+            const half = Math.round(((y - 2) / (baseY - 2)) * (w / 2 - 2));
+            ctx.fillStyle = '#7a5a28';
+            ctx.fillRect(apex + half - 2, y, 2, 1);
+        }
+        // Ridge line
+        ctx.fillStyle = '#3a2a10';
+        ctx.fillRect(apex - 1, 2, 2, baseY - 1);
+        // Flap doorway
+        ctx.fillStyle = '#3a2a18';
+        ctx.fillRect(apex - 3, baseY - 7, 6, 7);
+        ctx.fillStyle = '#1a0e06';
+        ctx.fillRect(apex - 1, baseY - 6, 2, 6);
+        ctx.fillStyle = '#5a4222';
+        ctx.fillRect(apex - 3, baseY - 7, 1, 7);
+        ctx.fillRect(apex + 2, baseY - 7, 1, 7);
+        // Ground line
+        ctx.fillStyle = '#2a1808';
+        ctx.fillRect(0, baseY, w, 1);
+        // Guy ropes
+        ctx.fillStyle = '#cdb89a';
+        ctx.fillRect(2, baseY - 2, 1, 1);
+        ctx.fillRect(3, baseY - 1, 1, 1);
+        ctx.fillRect(w - 3, baseY - 2, 1, 1);
+        ctx.fillRect(w - 4, baseY - 1, 1, 1);
+        // Apex finial
+        ctx.fillStyle = '#1a0e06';
+        ctx.fillRect(apex - 1, 1, 2, 2);
     }
 
 }

--- a/src/services/InventoryManager.js
+++ b/src/services/InventoryManager.js
@@ -443,6 +443,33 @@ export default class InventoryManager {
         );
     }
 
+    addCopper(amount = 1) {
+        const url = this._iconUrlForTexture('copper');
+        this._addOrStack('copper', amount, () =>
+            new InventoryItem('copper', null, 'Copper', 'material', url, {number: amount})
+        );
+    }
+
+    addIron(amount = 1) {
+        const url = this._iconUrlForTexture('iron');
+        this._addOrStack('iron', amount, () =>
+            new InventoryItem('iron', null, 'Iron', 'material', url, {number: amount})
+        );
+    }
+
+    // Inventory icons are HTML <img> elements, so procedural canvas
+    // textures need to be exported as a data URL once. Falls back to the
+    // coal sprite if the texture isn't there yet so the icon never blanks.
+    _iconUrlForTexture(key) {
+        const tex = this.game?.textures;
+        if (!tex || !tex.exists(key)) return 'images/coal.png';
+        try {
+            return tex.get(key).getSourceImage().toDataURL();
+        } catch (e) {
+            return 'images/coal.png';
+        }
+    }
+
     _addOrStack(id, amount, factory) {
         const bump = (existing) => {
             const current = existing.metadata?.number || 0;

--- a/src/services/craneManager.js
+++ b/src/services/craneManager.js
@@ -261,6 +261,18 @@ export default class CraneManager {
         // snapping in a single frame.
         this.liftMinDurationMs = 150;
         this.game = scene;
+        // Progression dials owned by the rig — gated behind crafting at the
+        // lift terminal. rigTier controls the platform/shelter visuals and
+        // sleep restoration; drillBitTier controls how deep the platform-
+        // mounted drill can crack a layer cap.
+        //   rigTier 0: bare platform + bedroll (no walls)
+        //   rigTier 1: platform + canvas tent
+        //   rigTier 2: full hut (current home)
+        //   drillBit 0: starter — clears layer 1 cap (coal-fuelled)
+        //   drillBit 1: copper — clears caps 2-3
+        //   drillBit 2: iron   — clears caps 4-6
+        this.rigTier = scene.rigTier ?? 0;
+        this.drillBitTier = scene.drillBitTier ?? 0;
         this.ropeColor = '0x6B3E22';
         const width = (this.game.chasmRange[1] - this.game.chasmRange[0]) * 10;
         const platformX = (this.game.chasmRange[0] * 10) + width / 2;
@@ -350,6 +362,13 @@ export default class CraneManager {
      * platform's top and re-synced every frame so they stay glued during
      * lift travel. Decor is persisted on the GameScene so it survives
      * scene transitions even though there's no world grid cell to anchor.
+     *
+     * The shelter art swaps between three tier-specific compositions:
+     *   tier 0: bedroll only — no walls, exposed deck.
+     *   tier 1: canvas tent — taller silhouette, still no facade.
+     *   tier 2: full hut facade with stoop, window glow, decor inside.
+     * Only one composition is visible at a time; the others stay hidden
+     * so a tier change just toggles visibility instead of teardown.
      */
     createPlatformHut(platformX, platformY) {
         const ts = this.game.tileSize;
@@ -366,6 +385,7 @@ export default class CraneManager {
             };
         }
 
+        // --- Tier 2: full hut facade -------------------------------------
         const facade = this.game.add.image(platformX, platformTop, textureKey);
         facade.setOrigin(0.5, 1);
         facade.setDisplaySize(HUT_TILE_W * ts, HUT_TILE_H * ts);
@@ -387,20 +407,35 @@ export default class CraneManager {
         windowGlow.setDepth(0.59);
         windowGlow.setBlendMode(Phaser.BlendModes.ADD);
 
-        // Invisible interactable rectangle sat just above the platform so
-        // the existing hutGroup overlap picks it up like a normal hut.
+        // --- Tier 0: bedroll laid out on the deck ------------------------
+        const bedroll = this.game.add.image(platformX, platformTop - 1, 'bedroll');
+        bedroll.setOrigin(0.5, 1);
+        bedroll.setDisplaySize(ts * 1.6, ts * 0.7);
+        bedroll.setDepth(0.62);
+        // Tiny lantern beside the bedroll so the early-game home isn't
+        // pitch black at night. Reuses the hut window glow palette.
+        const campLight = this.game.add.rectangle(
+            platformX - ts * 0.9, platformTop - ts * 0.4, ts * 0.4, ts * 0.4, 0xffd27a, 0.5
+        );
+        campLight.setDepth(0.61);
+        campLight.setBlendMode(Phaser.BlendModes.ADD);
+
+        // --- Tier 1: tent ------------------------------------------------
+        const tent = this.game.add.image(platformX, platformTop, 'tent');
+        tent.setOrigin(0.5, 1);
+        tent.setDisplaySize(ts * 2.6, ts * 2.0);
+        tent.setDepth(0.6);
+
+        // Door collider — same hit area at every tier so interaction stays
+        // predictable while the visible shelter changes around it.
         const door = this.game.add.rectangle(
             platformX, platformTop - (ts * 1.4) / 2, ts, ts * 1.4, 0xffffff
         );
         door.setAlpha(0);
         this.game.hutGroup.add(door);
-        // Stubs match the Tile-shaped interface — getAdjacentBlocks /
-        // chunk-unload / hover scans iterate every entity group and call
-        // these without checking whether they exist, so leaving them off
-        // crashes on the first chunk unload.
         door.tileRef = {
             tileDetails: {isPlayerHouse: true, paletteKey, hutId: 'platform_home'},
-            interactionText: 'Enter Home',
+            interactionText: 'Rest',
             enterHut: () => this._enterPlatformHut(),
             destroy: () => {},
             checkState: () => {},
@@ -409,24 +444,132 @@ export default class CraneManager {
             onClick: () => {},
         };
 
-        this.platformHut = {facade, stoop, windowGlow, door};
+        this.platformHut = {facade, stoop, windowGlow, bedroll, campLight, tent, door};
+        this._applyRigTierVisuals();
         this._syncPlatformHut();
+    }
+
+    /**
+     * Show/hide the shelter pieces matching the current rigTier and update
+     * the door's interaction prompt. Called on construct + on every
+     * setRigTier; cheap because every piece is already in the scene.
+     */
+    _applyRigTierVisuals() {
+        if (!this.platformHut) return;
+        const {facade, stoop, windowGlow, bedroll, campLight, tent, door} = this.platformHut;
+        const t = this.rigTier;
+        bedroll.setVisible(t === 0);
+        campLight.setVisible(t === 0 || t === 1);
+        tent.setVisible(t === 1);
+        facade.setVisible(t >= 2);
+        stoop.setVisible(t >= 2);
+        windowGlow.setVisible(t >= 2);
+        if (door?.tileRef) {
+            door.tileRef.interactionText =
+                t === 0 ? 'Use Bedroll' :
+                t === 1 ? 'Enter Tent'  :
+                          'Enter Home';
+        }
+    }
+
+    setRigTier(tier) {
+        const t = Math.max(0, Math.min(2, tier | 0));
+        if (t === this.rigTier) return;
+        this.rigTier = t;
+        this.game.rigTier = t;
+        this._applyRigTierVisuals();
+    }
+
+    setDrillBitTier(tier) {
+        const t = Math.max(0, Math.min(2, tier | 0));
+        if (t === this.drillBitTier) return;
+        this.drillBitTier = t;
+        this.game.drillBitTier = t;
     }
 
     _syncPlatformHut() {
         if (!this.platformHut) return;
         const ts = this.game.tileSize;
         const platformTop = this.craneFlat.y - PLATFORM_HALF_H;
-        const {facade, stoop, windowGlow, door} = this.platformHut;
+        const {facade, stoop, windowGlow, bedroll, campLight, tent, door} = this.platformHut;
         facade.x = this.craneFlat.x;
         facade.y = platformTop;
         stoop.x = this.craneFlat.x;
         stoop.y = platformTop;
         windowGlow.x = this.craneFlat.x;
         windowGlow.y = platformTop - ts * 2.1;
+        bedroll.x = this.craneFlat.x;
+        bedroll.y = platformTop - 1;
+        campLight.x = this.craneFlat.x - ts * 0.9;
+        campLight.y = platformTop - ts * 0.4;
+        tent.x = this.craneFlat.x;
+        tent.y = platformTop;
         door.x = this.craneFlat.x;
         door.y = platformTop - (ts * 1.4) / 2;
         if (door.body) door.body.updateFromGameObject();
+    }
+
+    /**
+     * Find the bedrock cap row sitting directly underneath the platform, if
+     * any. Used by the lift terminal to enable its DRILL action and to know
+     * which cells to clear when the drill fires. Returns null when no cap
+     * is within reach (a few tiles below the deck) — that includes both
+     * "already drilled past" and "platform parked above empty chasm".
+     */
+    capDirectlyBelow() {
+        const ts = this.game.tileSize;
+        const caps = this.game.layerCapRows || [];
+        if (!caps.length) return null;
+        const platformBottomY = this.craneFlat.body
+            ? this.craneFlat.body.y + (this.craneFlat.body.height || 5)
+            : this.craneFlat.y + PLATFORM_HALF_H;
+        const platformBottomCellY = Math.floor(platformBottomY / ts);
+        for (const cap of caps) {
+            const dy = cap.capY - platformBottomCellY;
+            // Cap row lives within ~3 tiles below the deck — far enough to
+            // forgive small parking errors, close enough that the player
+            // is clearly "at" this cap rather than drifting between two.
+            if (dy >= 0 && dy <= 3) {
+                // Verify the centre cell still holds bedrock (already-drilled
+                // caps stay in the list but resolve to empty cells).
+                const centreX = Math.floor((this.game.chasmRange[0] + this.game.chasmRange[1]) / 2);
+                const cell = this.game.mapService._cellAt(centreX, cap.capY);
+                const bedrockType = this.game.tileTypes.bedrock?.type;
+                if (cell && cell.id === this.game.tileTypes.bedrock.id && cell.type === bedrockType) {
+                    return cap;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Replace every bedrock cell in `cap` with empty cells, opening the
+     * shaft to the next layer. Caller is responsible for the bit-tier and
+     * fuel checks; this just performs the world mutation.
+     */
+    drillCap(cap) {
+        if (!cap) return false;
+        const ms = this.game.mapService;
+        const ts = this.game.tileSize;
+        const empty = this.game.tileTypes.empty;
+        const chasm = this.game.chasmRange;
+        for (let x = chasm[0] + 1; x < chasm[1]; x++) {
+            const worldX = x * ts;
+            const worldY = cap.capY * ts;
+            // Pass the sprite as cellItem — Tile.init stamps chunkKey /
+            // cellX / cellY / tileRef onto the sprite so setTile can resolve
+            // the grid slot and dispose the old tile in one call.
+            const sprite = ms.spriteAtWorld(worldX, worldY);
+            ms.setTile(worldX, worldY, {...empty}, sprite || undefined);
+        }
+        // Quick visual punch: dust burst at each cleared tile so the drill
+        // operation reads as something physical happened.
+        const cx = ((chasm[0] + chasm[1]) / 2) * ts;
+        const cy = cap.capY * ts;
+        this.game.dustEmitter?.setPosition(cx, cy);
+        this.game.dustEmitter?.explode(80);
+        return true;
     }
 
     _enterPlatformHut() {
@@ -439,6 +582,9 @@ export default class CraneManager {
                 isPlayerHouse: true,
                 paletteKey: 'homestead',
                 decor: this.game.platformHutDecor,
+                // Forward the rig tier so the interior renders the right
+                // furniture set and scales sleep restoration.
+                homeTier: this.rigTier,
             },
             persistDecor: (group, key) => {
                 this.game.platformHutDecor[group] = key;

--- a/src/services/liftTerminal.js
+++ b/src/services/liftTerminal.js
@@ -26,7 +26,17 @@ const STYLE_ID = 'lift-terminal-styles';
 const RESOURCE_LABELS = {
     wood: 'WOOD',
     coal: 'COAL',
+    copper: 'COPPER',
+    iron: 'IRON',
 };
+
+// Coal cost per drill, indexed by which cap layer is being drilled. Layer 1
+// is dirt-cheap to introduce the mechanic; deeper caps demand more fuel
+// and a stronger bit. The bit-tier requirement lives in DRILL_BIT_FOR_LAYER.
+const DRILL_FUEL_COST = {1: 30, 2: 50, 3: 80, 4: 120, 5: 180, 6: 250};
+const DRILL_BIT_FOR_LAYER = {1: 0, 2: 1, 3: 1, 4: 2, 5: 2, 6: 2};
+const DRILL_BIT_NAMES = ['BASIC', 'COPPER', 'IRON'];
+const RIG_TIER_NAMES = ['MK-I RAFT', 'MK-II TENT', 'MK-III CABIN'];
 
 function injectStyles() {
     if (document.getElementById(STYLE_ID)) return;
@@ -319,6 +329,8 @@ export default class LiftTerminal {
                         <h3>RIG STATUS</h3>
                         <div class="lift-terminal-row"><span class="lbl">DEPTH</span><span data-field="depth">--</span></div>
                         <div class="lift-terminal-row"><span class="lbl">ROPE</span><span data-field="rope">--</span></div>
+                        <div class="lift-terminal-row"><span class="lbl">RIG</span><span data-field="rigTier">--</span></div>
+                        <div class="lift-terminal-row"><span class="lbl">DRILL</span><span data-field="drillBit">--</span></div>
                         <div class="lift-terminal-row"><span class="lbl">STATUS</span><span data-field="status">--</span></div>
                     </div>
                     <div class="lift-terminal-section">
@@ -327,6 +339,8 @@ export default class LiftTerminal {
                             <div class="cell"><span class="lbl">WOOD</span><span class="val" data-field="stockWood">0</span></div>
                             <div class="cell"><span class="lbl">COAL</span><span class="val" data-field="stockCoal">0</span></div>
                             <div class="cell"><span class="lbl">ROPE</span><span class="val" data-field="stockMetal">0</span></div>
+                            <div class="cell"><span class="lbl">COPPER</span><span class="val" data-field="stockCopper">0</span></div>
+                            <div class="cell"><span class="lbl">IRON</span><span class="val" data-field="stockIron">0</span></div>
                         </div>
                     </div>
                     <div class="lift-terminal-section">
@@ -335,6 +349,10 @@ export default class LiftTerminal {
                             +<span data-field="extendIncrement">--</span>m
                             <span class="right">COST <span data-field="extendCost">--</span></span>
                         </button>
+                    </div>
+                    <div class="lift-terminal-section">
+                        <h3>DRILL</h3>
+                        <div data-field="drillBody"></div>
                     </div>
                 </div>
                 <div class="lift-terminal-col">
@@ -362,13 +380,18 @@ export default class LiftTerminal {
             depth: root.querySelector('[data-field="depth"]'),
             rope: root.querySelector('[data-field="rope"]'),
             status: root.querySelector('[data-field="status"]'),
+            rigTier: root.querySelector('[data-field="rigTier"]'),
+            drillBit: root.querySelector('[data-field="drillBit"]'),
             extendIncrement: root.querySelector('[data-field="extendIncrement"]'),
             extendCost: root.querySelector('[data-field="extendCost"]'),
             levels: root.querySelector('[data-field="levels"]'),
             stockWood: root.querySelector('[data-field="stockWood"]'),
             stockCoal: root.querySelector('[data-field="stockCoal"]'),
             stockMetal: root.querySelector('[data-field="stockMetal"]'),
+            stockCopper: root.querySelector('[data-field="stockCopper"]'),
+            stockIron: root.querySelector('[data-field="stockIron"]'),
             recipes: root.querySelector('[data-field="recipes"]'),
+            drillBody: root.querySelector('[data-field="drillBody"]'),
         };
 
         root.querySelector('[data-action="extend"]').addEventListener('click', () => this.extendRope());
@@ -422,8 +445,36 @@ export default class LiftTerminal {
         return this.craneManager.surfaceWorldY() + this.maxExtension;
     }
 
+    /**
+     * World Y of the topmost still-bedrock cap below the surface, or null
+     * if every cap has been drilled. Used to clamp `canReach` so the rope
+     * length isn't enough on its own — the shaft must also be open.
+     */
+    nextBlockingCapWorldY() {
+        const ts = this.game.tileSize;
+        const caps = this.game.layerCapRows || [];
+        const ms = this.game.mapService;
+        const bedrockId = this.game.tileTypes.bedrock?.id;
+        const bedrockType = this.game.tileTypes.bedrock?.type;
+        if (bedrockId == null || !ms) return null;
+        const centreX = Math.floor((this.game.chasmRange[0] + this.game.chasmRange[1]) / 2);
+        for (const cap of caps) {
+            const cell = ms._cellAt(centreX, cap.capY);
+            if (cell && cell.id === bedrockId && cell.type === bedrockType) {
+                return cap.capY * ts;
+            }
+        }
+        return null;
+    }
+
     canReach(worldY) {
-        return worldY <= this.maxReachableY() + 1;
+        if (worldY > this.maxReachableY() + 1) return false;
+        // Caps block descent regardless of rope reach. The platform parks
+        // one tile above the cap (so the deck still shows above it), so a
+        // request for that or any deeper Y is denied until the drill clears.
+        const capY = this.nextBlockingCapWorldY();
+        if (capY != null && worldY >= capY - this.game.tileSize) return false;
+        return true;
     }
 
     refresh() {
@@ -435,16 +486,128 @@ export default class LiftTerminal {
         this.fields.depth.textContent = `-${currentDepth} M`;
         this.fields.rope.textContent = `-${Math.round(this.maxExtension)} M`;
         this.fields.status.textContent = cm.moving ? 'IN MOTION' : 'IDLE';
+        this.fields.rigTier.textContent = RIG_TIER_NAMES[cm.rigTier] || 'MK-?';
+        this.fields.drillBit.textContent = DRILL_BIT_NAMES[cm.drillBitTier] || '?';
         this.fields.extendIncrement.textContent = String(this.extendIncrement);
         this.fields.extendCost.textContent = String(this.extendCost);
 
         this.renderLevels(currentY, surfaceY);
+        this.renderDrill();
         this.renderCrafting();
+    }
+
+    /**
+     * Show whether the platform is parked at a layer cap and, if so, expose
+     * a single DRILL button that consumes coal (gated by drill-bit tier).
+     * Otherwise show a hint at where the next drillable cap lives so the
+     * player has a goal in mind when they leave the terminal.
+     */
+    renderDrill() {
+        const body = this.fields.drillBody;
+        if (!body) return;
+        body.innerHTML = '';
+        const cm = this.craneManager;
+        const cap = cm.capDirectlyBelow ? cm.capDirectlyBelow() : null;
+        const fmtBitReq = (req) =>
+            req === 0 ? 'BASIC BIT' :
+            req === 1 ? 'COPPER BIT REQ.' :
+                        'IRON BIT REQ.';
+
+        if (!cap) {
+            const hint = document.createElement('div');
+            hint.className = 'lift-terminal-empty';
+            const next = (this.game.layerCapRows || []).find(c => {
+                const ts = this.game.tileSize;
+                const centreX = Math.floor((this.game.chasmRange[0] + this.game.chasmRange[1]) / 2);
+                const cell = this.game.mapService._cellAt(centreX, c.capY);
+                return cell && cell.id === this.game.tileTypes.bedrock.id && cell.type === this.game.tileTypes.bedrock.type;
+            });
+            if (next) {
+                const surfaceY = cm.surfaceWorldY();
+                const ts = this.game.tileSize;
+                const depthM = Math.round((next.capY * ts) - surfaceY);
+                hint.textContent = `> NEXT CAP @ -${depthM}M (${fmtBitReq(DRILL_BIT_FOR_LAYER[next.layer] ?? 0)}). PARK PLATFORM ABOVE TO DRILL.`;
+            } else {
+                hint.textContent = '> ALL KNOWN CAPS CLEARED.';
+            }
+            body.appendChild(hint);
+            return;
+        }
+
+        const cost = DRILL_FUEL_COST[cap.layer] || 50;
+        const bitReq = DRILL_BIT_FOR_LAYER[cap.layer] ?? 0;
+        const haveCoal = this._resourceCount('coal');
+        const hasBit = cm.drillBitTier >= bitReq;
+        const canDrill = haveCoal >= cost && hasBit && !cm.moving;
+
+        const status = document.createElement('div');
+        status.className = 'lift-terminal-row';
+        status.innerHTML = `<span class="lbl">CAP</span><span>L${cap.layer}  (${fmtBitReq(bitReq)})</span>`;
+        body.appendChild(status);
+
+        const fuel = document.createElement('div');
+        fuel.className = 'lift-terminal-row';
+        const shortFuel = haveCoal < cost ? ' style="color:#ff5050"' : '';
+        fuel.innerHTML = `<span class="lbl">FUEL</span><span${shortFuel}>COAL ${haveCoal}/${cost}</span>`;
+        body.appendChild(fuel);
+
+        const btn = document.createElement('button');
+        btn.className = 'lift-terminal-btn';
+        btn.disabled = !canDrill;
+        const label = !hasBit
+            ? '[ BIT TOO WEAK ]'
+            : haveCoal < cost
+                ? '[ NEED MORE COAL ]'
+                : '[ DRILL THROUGH ]';
+        btn.innerHTML = label;
+        btn.addEventListener('click', () => {
+            if (!btn.disabled) this.drill(cap);
+        });
+        body.appendChild(btn);
+    }
+
+    /**
+     * Spend the fuel, clear the cap, refresh. Re-checks both gates in case
+     * inventory state shifted between render and click.
+     */
+    drill(cap) {
+        const cm = this.craneManager;
+        const cost = DRILL_FUEL_COST[cap.layer] || 50;
+        const bitReq = DRILL_BIT_FOR_LAYER[cap.layer] ?? 0;
+        if (cm.moving) return;
+        if (cm.drillBitTier < bitReq) return;
+        if (this._resourceCount('coal') < cost) return;
+        this._consumeResource('coal', cost);
+        cm.drillCap(cap);
+        this.refresh();
     }
 
     renderLevels(currentY, surfaceY) {
         const cm = this.craneManager;
-        const levels = this._scanLevelsFromGrid();
+        const ts = this.game.tileSize;
+        const switchLevels = this._scanLevelsFromGrid().map(l => ({...l, kind: 'switch'}));
+
+        // Synthesise a "cap park" entry one tile above each undrilled
+        // bedrock cap — the wall-switch grid alone has nothing close enough
+        // to position the platform for a drill, so we manufacture stops at
+        // the right Y. The shifted park position lines the deck bottom up
+        // flush with the cap so capDirectlyBelow() resolves to the cap.
+        const ms = this.game.mapService;
+        const bedrockId = this.game.tileTypes.bedrock?.id;
+        const bedrockType = this.game.tileTypes.bedrock?.type;
+        const centreX = Math.floor((this.game.chasmRange[0] + this.game.chasmRange[1]) / 2);
+        const capLevels = (this.game.layerCapRows || []).map(cap => {
+            const cell = ms._cellAt(centreX, cap.capY);
+            const drilled = !cell || cell.id !== bedrockId || cell.type !== bedrockType;
+            return {
+                kind: 'cap',
+                worldY: cap.capY * ts - (ts + ts / 2),
+                cap,
+                drilled,
+            };
+        }).filter(l => !l.drilled);
+
+        const levels = [...switchLevels, ...capLevels].sort((a, b) => a.worldY - b.worldY);
         const list = this.fields.levels;
         list.innerHTML = '';
 
@@ -456,18 +619,25 @@ export default class LiftTerminal {
             return;
         }
 
-        levels.forEach((lvl, i) => {
+        let switchIdx = 0;
+        levels.forEach(lvl => {
             const depth = Math.round(lvl.worldY - surfaceY);
             const reachable = this.canReach(lvl.worldY);
-            const atHere = Math.abs(currentY - lvl.worldY) < 1;
+            const atHere = Math.abs(currentY - lvl.worldY) < 2;
             const btn = document.createElement('button');
             btn.className = 'lift-terminal-btn';
             btn.disabled = !reachable || atHere || cm.moving;
             const tag = !reachable ? 'LOCKED' : (atHere ? 'CURRENT' : 'TRAVEL');
-            const num = String(i + 1).padStart(2, '0');
             const depthLabel = depth >= 0 ? `-${depth}m` : `+${-depth}m`;
-            btn.innerHTML =
-                `LVL ${num} &nbsp; ${depthLabel}<span class="right">[ ${tag} ]</span>`;
+            let label;
+            if (lvl.kind === 'cap') {
+                label = `CAP L${lvl.cap.layer} &nbsp; ${depthLabel}`;
+            } else {
+                switchIdx++;
+                const num = String(switchIdx).padStart(2, '0');
+                label = `LVL ${num} &nbsp; ${depthLabel}`;
+            }
+            btn.innerHTML = `${label}<span class="right">[ ${tag} ]</span>`;
             btn.addEventListener('click', () => {
                 if (!btn.disabled) this.travelTo(lvl.worldY);
             });
@@ -496,6 +666,8 @@ export default class LiftTerminal {
         this.fields.stockWood.textContent = String(this._resourceCount('wood'));
         this.fields.stockCoal.textContent = String(this._resourceCount('coal'));
         this.fields.stockMetal.textContent = String(this.metal);
+        this.fields.stockCopper.textContent = String(this._resourceCount('copper'));
+        this.fields.stockIron.textContent = String(this._resourceCount('iron'));
 
         const list = this.fields.recipes;
         list.innerHTML = '';
@@ -531,12 +703,23 @@ export default class LiftTerminal {
             });
             card.appendChild(costs);
 
+            // One-shot upgrades flip from CRAFT to OWNED once the player has
+            // reached the recipe's target tier — keeps the recipe in the
+            // catalogue (so the cost stays visible as a reference) but
+            // disables it so accidental clicks don't no-op silently.
+            const cm = this.craneManager;
+            let owned = false;
+            if (recipe.output.kind === 'drillBit' && cm.drillBitTier >= recipe.output.tier) owned = true;
+            if (recipe.output.kind === 'rigTier'  && cm.rigTier      >= recipe.output.tier) owned = true;
+
             const btn = document.createElement('button');
             btn.className = 'lift-terminal-btn';
-            btn.disabled = !canAfford;
-            btn.innerHTML = canAfford
-                ? `[ CRAFT ] +${recipe.output.amount}`
-                : `[ INSUFFICIENT ]`;
+            btn.disabled = owned || !canAfford;
+            btn.innerHTML = owned
+                ? '[ INSTALLED ]'
+                : canAfford
+                    ? (recipe.output.amount ? `[ CRAFT ] +${recipe.output.amount}` : '[ INSTALL ]')
+                    : '[ INSUFFICIENT ]';
             btn.title = recipe.description || '';
             btn.addEventListener('click', () => {
                 if (!btn.disabled) this.craft(recipe);
@@ -550,11 +733,18 @@ export default class LiftTerminal {
     /**
      * Run a recipe: re-check costs (in case state changed between render
      * and click), then consume inputs and apply the output. Output kinds:
-     *   - 'metal': top up the rig's rope stockpile.
-     *   - 'tool':  bump an existing tool stack's metadata.number. If the
-     *              player isn't carrying that tool, the craft is refused
-     *              (resources stay untouched) so we don't silently eat
-     *              materials for an item the player can't receive.
+     *   - 'metal':    top up the rig's rope stockpile.
+     *   - 'tool':     bump an existing tool stack's metadata.number. If
+     *                 the player isn't carrying that tool, the craft is
+     *                 refused (resources stay untouched) so we don't
+     *                 silently eat materials for an item the player can't
+     *                 receive.
+     *   - 'drillBit': upgrade the rig's drill-bit tier (one-shot — once
+     *                 owned, the bit applies to all future drills).
+     *   - 'rigTier':  upgrade the platform/shelter tier (one-shot ladder
+     *                 to the next tier; refuses if already past).
+     * One-shot upgrades refuse before consuming inputs if the player is
+     * already at or above the target tier.
      */
     craft(recipe) {
         for (const input of recipe.inputs) {
@@ -567,6 +757,9 @@ export default class LiftTerminal {
                 || tb?.slots?.some(s => s && s.id === recipe.output.toolId);
             if (!hasSlot) return;
         }
+        const cm = this.craneManager;
+        if (recipe.output.kind === 'drillBit' && cm.drillBitTier >= recipe.output.tier) return;
+        if (recipe.output.kind === 'rigTier'  && cm.rigTier      >= recipe.output.tier) return;
 
         for (const input of recipe.inputs) {
             this._consumeResource(input.id, input.amount);
@@ -576,6 +769,10 @@ export default class LiftTerminal {
             this.metal += recipe.output.amount;
         } else if (recipe.output.kind === 'tool') {
             this.game.inventoryManager?.addToToolStack?.(recipe.output.toolId, recipe.output.amount);
+        } else if (recipe.output.kind === 'drillBit') {
+            cm.setDrillBitTier(recipe.output.tier);
+        } else if (recipe.output.kind === 'rigTier') {
+            cm.setRigTier(recipe.output.tier);
         }
 
         this.refresh();

--- a/src/services/map.js
+++ b/src/services/map.js
@@ -969,6 +969,29 @@ export default class MapService {
         const chunkPixelY = chunkStartY * this.game.tileSize;
         const chunkPixelSize = this.game.chunkSize * this.game.tileSize;
 
+        // Crash insulation: when a tile slips into an entity group without a
+        // properly-shaped tileRef (the platform's hut door + control panel
+        // both expose Tile-shaped stubs to satisfy this iteration), missing
+        // a destroy method would otherwise stop the player's whole session
+        // mid-walk. Skip + warn instead of throwing.
+        const safeDestroy = (tile, prefs) => {
+            const fn = tile?.tileRef?.destroy;
+            if (typeof fn === 'function') {
+                fn.call(tile.tileRef, prefs);
+            } else {
+                if (!this._warnedTileRefShape) {
+                    this._warnedTileRefShape = true;
+                    console.warn(
+                        '[map.unloadChunk] tile in entity group missing tileRef.destroy — skipping. ' +
+                        'tileRef keys:', tile?.tileRef ? Object.keys(tile.tileRef) : tile?.tileRef
+                    );
+                }
+                // Phaser-level fallback so the leftover sprite at least
+                // disappears rather than rendering forever in an unloaded chunk.
+                if (typeof tile?.destroy === 'function') tile.destroy();
+            }
+        };
+
         this.game.entityChildren.forEach((entityGroup) => {
             if (entityGroup?.children) {
                 entityGroup.children.getArray().slice().forEach((tile) => {
@@ -979,7 +1002,7 @@ export default class MapService {
                         x >= chunkPixelX && x < chunkPixelX + chunkPixelSize &&
                         y >= chunkPixelY && y < chunkPixelY + chunkPixelSize
                     ) {
-                        tile.tileRef.destroy({preserveAttached: true});
+                        safeDestroy(tile, {preserveAttached: true});
                     }
                 });
             } else if (Array.isArray(entityGroup)) {
@@ -991,7 +1014,7 @@ export default class MapService {
                         x >= chunkPixelX && x < chunkPixelX + chunkPixelSize &&
                         y >= chunkPixelY && y < chunkPixelY + chunkPixelSize
                     ) {
-                        tile.tileRef.destroy();
+                        safeDestroy(tile);
                     }
                 });
             }

--- a/src/services/map.js
+++ b/src/services/map.js
@@ -224,6 +224,11 @@ export default class MapService {
         // we can clear nearby trunks that would clip into the facades.
         this.placeGhostTown();
 
+        // Bedrock caps seal the chasm at every layer boundary. The platform
+        // can't pass them until the player drills through, which gates
+        // descent into the lower biomes behind the drill-bit progression.
+        this.placeLayerCaps();
+
         // worldX, worldY, tileType, cellItem
         // Update region: every cell in columns 40 through 48 gets updated to a new tile type.
         // this.updateRegion(156, 164, this.game.tileTypes.empty);
@@ -417,6 +422,71 @@ export default class MapService {
      * generateMap can still call it without branching.
      */
     placeGhostTown() {
+    }
+
+    /**
+     * Drop a single row of bedrock across the chasm interior at every layer
+     * boundary below the surface. Each cap is one tile tall and just narrow
+     * enough to fit between the chasm walls — the wall tunnels stay clear
+     * so foot traffic via the side soil still works, but the platform can't
+     * descend past a cap until the drill clears it.
+     *
+     * Cap rows are listed on `this.game.layerCapRows` so the lift terminal
+     * can render a "DRILL" call-to-action when the platform is parked at
+     * one and the drill operation knows which cells to clear.
+     */
+    placeLayerCaps() {
+        const tileTypes = this.game.tileTypes;
+        if (!tileTypes?.bedrock) return;
+        const chasm = this.game.chasmRange;
+        const layerH = this.layerHeight;
+        const above = this.game.aboveGround;
+
+        const caps = [];
+        for (let i = 1; i < this.layerCount; i++) {
+            // Land exactly on the layer boundary; nudge by one row if it
+            // would collide with a tunnel slot in the chasm wall (every
+            // 30th row carries a lift switch and a wall opening).
+            let capY = i * layerH;
+            if (capY <= above + 4) continue;
+            if (capY % 30 === 0) capY -= 1;
+            for (let x = chasm[0] + 1; x < chasm[1]; x++) {
+                this._setCell(x, capY, {...tileTypes.bedrock, capLayer: i});
+            }
+            caps.push({layer: i, capY, depthRows: capY - above});
+        }
+        this.game.layerCapRows = caps;
+    }
+
+    /**
+     * Backfill bedrock caps onto saves that pre-date the layer-cap feature.
+     * Idempotent so it's safe to call on every load — only seeds rows that
+     * don't already contain bedrock.
+     */
+    ensureLayerCaps() {
+        const tileTypes = this.game.tileTypes;
+        if (!tileTypes?.bedrock || !this.game.grid) return;
+        const chasm = this.game.chasmRange;
+        const layerH = this.layerHeight;
+        const above = this.game.aboveGround;
+        const caps = [];
+        for (let i = 1; i < this.layerCount; i++) {
+            let capY = i * layerH;
+            if (capY <= above + 4) continue;
+            if (capY % 30 === 0) capY -= 1;
+            // Sample the centre cell to decide if this layer is already
+            // capped (or already drilled). Either state means "leave it".
+            const sample = this._cellAt(Math.floor((chasm[0] + chasm[1]) / 2), capY);
+            const isBedrock = sample && sample.id === tileTypes.bedrock.id && sample.type === tileTypes.bedrock.type;
+            const isEmpty   = sample && sample.id === tileTypes.empty.id;
+            if (!isBedrock && !isEmpty) {
+                for (let x = chasm[0] + 1; x < chasm[1]; x++) {
+                    this._setCell(x, capY, {...tileTypes.bedrock, capLayer: i});
+                }
+            }
+            caps.push({layer: i, capY, depthRows: capY - above});
+        }
+        this.game.layerCapRows = caps;
     }
 
     /**

--- a/src/services/recipes.js
+++ b/src/services/recipes.js
@@ -142,3 +142,56 @@ export const RECIPES = [
         output: {kind: 'rigTier', tier: 2},
     },
 ];
+
+// Forge recipes live inside the cabin, not at the lift terminal — the
+// player has to enter the home and walk to the forge to upgrade their
+// tools. Each upgrade is one-shot and bumps the matching tool's tier on
+// the toolbar item's metadata, where breakable / tree damage formulas
+// read it back. Names ladder up worn → copper → iron in step with the
+// ore tiers unlocked by drilling.
+export const FORGE_RECIPES = [
+    {
+        id: 'pickaxeCopper',
+        name: 'Copper Pickaxe',
+        description: 'Mining hits land 60% harder.',
+        icon: 'images/pickaxe.png',
+        inputs: [
+            {id: 'copper', amount: 5},
+            {id: 'coal',   amount: 5},
+        ],
+        output: {kind: 'toolTier', toolId: 'pickaxe', tier: 1, newName: 'Copper Pickaxe'},
+    },
+    {
+        id: 'pickaxeIron',
+        name: 'Iron Pickaxe',
+        description: 'Mining hits land 150% harder.',
+        icon: 'images/pickaxe.png',
+        inputs: [
+            {id: 'iron', amount: 5},
+            {id: 'coal', amount: 5},
+        ],
+        output: {kind: 'toolTier', toolId: 'pickaxe', tier: 2, newName: 'Iron Pickaxe'},
+    },
+    {
+        id: 'axeCopper',
+        name: 'Copper Axe',
+        description: 'Fells trees twice as fast.',
+        icon: 'images/pickaxe.png',
+        inputs: [
+            {id: 'copper', amount: 5},
+            {id: 'coal',   amount: 5},
+        ],
+        output: {kind: 'toolTier', toolId: 'axe', tier: 1, newName: 'Copper Axe'},
+    },
+    {
+        id: 'axeIron',
+        name: 'Iron Axe',
+        description: 'Fells trees three times as fast.',
+        icon: 'images/pickaxe.png',
+        inputs: [
+            {id: 'iron', amount: 5},
+            {id: 'coal', amount: 5},
+        ],
+        output: {kind: 'toolTier', toolId: 'axe', tier: 2, newName: 'Iron Axe'},
+    },
+];

--- a/src/services/recipes.js
+++ b/src/services/recipes.js
@@ -90,4 +90,55 @@ export const RECIPES = [
         ],
         output: {kind: 'tool', toolId: 'minecart', amount: 1},
     },
+    // --- Drill bit progression ----------------------------------------
+    // One-shot upgrades that gate which layer caps the platform drill can
+    // chew through. Mounted on the rig, not carried, so they're tracked on
+    // CraneManager.drillBitTier rather than as inventory items.
+    {
+        id: 'drillBitCopper',
+        name: 'Copper Drill Bit',
+        description: 'Mounts on the rig drill. Cracks layer-2 and layer-3 caps.',
+        icon: 'images/coal.png',
+        inputs: [
+            {id: 'copper', amount: 5},
+            {id: 'coal',   amount: 5},
+        ],
+        output: {kind: 'drillBit', tier: 1},
+    },
+    {
+        id: 'drillBitIron',
+        name: 'Iron Drill Bit',
+        description: 'Mounts on the rig drill. Cracks layer-4 caps and below.',
+        icon: 'images/coal.png',
+        inputs: [
+            {id: 'iron', amount: 5},
+            {id: 'coal', amount: 5},
+        ],
+        output: {kind: 'drillBit', tier: 2},
+    },
+    // --- Rig / shelter progression -----------------------------------
+    // Each tier upgrade swaps the visible shelter on the platform deck and
+    // unlocks better sleep restoration in the home interior.
+    {
+        id: 'rigUpgradeTent',
+        name: 'Pitch Tent',
+        description: 'Upgrade Mk-I raft to the Mk-II tent. Better sleep.',
+        icon: 'images/wood.png',
+        inputs: [
+            {id: 'wood', amount: 20},
+            {id: 'coal', amount: 5},
+        ],
+        output: {kind: 'rigTier', tier: 1},
+    },
+    {
+        id: 'rigUpgradeCabin',
+        name: 'Build Cabin',
+        description: 'Upgrade Mk-II tent to the Mk-III cabin. Full home interior.',
+        icon: 'images/wood.png',
+        inputs: [
+            {id: 'wood',   amount: 30},
+            {id: 'copper', amount: 10},
+        ],
+        output: {kind: 'rigTier', tier: 2},
+    },
 ];


### PR DESCRIPTION
## Summary
This PR implements a multi-layer progression system for the platform rig, including a drill mechanic to break through bedrock caps, new ore types (copper and iron), and a tiered shelter system that evolves from a bedroll to a tent to a full cabin as the player upgrades.

## Key Changes

### Tiered Shelter System
- Added `TIER_LAYOUT` configuration with three shelter tiers (0: bedroll, 1: tent, 2: cabin) with different room dimensions and camera zoom levels
- Modified `HouseScene` to support tier-specific interiors and furniture layouts:
  - Tier 0: Bedroll on an open platform with minimal UI (no decor button, no forge)
  - Tier 1: Canvas tent interior with a cot and lantern
  - Tier 2: Full cabin with all amenities (TV, forge, decorative bed)
- Updated `CraneManager` to manage `rigTier` and `drillBitTier` progression and toggle visibility of shelter visuals

### Drilling & Layer Caps
- Added bedrock tile type that blocks descent through layer boundaries
- Implemented `placeLayerCaps()` in `MapService` to create bedrock barriers at each layer boundary
- Added drill UI to `LiftTerminal` showing drill status and allowing drilling when parked at a cap
- Drill progression gated by bit tier: basic (layer 1), copper (layers 2-3), iron (layers 4-6)
- Drill operations consume coal based on layer depth

### New Ore Types
- Added copper and iron tile types with procedurally generated textures
- Copper veins seed layers 2-3; iron veins seed layers 4-6
- Added inventory methods `addCopper()` and `addIron()` to `InventoryManager`
- Updated minecart to deliver copper and iron to inventory

### Forge & Tool Upgrades
- Created `FORGE_RECIPES` export in `recipes.js` for in-cabin tool tier upgrades
- Pickaxe and axe can be upgraded to copper and iron variants with damage multipliers (1.6× and 2.5× for pickaxe)
- Forge is only available in tier-2 cabins and mounted on the right wall

### Rig Upgrade Recipes
- Added lift terminal recipes to upgrade from bedroll → tent (tier 1) and tent → cabin (tier 2)
- Tier upgrades unlock better sleep restoration and new interior features

### Texture Generation
- Added procedural texture generation for copper ore, iron ore, bedrock, bedroll, and tent sprites in `PreloadScene`
- All textures follow pixel-art style consistent with existing coal sprite

### UI Updates
- Extended lift terminal display to show rig tier, drill bit tier, copper/iron inventory, and drill status
- Updated door interaction text from "Enter Home" to "Rest" for platform hut
- Decor button only appears in tier-2 cabins where wallpaper/floor swaps make sense

## Notable Implementation Details
- Shelter pieces (facade, tent, bedroll) are all created at once but visibility is toggled by tier to avoid teardown/rebuild overhead
- Room dimensions scale with tier so camera zoom packs smaller shelters into viewport (bedroll feels like crouching into a tarp)
- Layer caps are stored on `game.layerCapRows` so lift terminal can render drilling hints and platform can check if descent is blocked
- Drill fuel cost and bit requirements are tier-gated to pace progression through the ore layers
- Tool tier multipliers are applied in `Breakable.onClick()` and `Tree.onClick()` based on equipped tool metadata

https://claude.ai/code/session_01VZtBNvYEzH1v1ouu4bP7vd